### PR TITLE
Centralize cache TTL configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Centralized cache TTL configuration in `shared/settings` and documented the
+  new environment keys for quote and FX caches.
 ### Fixed
 - Successful login now marks the session as authenticated to access the main page.
 - Fixed: los paneles ahora se recargan automáticamente después de logout/login sin requerir refresco manual.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ IOL_ALLOW_PLAIN_TOKENS=0
 # Otros ajustes opcionales
 CACHE_TTL_PORTFOLIO=20
 CACHE_TTL_LAST_PRICE=10
+CACHE_TTL_QUOTES=8
+CACHE_TTL_FX=60
 ASSET_CATALOG_PATH="/ruta/a/assets_catalog.json"
 # Nivel de los logs ("DEBUG", "INFO", etc.; predeterminado: INFO)
 LOG_LEVEL="INFO"
@@ -122,6 +124,8 @@ IOL_TOKENS_FILE=/app/tokens/tokens_iol.json
    IOL_ALLOW_PLAIN_TOKENS = 0
    CACHE_TTL_PORTFOLIO = 20
    CACHE_TTL_LAST_PRICE = 10
+   CACHE_TTL_QUOTES = 8
+   CACHE_TTL_FX = 60
    ASSET_CATALOG_PATH = "/ruta/a/assets_catalog.json"
    LOG_LEVEL = "INFO"
    LOG_FORMAT = "plain"
@@ -172,7 +176,7 @@ Los siguientes tiempos se observan en condiciones normales (aprox. 20 posiciones
 | `fetch_portfolio`   | < 600 ms        | ~20 posiciones |
 | `fetch_quotes_bulk` | < 1 s           | 20 símbolos |
 
-Si algún paso supera estos valores, considera reducir llamadas redundantes, ajustar los TTL de cache en `shared/config.py` o incrementar `max_quote_workers` cuando existan muchas posiciones.
+Si algún paso supera estos valores, considera reducir llamadas redundantes, ajustar los TTL de cache en `shared/settings.py` o incrementar `MAX_QUOTE_WORKERS` cuando existan muchas posiciones.
 
 ## Fallback de análisis técnico
 

--- a/infrastructure/fx/provider.py
+++ b/infrastructure/fx/provider.py
@@ -8,7 +8,7 @@ from typing import Optional, Dict, Tuple, List
 import traceback
 
 from infrastructure.http.session import build_session
-from shared.config import settings
+from shared.settings import cache_ttl_fx, settings
 from shared.utils import _to_float
 import requests
 
@@ -17,7 +17,6 @@ logger = logging.getLogger(__name__)
 BASE_DIR = Path(__file__).resolve().parent
 CACHE_FILE = BASE_DIR / ".cache" / "fx_rates.json"
 FALLBACK_FILE = BASE_DIR / "fallback_rates.json"
-CACHE_TTL  = 45  # segundos
 
 
 # -------------------------
@@ -79,7 +78,7 @@ class FXProviderAdapter:
             if CACHE_FILE.exists():
                 data = json.loads(CACHE_FILE.read_text(encoding="utf-8"))
                 # tolerante: si el cache está viejo, ignoramos
-                if time.time() - float(data.get("_ts", 0)) < CACHE_TTL:
+                if time.time() - float(data.get("_ts", 0)) < cache_ttl_fx:
                     # por si el cache viejo no estaba normalizado
                     return _normalize_rates(data)
         except Exception as e:

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -1,0 +1,31 @@
+"""Cache and application settings exposed for cross-module use.
+
+This module centralizes access to the configuration values used across
+services and infrastructure layers. Values are sourced from environment
+variables, `streamlit` secrets or ``config.json`` via ``shared.config``.
+"""
+from __future__ import annotations
+
+from shared.config import settings as _config_settings
+
+# Re-export the shared Settings instance so existing imports keep working.
+settings = _config_settings
+
+# Cache-related configuration. Importers can rely on these names instead of
+# scattering magic numbers or environment lookups throughout the codebase.
+cache_ttl_portfolio: int = settings.cache_ttl_portfolio
+cache_ttl_last_price: int = settings.cache_ttl_last_price
+cache_ttl_fx: int = settings.cache_ttl_fx
+cache_ttl_quotes: int = settings.cache_ttl_quotes
+quotes_hist_maxlen: int = settings.quotes_hist_maxlen
+max_quote_workers: int = settings.max_quote_workers
+
+__all__ = [
+    "settings",
+    "cache_ttl_portfolio",
+    "cache_ttl_last_price",
+    "cache_ttl_fx",
+    "cache_ttl_quotes",
+    "quotes_hist_maxlen",
+    "max_quote_workers",
+]

--- a/test/test_fx_provider.py
+++ b/test/test_fx_provider.py
@@ -5,13 +5,14 @@ from unittest.mock import MagicMock
 import requests
 
 from infrastructure.fx import provider as fx_provider
+from shared.settings import cache_ttl_fx
 
 
 # _load_cache tests
 
 def test_load_cache_expired_file(monkeypatch, tmp_path):
     cache_file = tmp_path / "fx_cache.json"
-    data = {"oficial": 1, "_ts": time.time() - fx_provider.CACHE_TTL - 10}
+    data = {"oficial": 1, "_ts": time.time() - cache_ttl_fx - 10}
     cache_file.write_text(json.dumps(data), encoding="utf-8")
     monkeypatch.setattr(fx_provider, "CACHE_FILE", cache_file)
     provider = fx_provider.FXProviderAdapter()


### PR DESCRIPTION
## Summary
- add a shared `settings` module that exposes cache TTLs sourced from the existing configuration helper
- update the FX provider, cache service, and related tests to consume the centralized TTL values
- document the new environment keys and mention the change in the changelog

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c83b27252083328b1e919b43015510

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configurable cache TTLs for quotes and FX via environment variables: CACHE_TTL_QUOTES and CACHE_TTL_FX.
  - Centralized cache TTL configuration for consistent behavior across the app.
  - Client session caching for faster, more reliable connections.

- Performance
  - Improved cache usage for quotes, portfolios, and FX rates to reduce latency.

- Documentation
  - README and CHANGELOG updated with new env keys, examples, and paths.
  - Noted rename to MAX_QUOTE_WORKERS in configuration references.
  - Clarified where cache settings are sourced and how to adjust them.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->