### PR TITLE
chore: add semantic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    branches: [main]
+    types:
+      - completed
+
+jobs:
+  release:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install semantic-release
+        run: pip install python-semantic-release
+      - name: Run semantic-release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: semantic-release publish

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[project]
+name = "portafolio-iol"
+version = "0.1.0"
+
+[tool.semantic_release]
+version_variable = "pyproject.toml:project.version"
+changelog_file = "CHANGELOG.md"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to publish releases after CI succeeds
- configure python-semantic-release to manage versions and changelog

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c74136ffc48332a700ca163ea737d0