### PR TITLE
Add caption to daily P/L chart

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -86,6 +86,9 @@ def render_basic_section(df_view, controls, ccl_rate):
             key="pl_diario",
             config=PLOTLY_CONFIG,
         )
+        st.caption(
+            "Muestra las ganancias o pérdidas del día para los activos con mayor movimiento."
+        )
     else:
         st.info("Aún no hay datos de P/L diario.")
 


### PR DESCRIPTION
## Summary
- Add explanatory caption for daily P/L chart to clarify meaning of displayed values

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c77ff2b72083329eace63cd3f3de12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a user-visible caption below the “P/L diario (Top N)” chart: “Muestra las ganancias o pérdidas del día para los activos con mayor movimiento.” The caption appears only when the chart successfully renders, providing immediate context for the displayed data.
* **Bug Fixes**
  * No behavioral changes when chart data is unavailable; existing handling remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->