### PR TITLE
Add caption summarizing fundamental indicators table

### DIFF
--- a/ui/fundamentals.py
+++ b/ui/fundamentals.py
@@ -79,6 +79,7 @@ def render_fundamental_data(data: dict):
         )
         
     st.table(pd.DataFrame(rows))
+    st.caption("Resumen de indicadores fundamentales básicos.")
     st.divider()
 
 def render_fundamental_ranking(df: pd.DataFrame):

--- a/ui/test/test_ui_fundamentals.py
+++ b/ui/test/test_ui_fundamentals.py
@@ -34,7 +34,12 @@ def test_render_fundamental_data_normal_flow():
         fundamentals.render_fundamental_data(data)
     st.warning.assert_not_called()
     st.subheader.assert_called_once_with("Análisis Fundamental: ACME")
-    st.caption.assert_called_once_with("**Sector:** Tech | **Web:** https://acme.com")
+    st.caption.assert_has_calls(
+        [
+            call("**Sector:** Tech | **Web:** https://acme.com"),
+            call("Resumen de indicadores fundamentales básicos."),
+        ]
+    )
     df_arg = st.table.call_args[0][0]
     assert isinstance(df_arg, pd.DataFrame)
     assert len(df_arg) == len(fundamentals.INDICATORS)


### PR DESCRIPTION
## Summary
- add caption below fundamental indicators table for additional context
- update unit test to expect new caption

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e7d121bc8332854b94cd4a9f54fb