### PR TITLE
Replace use_container_width with width parameter

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -46,7 +46,7 @@ def render_basic_section(df_view, controls, ccl_rate):
         if fig is not None:
             st.plotly_chart(
                 fig,
-                use_container_width=True,
+                width="stretch",
                 key="pl_topn",
                 config=PLOTLY_CONFIG,
             )
@@ -58,7 +58,7 @@ def render_basic_section(df_view, controls, ccl_rate):
         if fig is not None:
             st.plotly_chart(
                 fig,
-                use_container_width=True,
+                width="stretch",
                 key="donut_tipo",
                 config=PLOTLY_CONFIG,
             )
@@ -70,7 +70,7 @@ def render_basic_section(df_view, controls, ccl_rate):
     if fig is not None:
         st.plotly_chart(
             fig,
-            use_container_width=True,
+            width="stretch",
             key="dist_tipo",
             config=PLOTLY_CONFIG,
         )
@@ -82,7 +82,7 @@ def render_basic_section(df_view, controls, ccl_rate):
     if fig is not None:
         st.plotly_chart(
             fig,
-            use_container_width=True,
+            width="stretch",
             key="pl_diario",
             config=PLOTLY_CONFIG,
         )
@@ -142,7 +142,7 @@ def render_advanced_analysis(df_view):
         if fig is not None:
             st.plotly_chart(
                 fig,
-                use_container_width=True,
+                width="stretch",
                 key="bubble_chart",
                 config=PLOTLY_CONFIG,
             )
@@ -163,7 +163,7 @@ def render_advanced_analysis(df_view):
         if fig is not None:
             st.plotly_chart(
                 fig,
-                use_container_width=True,
+                width="stretch",
                 key="heatmap_chart",
                 config=PLOTLY_CONFIG,
             )

--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -165,7 +165,7 @@ def render_portfolio_section(container, cli, fx_rates):
                             )
                             st.plotly_chart(
                                 fig,
-                                use_container_width=True,
+                                width="stretch",
                                 key="ta_chart",
                                 config=PLOTLY_CONFIG,
                             )

--- a/controllers/portfolio/risk.py
+++ b/controllers/portfolio/risk.py
@@ -53,7 +53,7 @@ def render_risk_analysis(df_view, tasvc):
             )
             st.plotly_chart(
                 fig,
-                use_container_width=True,
+                width="stretch",
                 key="corr_heatmap",
                 config=PLOTLY_CONFIG,
             )
@@ -120,7 +120,7 @@ def render_risk_analysis(df_view, tasvc):
                     )
                     st.plotly_chart(
                         fig_vol,
-                        use_container_width=True,
+                        width="stretch",
                         config=PLOTLY_CONFIG,
                     )
                     st.caption(
@@ -138,7 +138,7 @@ def render_risk_analysis(df_view, tasvc):
                     )
                     st.plotly_chart(
                         fig_var,
-                        use_container_width=True,
+                        width="stretch",
                         config=PLOTLY_CONFIG,
                     )
                     st.caption(

--- a/controllers/test/test_portfolio_controller.py
+++ b/controllers/test/test_portfolio_controller.py
@@ -222,5 +222,5 @@ def test_ta_section_symbol_with_data():
         render_portfolio_section(container, cli=mock_cli, fx_rates={})
 
     mock_st.plotly_chart.assert_called_once_with(
-        'fig', use_container_width=True, key='ta_chart', config=ANY
+        'fig', width="stretch", key='ta_chart', config=ANY
     )

--- a/ui/actions.py
+++ b/ui/actions.py
@@ -11,10 +11,10 @@ def render_action_menu() -> None:
     with pop:
         st.caption("Operaciones rápidas")
         c1, c2 = st.columns(2)
-        if c1.button("⟳ Refrescar", use_container_width=True):
+        if c1.button("⟳ Refrescar", width="stretch"):
             st.session_state["refresh_pending"] = True
             st.rerun()
-        if c2.button("🔒 Cerrar sesión", use_container_width=True):
+        if c2.button("🔒 Cerrar sesión", width="stretch"):
             st.session_state["logout_pending"] = True
             st.rerun()
 

--- a/ui/fundamentals.py
+++ b/ui/fundamentals.py
@@ -136,7 +136,7 @@ def render_sector_comparison(df: pd.DataFrame):
         annotation_text="Promedio sector",
         annotation_position="top left",
     )
-    st.plotly_chart(fig, use_container_width=True, config=PLOTLY_CONFIG)
+    st.plotly_chart(fig, width="stretch", config=PLOTLY_CONFIG)
     st.caption(
         "Valores mayores a 1 indican métricas por encima del promedio del sector (posible sobrevaluación)."
     )

--- a/ui/fx_panels.py
+++ b/ui/fx_panels.py
@@ -107,7 +107,7 @@ def render_spreads(rates: dict):
         rows.append({"Par": "Mayorista vs CCL", "Brecha": format_percent(pct(ccl, mayorista))})
     rows.append({"Par": "Blue vs Oficial", "Brecha": format_percent(pct(blue, oficial))})
 
-    _ = st.dataframe(pd.DataFrame(rows), use_container_width=True, hide_index=True)
+    _ = st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
 
 def render_fx_history(history: pd.DataFrame):
     st.subheader("⏱️ Serie intradía del dólar")
@@ -123,4 +123,4 @@ def render_fx_history(history: pd.DataFrame):
     df_long = hist[["ts_dt"] + cols].melt("ts_dt", var_name="Tipo", value_name="ARS")
     fig = px.line(df_long, x="ts_dt", y="ARS", color="Tipo", hover_name="Tipo")
     fig.update_layout(xaxis_title="", yaxis_title="ARS / USD", legend_title_text="Tipo")
-    st.plotly_chart(fig, use_container_width=True)
+    st.plotly_chart(fig, width="stretch")

--- a/ui/tables.py
+++ b/ui/tables.py
@@ -246,7 +246,7 @@ def render_table(df_view: pd.DataFrame, order_by: str, desc: bool, ccl_rate: flo
             _color_pl,
             subset=["pl_num", "pl_d_num", "pl_pct_num", "chg_pct_num"],
         ),
-        use_container_width=True,
+        width="stretch",
         hide_index=True,
         height=420,
         column_config=column_config,

--- a/ui/test/test_fx_panels.py
+++ b/ui/test/test_fx_panels.py
@@ -76,4 +76,4 @@ def test_render_fx_history_plots_when_valid_series():
 
     mock_st.info.assert_not_called()
     mock_st.line_chart.assert_called_once()
-    mock_st.plotly_chart.assert_called_once_with(fig, use_container_width=True)
+    mock_st.plotly_chart.assert_called_once_with(fig, width="stretch")


### PR DESCRIPTION
## Summary
- replace deprecated `use_container_width=True` with `width="stretch"` in buttons, dataframes and Plotly charts
- update tests to reflect new `width` argument

## Testing
- `pytest`
- `timeout 15 streamlit run app.py --server.headless true`


------
https://chatgpt.com/codex/tasks/task_e_68c72b1b2d0c833284cad63ba6b2fe65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Unified layout by switching charts, tables, and buttons to stretch to available width across portfolio, risk, fundamentals, and FX panels.
  - Plotly charts and dataframes now render with consistent, responsive sizing for improved readability on all screen sizes.
  - Action menu buttons now expand to full width for better usability.

- Tests
  - Updated test expectations to reflect the new width-based rendering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->