### PR TITLE
Add caption for Monte Carlo simulation

### DIFF
--- a/controllers/portfolio/risk.py
+++ b/controllers/portfolio/risk.py
@@ -168,6 +168,9 @@ def render_risk_analysis(df_view, tasvc):
                         returns_df, weights, n_sims=sims, horizon=horizon
                     )
                     st.line_chart(final_prices)
+                    st.caption(
+                        "Simula muchos escenarios posibles para estimar cómo podría variar el valor de la cartera en el futuro."
+                    )
 
                 with st.expander("Aplicar shocks"):
                     templates = {"Leve": 0.03, "Moderado": 0.07, "Fuerte": 0.12}


### PR DESCRIPTION
## Summary
- Explain Monte Carlo simulation results with a new caption in risk analysis view.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c77ff64bd8833285f701df66b2b813