### PR TITLE
refactor: centralize auth errors

### DIFF
--- a/infrastructure/iol/auth.py
+++ b/infrastructure/iol/auth.py
@@ -13,6 +13,7 @@ import requests
 from cryptography.fernet import Fernet, InvalidToken
 
 from shared.config import settings
+from shared.errors import InvalidCredentialsError, NetworkError, TimeoutError
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +26,6 @@ if settings.tokens_key:
         FERNET = Fernet(settings.tokens_key.encode())
     except Exception as e:
         logger.warning("Clave de cifrado inválida: %s", e)
-
-
-class InvalidCredentialsError(Exception):
-    """Se lanza cuando el usuario o contraseña son inválidos."""
-
-
-class NetworkError(Exception):
-    """Se lanza ante problemas de conectividad con la API."""
 
 @dataclass
 class IOLAuth:
@@ -116,7 +109,7 @@ class IOLAuth:
                     e,
                     extra={"tokens_file": self.tokens_path, "result": "error"},
                 )
-                raise NetworkError("Fallo de red") from e
+                raise TimeoutError("Fallo de red") from e
             except requests.RequestException as e:
                 logger.warning(
                     "Login IOL falló: %s",
@@ -141,7 +134,7 @@ class IOLAuth:
                     e,
                     extra={"tokens_file": self.tokens_path, "result": "error"},
                 )
-                raise NetworkError("Fallo de red") from e
+                raise NetworkError(str(e)) from e
 
             self._save_tokens(self.tokens)
             logger.info(
@@ -174,7 +167,7 @@ class IOLAuth:
                     e,
                     extra={"tokens_file": self.tokens_path, "result": "error"},
                 )
-                raise NetworkError("Fallo de red") from e
+                raise TimeoutError("Fallo de red") from e
             except requests.RequestException as e:
                 logger.warning(
                     "Refresh falló: %s",
@@ -200,7 +193,7 @@ class IOLAuth:
                     e,
                     extra={"tokens_file": self.tokens_path, "result": "error"},
                 )
-                raise NetworkError("Fallo de red") from e
+                raise NetworkError(str(e)) from e
 
             self._save_tokens(self.tokens)
             logger.info(

--- a/shared/errors.py
+++ b/shared/errors.py
@@ -1,0 +1,26 @@
+"""Excepciones compartidas para la aplicación."""
+from __future__ import annotations
+
+
+class Error(Exception):
+    """Excepción base para errores de la aplicación."""
+
+
+class InvalidCredentialsError(Error):
+    """Se lanza cuando el usuario o contraseña son inválidos."""
+
+
+class NetworkError(Error):
+    """Se lanza ante problemas de conectividad con la API."""
+
+
+class TimeoutError(NetworkError):
+    """Se lanza ante timeouts de red."""
+
+
+__all__ = [
+    "Error",
+    "InvalidCredentialsError",
+    "NetworkError",
+    "TimeoutError",
+]


### PR DESCRIPTION
## Summary
- add a shared.errors module with reusable InvalidCredentialsError, NetworkError and TimeoutError classes
- update the IOL auth client to use the shared errors and raise TimeoutError for connection and timeout issues while propagating request error messages

## Testing
- PYTHONPATH=. pytest infrastructure/test/test_iol_auth_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68c8a66aeff08332bdad8e69753d75d0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Clearer error handling during sign-in and session refresh: timeouts are now reported distinctly from other network issues for more precise feedback to users.

* **Documentation**
  * Error class documentation updated to Spanish, improving accessibility for Spanish-speaking team members.

* **Refactor**
  * Standardized authentication error types across the app for consistency in user-facing messages without changing token behavior.

* **Chores**
  * Minor internal cleanup of legacy error definitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->