### PR TITLE
Add shared error hierarchy

### DIFF
--- a/shared/errors.py
+++ b/shared/errors.py
@@ -1,0 +1,32 @@
+"""Shared application error hierarchy."""
+
+from __future__ import annotations
+
+
+class AppError(Exception):
+    """Base exception for application-specific errors."""
+
+
+class NetworkError(AppError):
+    """Represents network-related failures."""
+
+
+class InvalidCredentialsError(AppError):
+    """Raised when provided credentials are invalid."""
+
+
+class TimeoutError(NetworkError):
+    """Raised when a network operation times out."""
+
+
+class ExternalAPIError(AppError):
+    """Raised when an external API returns an error."""
+
+
+__all__ = [
+    "AppError",
+    "NetworkError",
+    "InvalidCredentialsError",
+    "TimeoutError",
+    "ExternalAPIError",
+]


### PR DESCRIPTION
## Summary
- add a centralized application error hierarchy under `shared/errors.py`
- export the new error classes via `__all__`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c8a669e084833296ab11e067939362

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized application error handling with a unified hierarchy, improving consistency across network, timeout, external service, and authentication failures.
  * Delivers clearer, more user-friendly error messages and more predictable behavior during failures.
  * Enhances resilience and diagnostics during connectivity issues, laying groundwork for future improvements.
  * No expected changes to typical user workflows; improved reliability in edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->