### PR TITLE
Add sidebar health panel and track data metrics

### DIFF
--- a/app.py
+++ b/app.py
@@ -15,6 +15,7 @@ from shared.config import configure_logging, ensure_tokens_key
 from ui.ui_settings import init_ui
 from ui.header import render_header
 from ui.actions import render_action_menu
+from ui.health_sidebar import render_health_sidebar
 from ui.login import render_login_page
 from ui.footer import render_footer
 #from controllers.fx import render_fx_section
@@ -62,6 +63,8 @@ def main(argv: list[str] | None = None):
         now = datetime.now()
         st.caption(f"🕒 {now.strftime('%d/%m/%Y %H:%M:%S')}")
         render_action_menu()
+
+    render_health_sidebar()
 
     # main_col, side_col = st.columns([4, 1])
 

--- a/services/health.py
+++ b/services/health.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+"""Helpers to capture health metrics and expose them via ``st.session_state``."""
+
+from typing import Any, Dict, Optional
+import time
+
+import streamlit as st
+
+
+_HEALTH_KEY = "health_metrics"
+
+
+def _store() -> Dict[str, Any]:
+    """Return the mutable health metrics store from the session state."""
+    return st.session_state.setdefault(_HEALTH_KEY, {})
+
+
+def _clean_detail(detail: Optional[str]) -> Optional[str]:
+    if detail is None:
+        return None
+    text = str(detail).strip()
+    return text or None
+
+
+def record_iol_refresh(success: bool, *, detail: Optional[str] = None) -> None:
+    """Persist the outcome of the last IOL login/refresh attempt."""
+    store = _store()
+    store["iol_refresh"] = {
+        "status": "success" if success else "error",
+        "detail": _clean_detail(detail),
+        "ts": time.time(),
+    }
+
+
+def record_yfinance_usage(source: str, *, detail: Optional[str] = None) -> None:
+    """Persist whether Yahoo Finance or a fallback served the last request."""
+    store = _store()
+    store["yfinance"] = {
+        "source": source,
+        "detail": _clean_detail(detail),
+        "ts": time.time(),
+    }
+
+
+def record_fx_api_response(
+    *, error: Optional[str] = None, elapsed_ms: Optional[float] = None
+) -> None:
+    """Persist metadata about the latest FX API call."""
+    store = _store()
+    store["fx_api"] = {
+        "status": "success" if not error else "error",
+        "error": _clean_detail(error),
+        "elapsed_ms": float(elapsed_ms) if elapsed_ms is not None else None,
+        "ts": time.time(),
+    }
+
+
+def record_fx_cache_usage(mode: str, *, age: Optional[float] = None) -> None:
+    """Persist information about session cache usage for FX rates."""
+    store = _store()
+    store["fx_cache"] = {
+        "mode": mode,
+        "age": float(age) if age is not None else None,
+        "ts": time.time(),
+    }
+
+
+def record_portfolio_load(
+    elapsed_ms: Optional[float], *, source: str, detail: Optional[str] = None
+) -> None:
+    """Persist response time and source for the latest portfolio load."""
+    store = _store()
+    store["portfolio"] = {
+        "elapsed_ms": float(elapsed_ms) if elapsed_ms is not None else None,
+        "source": source,
+        "detail": _clean_detail(detail),
+        "ts": time.time(),
+    }
+
+
+def record_quote_load(
+    elapsed_ms: Optional[float], *, source: str, count: Optional[int] = None
+) -> None:
+    """Persist response time and source for the latest quote load."""
+    store = _store()
+    store["quotes"] = {
+        "elapsed_ms": float(elapsed_ms) if elapsed_ms is not None else None,
+        "source": source,
+        "count": int(count) if count is not None else None,
+        "ts": time.time(),
+    }
+
+
+def get_health_metrics() -> Dict[str, Any]:
+    """Return a shallow copy of the tracked metrics for UI consumption."""
+    store = _store()
+    return {
+        "iol_refresh": store.get("iol_refresh"),
+        "yfinance": store.get("yfinance"),
+        "fx_api": store.get("fx_api"),
+        "fx_cache": store.get("fx_cache"),
+        "portfolio": store.get("portfolio"),
+        "quotes": store.get("quotes"),
+    }
+
+
+__all__ = [
+    "get_health_metrics",
+    "record_fx_api_response",
+    "record_fx_cache_usage",
+    "record_iol_refresh",
+    "record_portfolio_load",
+    "record_quote_load",
+    "record_yfinance_usage",
+]

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+"""Sidebar panel summarising recent data source health."""
+
+from datetime import datetime
+from typing import Iterable, Optional
+
+import streamlit as st
+
+from services.health import get_health_metrics
+
+
+def _format_timestamp(ts: Optional[float]) -> str:
+    if not ts:
+        return "Sin registro"
+    try:
+        dt = datetime.fromtimestamp(float(ts))
+    except (TypeError, ValueError, OSError):
+        return "Sin registro"
+    return dt.strftime("%d/%m/%Y %H:%M:%S")
+
+
+def _format_iol_status(data: Optional[dict]) -> str:
+    if not data:
+        return "_Sin actividad registrada._"
+    status = data.get("status")
+    icon = "✅" if status == "success" else "⚠️"
+    label = "Refresh correcto" if status == "success" else "Error al refrescar"
+    ts = _format_timestamp(data.get("ts"))
+    detail = data.get("detail")
+    detail_txt = f" — {detail}" if detail else ""
+    return f"{icon} {label} • {ts}{detail_txt}"
+
+
+def _format_yfinance_status(data: Optional[dict]) -> str:
+    if not data:
+        return "_Sin consultas registradas._"
+    source = data.get("source") or "desconocido"
+    mapping = {
+        "yfinance": ("✅", "Datos de Yahoo Finance"),
+        "fallback": ("♻️", "Fallback local"),
+        "error": ("⚠️", "Error o sin datos"),
+    }
+    icon, label = mapping.get(source, ("ℹ️", f"Fuente: {source}"))
+    ts = _format_timestamp(data.get("ts"))
+    detail = data.get("detail")
+    detail_txt = f" — {detail}" if detail else ""
+    return f"{icon} {label} • {ts}{detail_txt}"
+
+
+def _format_fx_api_status(data: Optional[dict]) -> str:
+    if not data:
+        return "_Sin llamadas a la API FX._"
+    status = data.get("status")
+    icon = "✅" if status == "success" else "⚠️"
+    label = "API FX OK" if status == "success" else "API FX con errores"
+    ts = _format_timestamp(data.get("ts"))
+    elapsed = data.get("elapsed_ms")
+    elapsed_txt = f"{float(elapsed):.0f} ms" if isinstance(elapsed, (int, float)) else "s/d"
+    detail = data.get("error")
+    detail_txt = f" — {detail}" if detail else ""
+    return f"{icon} {label} • {ts} ({elapsed_txt}){detail_txt}"
+
+
+def _format_fx_cache_status(data: Optional[dict]) -> str:
+    if not data:
+        return "_Sin uso de caché registrado._"
+    mode = data.get("mode")
+    icon = "♻️" if mode == "hit" else "🔄"
+    label = "Uso de caché" if mode == "hit" else "Actualización"
+    ts = _format_timestamp(data.get("ts"))
+    age = data.get("age")
+    age_txt = f"{float(age):.0f}s" if isinstance(age, (int, float)) else "s/d"
+    return f"{icon} {label} • {ts} (edad {age_txt})"
+
+
+def _format_latency_line(label: str, data: Optional[dict]) -> str:
+    if not data:
+        return f"- {label}: sin registro"
+    elapsed = data.get("elapsed_ms")
+    elapsed_txt = f"{float(elapsed):.0f} ms" if isinstance(elapsed, (int, float)) else "s/d"
+    parts = [f"- {label}: {elapsed_txt}"]
+    source = data.get("source")
+    if source:
+        parts.append(f"fuente: {source}")
+    count = data.get("count")
+    if count is not None:
+        parts.append(f"items: {count}")
+    detail = data.get("detail")
+    if detail:
+        parts.append(detail)
+    parts.append(_format_timestamp(data.get("ts")))
+    return " • ".join(parts)
+
+
+def _format_fx_section(api_data: Optional[dict], cache_data: Optional[dict]) -> Iterable[str]:
+    lines = []
+    lines.append(_format_fx_api_status(api_data))
+    lines.append(_format_fx_cache_status(cache_data))
+    return lines
+
+
+def _format_latency_section(portfolio: Optional[dict], quotes: Optional[dict]) -> Iterable[str]:
+    return [
+        _format_latency_line("Portafolio", portfolio),
+        _format_latency_line("Cotizaciones", quotes),
+    ]
+
+
+def render_health_sidebar() -> None:
+    """Render the health summary panel inside the sidebar."""
+    metrics = get_health_metrics()
+    sidebar = st.sidebar
+    sidebar.header("🩺 Salud de datos")
+    sidebar.caption("Monitorea la procedencia y el rendimiento de los datos cargados.")
+
+    sidebar.markdown("#### 🔐 Conexión IOL")
+    sidebar.markdown(_format_iol_status(metrics.get("iol_refresh")))
+
+    sidebar.markdown("#### 📈 Yahoo Finance")
+    sidebar.markdown(_format_yfinance_status(metrics.get("yfinance")))
+
+    sidebar.markdown("#### 💱 FX")
+    for line in _format_fx_section(metrics.get("fx_api"), metrics.get("fx_cache")):
+        sidebar.markdown(line)
+
+    sidebar.markdown("#### ⏱️ Latencias")
+    for line in _format_latency_section(metrics.get("portfolio"), metrics.get("quotes")):
+        sidebar.markdown(line)
+
+
+__all__ = ["render_health_sidebar"]

--- a/ui/test/test_health_sidebar.py
+++ b/ui/test/test_health_sidebar.py
@@ -1,0 +1,66 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import ui.health_sidebar as health_sidebar
+
+
+def _build_sidebar_mock():
+    return SimpleNamespace(
+        header=MagicMock(),
+        caption=MagicMock(),
+        markdown=MagicMock(),
+    )
+
+
+def test_render_health_sidebar_with_metrics(monkeypatch):
+    metrics = {
+        "iol_refresh": {"status": "success", "detail": "Tokens OK", "ts": 1},
+        "yfinance": {"source": "fallback", "detail": "AAPL", "ts": 2},
+        "fx_api": {
+            "status": "success",
+            "error": None,
+            "elapsed_ms": 123.4,
+            "ts": 3,
+        },
+        "fx_cache": {"mode": "hit", "age": 5.0, "ts": 4},
+        "portfolio": {"elapsed_ms": 200.0, "source": "api", "ts": 5},
+        "quotes": {"elapsed_ms": 350.0, "source": "fallback", "count": 3, "ts": 6},
+    }
+    sidebar_mock = _build_sidebar_mock()
+    monkeypatch.setattr(health_sidebar, "st", SimpleNamespace(sidebar=sidebar_mock))
+    monkeypatch.setattr(health_sidebar, "get_health_metrics", lambda: metrics)
+
+    health_sidebar.render_health_sidebar()
+
+    md_calls = [call.args[0] for call in sidebar_mock.markdown.call_args_list]
+    assert any("#### 🔐 Conexión IOL" in text for text in md_calls)
+    assert any("Tokens OK" in text for text in md_calls)
+    assert any("Fallback local" in text for text in md_calls)
+    assert any("API FX OK" in text for text in md_calls)
+    assert any("Uso de caché" in text for text in md_calls)
+    assert any("Portafolio" in text and "200" in text for text in md_calls)
+    assert any("Cotizaciones" in text and "items: 3" in text for text in md_calls)
+
+
+def test_render_health_sidebar_without_metrics(monkeypatch):
+    metrics = {
+        "iol_refresh": None,
+        "yfinance": None,
+        "fx_api": None,
+        "fx_cache": None,
+        "portfolio": None,
+        "quotes": None,
+    }
+    sidebar_mock = _build_sidebar_mock()
+    monkeypatch.setattr(health_sidebar, "st", SimpleNamespace(sidebar=sidebar_mock))
+    monkeypatch.setattr(health_sidebar, "get_health_metrics", lambda: metrics)
+
+    health_sidebar.render_health_sidebar()
+
+    md_calls = [call.args[0] for call in sidebar_mock.markdown.call_args_list]
+    assert "_Sin actividad registrada._" in md_calls
+    assert "_Sin consultas registradas._" in md_calls
+    assert "_Sin llamadas a la API FX._" in md_calls
+    assert "_Sin uso de caché registrado._" in md_calls
+    assert any(text.startswith("- Portafolio: sin registro") for text in md_calls)
+    assert any(text.startswith("- Cotizaciones: sin registro") for text in md_calls)


### PR DESCRIPTION
## Summary
- add a health metrics service that records data source events in the Streamlit session
- instrument cache, FX, and TA flows to update metrics and expose them in a new sidebar panel
- add a Streamlit sidebar component with tests covering populated and empty health states

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c83b275a9c83328e3e3b9204838a3a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a Health sidebar panel displaying live system status: IOL connection, Yahoo Finance source (API vs. fallback), FX API/cache state, and recent latencies for Portfolio and Quotes. Always visible for quick diagnostics.
- Tests
  - Introduced unit tests covering sidebar rendering with and without metrics, ensuring correct messages for success, fallback, cache usage, and no-activity scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->