### PR TITLE
Add caption to backtest chart

### DIFF
--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -191,6 +191,9 @@ def render_portfolio_section(container, cli, fx_rates):
                                 st.info("Sin datos suficientes para el backtesting.")
                             else:
                                 st.line_chart(bt["equity"])
+                                st.caption(
+                                    "La línea muestra cómo habría crecido la inversión usando la estrategia seleccionada."
+                                )
                                 st.metric(
                                     "Retorno acumulado", f"{bt['equity'].iloc[-1] - 1:.2%}"
                                 )


### PR DESCRIPTION
## Summary
- Add explanatory caption beneath backtesting equity chart

## Testing
- `pytest`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c77ff8b8648332a88486b801254baa