### PR TITLE
feat: add portfolio data caption

### DIFF
--- a/controllers/portfolio/load_data.py
+++ b/controllers/portfolio/load_data.py
@@ -56,6 +56,7 @@ def load_portfolio_data(cli, psvc):
         )
         if isinstance(payload, dict) and "activos" in payload:
             st.dataframe(pd.DataFrame(payload["activos"]).head(20))
+            st.caption("Ejemplo de datos recibidos del portafolio")
         st.stop()
 
     all_symbols = sorted(df_pos["simbolo"].astype(str).str.upper().unique())


### PR DESCRIPTION
## Summary
- display example caption for portfolio data when no positions found

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7f3fcd8f48332980c5c6774f0ad9f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a UI caption “Ejemplo de datos recibidos del portafolio” displayed beneath the portfolio assets table. The caption appears only when asset data is available, providing immediate context for the displayed information and helping users verify the imported dataset at a glance. No changes to workflows or data processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->