### PR TITLE
Add caption for portfolio optimization chart

### DIFF
--- a/controllers/portfolio/risk.py
+++ b/controllers/portfolio/risk.py
@@ -148,6 +148,9 @@ def render_risk_analysis(df_view, tasvc):
                 with st.expander("Optimización de portafolio (Markowitz)"):
                     opt_df = pd.DataFrame({"ticker": opt_w.index, "weight": opt_w.values})
                     st.bar_chart(opt_df, x="ticker", y="weight")
+                    st.caption(
+                        "Barras con la proporción que el modelo recomienda invertir en cada activo para equilibrar riesgo y retorno."
+                    )
 
                 with st.expander("Simulación Monte Carlo"):
                     sims = st.number_input(


### PR DESCRIPTION
## Summary
- Clarify portfolio optimization chart with explanatory caption describing recommended asset proportions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77ff45ba08332944eb79afe7e2568