### PR TITLE
Add tests for TTL overrides and network error handling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
           pip install pytest pytest-cov
       - name: Run tests
         run: |
-          pytest --cov --cov-report=xml
+          pytest --cov --cov-report=xml tests test shared/test application/test ui/test controllers/test domain/test infrastructure/test services/test
       - name: Upload coverage report
         uses: actions/upload-artifact@v4
         with:

--- a/application/test/test_network_errors.py
+++ b/application/test/test_network_errors.py
@@ -1,0 +1,64 @@
+"""Network error propagation for service helpers."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from services import cache as svc_cache
+from shared.errors import NetworkError
+
+
+@pytest.fixture(autouse=True)
+def streamlit_state(monkeypatch: pytest.MonkeyPatch):
+    """Provide an isolated Streamlit session state for cache decorators."""
+    state: dict = {}
+    monkeypatch.setattr(svc_cache, "st", SimpleNamespace(session_state=state))
+    monkeypatch.setattr("shared.cache.st", SimpleNamespace(session_state=state))
+    svc_cache.get_client_cached.clear()
+    svc_cache.fetch_fx_rates.clear()
+    yield
+    svc_cache.get_client_cached.clear()
+    svc_cache.fetch_fx_rates.clear()
+
+
+def test_get_client_cached_raises_network_error(monkeypatch: pytest.MonkeyPatch):
+    """Refreshing tokens should surface IOL network errors to callers."""
+
+    class DummyAuth:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def refresh(self):
+            raise NetworkError("offline")
+
+        def clear_tokens(self):  # pragma: no cover - defensive
+            pass
+
+    monkeypatch.setattr(svc_cache, "IOLAuth", DummyAuth)
+    recorder = MagicMock()
+    monkeypatch.setattr(svc_cache, "record_iol_refresh", recorder)
+
+    with pytest.raises(NetworkError):
+        svc_cache.get_client_cached("cache-key", "user", None)
+
+    recorder.assert_called_once()
+    args, kwargs = recorder.call_args
+    assert args[0] is False
+    assert isinstance(kwargs.get("detail"), NetworkError)
+
+
+def test_fetch_fx_rates_propagates_timeout(monkeypatch: pytest.MonkeyPatch):
+    """Timeouts from the FX provider should not be swallowed by the cache layer."""
+    monkeypatch.setattr(svc_cache, "record_fx_api_response", MagicMock())
+
+    class DummyProvider:
+        def get_rates(self):
+            raise TimeoutError("too slow")
+
+    monkeypatch.setattr(svc_cache, "get_fx_provider", lambda: DummyProvider())
+
+    with pytest.raises(TimeoutError):
+        svc_cache.fetch_fx_rates()
+

--- a/shared/errors.py
+++ b/shared/errors.py
@@ -1,0 +1,6 @@
+"""Shared exception types exposed for cross-layer use."""
+from __future__ import annotations
+
+from infrastructure.iol.auth import InvalidCredentialsError, NetworkError
+
+__all__ = ["InvalidCredentialsError", "NetworkError"]

--- a/tests/test_settings_ttl.py
+++ b/tests/test_settings_ttl.py
@@ -1,0 +1,77 @@
+"""Tests for cache TTL exports sourced from shared.settings."""
+from __future__ import annotations
+
+import importlib
+from typing import Iterable
+
+import pytest
+
+TTL_EXPORTS: tuple[str, ...] = (
+    "cache_ttl_portfolio",
+    "cache_ttl_last_price",
+    "cache_ttl_fx",
+    "cache_ttl_quotes",
+    "quotes_hist_maxlen",
+    "max_quote_workers",
+)
+
+ENV_KEYS: tuple[str, ...] = (
+    "CACHE_TTL_PORTFOLIO",
+    "CACHE_TTL_LAST_PRICE",
+    "CACHE_TTL_FX",
+    "CACHE_TTL_QUOTES",
+    "QUOTES_HIST_MAXLEN",
+    "MAX_QUOTE_WORKERS",
+)
+
+
+@pytest.fixture(autouse=True)
+def reload_settings_after_test():
+    """Ensure shared configuration modules are reset after each test."""
+    yield
+    _reload_settings_module()
+
+
+def _reload_settings_module():
+    """Reload configuration modules and return the shared.settings module."""
+    shared_config = importlib.import_module("shared.config")
+    shared_settings = importlib.import_module("shared.settings")
+    importlib.reload(shared_config)
+    importlib.reload(shared_settings)
+    return shared_settings
+
+
+def _clear_env(monkeypatch: pytest.MonkeyPatch, keys: Iterable[str]) -> None:
+    for key in keys:
+        monkeypatch.delenv(key, raising=False)
+
+
+def test_ttl_exports_match_underlying_settings(monkeypatch: pytest.MonkeyPatch):
+    """Exported TTL constants should mirror the values in the Settings object."""
+    _clear_env(monkeypatch, ENV_KEYS)
+    settings_module = _reload_settings_module()
+    for attr in TTL_EXPORTS:
+        exported = getattr(settings_module, attr)
+        underlying = getattr(settings_module.settings, attr)
+        assert exported == underlying, attr
+
+
+def test_ttl_values_respect_environment_overrides(monkeypatch: pytest.MonkeyPatch):
+    """Environment variables must override the default TTL configuration."""
+    overrides = {
+        "CACHE_TTL_PORTFOLIO": "123",
+        "CACHE_TTL_LAST_PRICE": "45",
+        "CACHE_TTL_FX": "67",
+        "CACHE_TTL_QUOTES": "89",
+        "QUOTES_HIST_MAXLEN": "42",
+        "MAX_QUOTE_WORKERS": "7",
+    }
+    for key, value in overrides.items():
+        monkeypatch.setenv(key, value)
+
+    settings_module = _reload_settings_module()
+
+    for attr, key in zip(TTL_EXPORTS, overrides):
+        value = getattr(settings_module, attr)
+        assert value == int(overrides[key])
+        assert value == getattr(settings_module.settings, attr)

--- a/ui/test/test_sidebar_healthcheck.py
+++ b/ui/test/test_sidebar_healthcheck.py
@@ -1,0 +1,57 @@
+"""Assertions around the health sidebar rendering for error scenarios."""
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import ui.health_sidebar as sidebar
+
+
+def _make_sidebar_mock() -> SimpleNamespace:
+    return SimpleNamespace(
+        header=MagicMock(),
+        caption=MagicMock(),
+        markdown=MagicMock(),
+    )
+
+
+def test_health_panel_renders_problem_states(monkeypatch):
+    metrics = {
+        "iol_refresh": {"status": "error", "detail": "token", "ts": 1700000000},
+        "yfinance": {"source": "error", "detail": "AAPL", "ts": 1700001000},
+        "fx_api": {
+            "status": "error",
+            "error": "timeout",
+            "elapsed_ms": 512.8,
+            "ts": 1700002000,
+        },
+        "fx_cache": {"mode": "miss", "age": 21.4, "ts": 1700003000},
+        "portfolio": {
+            "elapsed_ms": 99.9,
+            "source": "api",
+            "detail": "cache-miss",
+            "ts": 1700004000,
+        },
+        "quotes": {
+            "elapsed_ms": 77.7,
+            "source": "api",
+            "count": 12,
+            "detail": "partial",
+            "ts": 1700005000,
+        },
+    }
+    sidebar_mock = _make_sidebar_mock()
+    monkeypatch.setattr(sidebar, "st", SimpleNamespace(sidebar=sidebar_mock))
+    monkeypatch.setattr(sidebar, "get_health_metrics", lambda: metrics)
+
+    sidebar.render_health_sidebar()
+
+    rendered = [entry.args[0] for entry in sidebar_mock.markdown.call_args_list]
+    assert any("⚠️ Error al refrescar" in text for text in rendered)
+    assert any("⚠️ Error o sin datos" in text for text in rendered)
+    assert any("⚠️ API FX con errores" in text for text in rendered)
+    assert any("🔄 Actualización" in text for text in rendered)
+    assert any("cache-miss" in text for text in rendered)
+    assert any("partial" in text for text in rendered)
+    assert any("items: 12" in text for text in rendered)
+


### PR DESCRIPTION
## Summary
- add coverage that reloads shared settings to verify cache TTL exports and environment overrides
- exercise the sidebar health panel with mocked error states and ensure cache/network errors surface through shared error aliases
- add shared.errors for reuse, verify cache services raise the expected exceptions, and update CI to run all pytest directories

## Testing
- pytest tests/test_settings_ttl.py ui/test/test_sidebar_healthcheck.py application/test/test_network_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68c898c806ac8332910560744ee134a2