### PR TITLE
Centralize version retrieval for footer and login

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@ build/
 
 # --- Generated version file
 version.py
+!shared/version.py

--- a/shared/version.py
+++ b/shared/version.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+import tomllib
+
+
+def _read_version() -> str:
+    project_file = Path(__file__).resolve().parent.parent / "pyproject.toml"
+    try:
+        with project_file.open("rb") as f:
+            data = tomllib.load(f)
+        return data.get("project", {}).get("version", "0.0.0")
+    except Exception:
+        return "0.0.0"
+
+
+__version__ = _read_version()

--- a/ui/footer.py
+++ b/ui/footer.py
@@ -1,25 +1,12 @@
 import subprocess
-import streamlit as st
 from datetime import datetime
+
+import streamlit as st
+from shared.version import __version__
 
 
 def get_version():
-    try:
-        version = (
-            subprocess.check_output(["git", "describe", "--tags"], stderr=subprocess.STDOUT)
-            .decode()
-            .strip()
-        )
-    except Exception:
-        try:
-            version = (
-                subprocess.check_output(["git", "rev-parse", "--short", "HEAD"], stderr=subprocess.STDOUT)
-                .decode()
-                .strip()
-            )
-        except Exception:
-            version = "desconocida"
-
+    version = __version__
     try:
         date = (
             subprocess.check_output(

--- a/ui/login.py
+++ b/ui/login.py
@@ -5,16 +5,12 @@ from application.auth_service import (
     InvalidCredentialsError,
     NetworkError,
 )
+from ui.footer import render_footer
 from ui.header import render_header
 from shared.config import settings
 
 
 logger = logging.getLogger(__name__)
-
-
-def render_footer() -> None:
-    """Render developer information at the bottom of the login form."""
-    st.caption("Desarrollado por Nicolás Kachuk")
 
 
 def render_login_page() -> None:


### PR DESCRIPTION
## Summary
- Provide project version via shared/version module
- Use shared __version__ in footer instead of git describe
- Reuse footer renderer in login page

## Testing
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68c7e7cf80048332a28d0c744d137767

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - App version is now displayed based on the packaged version, not Git metadata, ensuring predictable version info.
- Bug Fixes
  - Prevents version display failures when Git data isn’t available; a safe default is shown if needed.
- Refactor
  - Centralized footer rendering for consistent display across screens.
- Chores
  - Updated ignore rules to ensure the version source is tracked appropriately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->