### PR TITLE
Add caption to FX spreads panel

### DIFF
--- a/ui/fx_panels.py
+++ b/ui/fx_panels.py
@@ -108,6 +108,7 @@ def render_spreads(rates: dict):
     rows.append({"Par": "Blue vs Oficial", "Brecha": format_percent(pct(blue, oficial))})
 
     _ = st.dataframe(pd.DataFrame(rows), width="stretch", hide_index=True)
+    st.caption("Muestra la diferencia porcentual entre distintas cotizaciones del dólar.")
 
 def render_fx_history(history: pd.DataFrame):
     st.subheader("⏱️ Serie intradía del dólar")

--- a/ui/test/test_fx_panels.py
+++ b/ui/test/test_fx_panels.py
@@ -10,12 +10,14 @@ def test_render_spreads_shows_info_when_no_rates():
         subheader=MagicMock(),
         info=MagicMock(),
         dataframe=MagicMock(),
+        caption=MagicMock(),
     )
     with patch("ui.fx_panels.st", mock_st):
         render_spreads({})
 
     mock_st.info.assert_called_once_with("Sin cotizaciones para calcular brechas.")
     mock_st.dataframe.assert_not_called()
+    mock_st.caption.assert_not_called()
 
 
 def test_render_spreads_includes_mayorista_when_available():
@@ -31,12 +33,16 @@ def test_render_spreads_includes_mayorista_when_available():
         subheader=MagicMock(),
         info=MagicMock(),
         dataframe=MagicMock(side_effect=lambda df, **kwargs: captured_df.update(df=df)),
+        caption=MagicMock(),
     )
     with patch("ui.fx_panels.st", mock_st):
         render_spreads(rates)
 
     mock_st.info.assert_not_called()
     assert "Mayorista vs CCL" in captured_df["df"]["Par"].tolist()
+    mock_st.caption.assert_called_once_with(
+        "Muestra la diferencia porcentual entre distintas cotizaciones del dólar."
+    )
 
 
 def test_render_fx_history_info_when_no_valid_columns():


### PR DESCRIPTION
## Summary
- Clarify FX spreads table with descriptive caption
- Update tests for new caption behavior

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c77ffef1bc8332a6e0ec8a6fe33f2b