### PR TITLE
Add caption to FX history chart

### DIFF
--- a/ui/fx_panels.py
+++ b/ui/fx_panels.py
@@ -124,3 +124,5 @@ def render_fx_history(history: pd.DataFrame):
     fig = px.line(df_long, x="ts_dt", y="ARS", color="Tipo", hover_name="Tipo")
     fig.update_layout(xaxis_title="", yaxis_title="ARS / USD", legend_title_text="Tipo")
     st.plotly_chart(fig, width="stretch")
+    st.caption("Línea que refleja cómo cambian las cotizaciones del dólar a lo largo del día.")
+

--- a/ui/test/test_fx_panels.py
+++ b/ui/test/test_fx_panels.py
@@ -46,6 +46,7 @@ def test_render_fx_history_info_when_no_valid_columns():
         info=MagicMock(),
         line_chart=MagicMock(),
         plotly_chart=MagicMock(),
+        caption=MagicMock(),
     )
     with patch("ui.fx_panels.st", mock_st):
         render_fx_history(hist)
@@ -53,6 +54,7 @@ def test_render_fx_history_info_when_no_valid_columns():
     mock_st.info.assert_called_once_with("No hay series disponibles para graficar.")
     mock_st.line_chart.assert_not_called()
     mock_st.plotly_chart.assert_not_called()
+    mock_st.caption.assert_not_called()
 
 
 def test_render_fx_history_plots_when_valid_series():
@@ -68,6 +70,7 @@ def test_render_fx_history_plots_when_valid_series():
         info=MagicMock(),
         line_chart=MagicMock(),
         plotly_chart=MagicMock(),
+        caption=MagicMock(),
     )
     fig = SimpleNamespace(update_layout=MagicMock())
     mock_px = SimpleNamespace(line=MagicMock(return_value=fig))
@@ -77,3 +80,6 @@ def test_render_fx_history_plots_when_valid_series():
     mock_st.info.assert_not_called()
     mock_st.line_chart.assert_called_once()
     mock_st.plotly_chart.assert_called_once_with(fig, width="stretch")
+    mock_st.caption.assert_called_once_with(
+        "Línea que refleja cómo cambian las cotizaciones del dólar a lo largo del día."
+    )


### PR DESCRIPTION
## Summary
- add caption describing intraday dollar quote changes after plot
- update fx panel tests for caption

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c78001285483329ae22a4b2f04fb8f