### PR TITLE
Add caption describing positions table

### DIFF
--- a/ui/tables.py
+++ b/ui/tables.py
@@ -230,6 +230,7 @@ def render_table(df_view: pd.DataFrame, order_by: str, desc: bool, ccl_rate: flo
     )
 
     st.subheader("Detalle por símbolo")
+    st.caption("Tabla con todas tus posiciones actuales. Te ayuda a ver cuánto tenés en cada activo y cómo viene rindiendo.")
     df_export = df_tbl.rename(columns=rename_map)
     download_csv(df_export, "portafolio.csv")
 


### PR DESCRIPTION
## Summary
- add caption explaining the table listing portfolio positions

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c77fecccb883328f11d288b778d6f3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a descriptive caption to the portfolio table under “Detalle por símbolo” to clarify what the table shows and how to interpret positions and performance.
- Documentation
  - Improved in-app copy for the portfolio table to better guide users on their current holdings and returns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->