### PR TITLE
Add caption clarifying P/L bar chart impact

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -50,6 +50,9 @@ def render_basic_section(df_view, controls, ccl_rate):
                 key="pl_topn",
                 config=PLOTLY_CONFIG,
             )
+            st.caption(
+                "Barras que muestran qué activos ganan o pierden más. Las más altas son las que más afectan tu resultado."
+            )
         else:
             st.info("Sin datos para graficar P/L Top N.")
     with colB:


### PR DESCRIPTION
## Summary
- Clarify P/L Top N chart with caption about asset gains/losses

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c77ff12eb88332bba644db73b947d6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explanatory caption beneath the P/L Top N chart for Spanish-speaking users: “Barras que muestran qué activos ganan o pierden más. Las más altas son las que más afectan tu resultado.” The caption appears after the chart renders successfully, improving clarity without changing data, chart logic, or error handling. Existing behavior for missing data remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->