### PR TITLE
Add caption explaining distribution by asset type chart

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -74,6 +74,9 @@ def render_basic_section(df_view, controls, ccl_rate):
             key="dist_tipo",
             config=PLOTLY_CONFIG,
         )
+        st.caption(
+            "Compara cuánto dinero tenés en cada categoría de activos. Ayuda a detectar concentraciones."
+        )
     else:
         st.info("No hay datos para la distribución por tipo.")
 


### PR DESCRIPTION
## Summary
- annotate distribution by asset type chart with explanatory caption

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c77ff239008332aa550c0993793e93