### PR TITLE
Add diversification caption to portfolio donut chart

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -62,6 +62,9 @@ def render_basic_section(df_view, controls, ccl_rate):
                 key="donut_tipo",
                 config=PLOTLY_CONFIG,
             )
+            st.caption(
+                "Indica qué porcentaje de tu inversión está en cada tipo de activo para ver si estás diversificando bien."
+            )
         else:
             st.info("No hay datos para el donut por tipo.")
 


### PR DESCRIPTION
## Summary
- Clarify donut chart by adding caption about asset type diversification

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77ff0b28c8332bae4b0b916cabc3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an explanatory caption beneath the “Donut por tipo” chart to aid interpretation of portfolio diversification: “Indica qué porcentaje de tu inversión está en cada tipo de activo para ver si estás diversificando bien.” The caption is shown only when data is available, improving clarity without altering data processing or other charts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->