### PR TITLE
Raise shared network errors

### DIFF
--- a/application/test/test_error_handling.py
+++ b/application/test/test_error_handling.py
@@ -23,6 +23,7 @@ from application.ta_service import fetch_with_indicators
 from services import cache
 from controllers import auth
 from infrastructure.iol.auth import InvalidCredentialsError
+from shared.errors import ExternalAPIError
 
 
 @pytest.mark.parametrize("exc_cls", [HTTPError, Timeout])
@@ -48,9 +49,9 @@ def test_fetch_fx_rates_handles_network_error(monkeypatch):
             raise requests.RequestException("boom")
 
     monkeypatch.setattr(cache, "get_fx_provider", lambda: FailProv())
-    data, error = cache.fetch_fx_rates()
-    assert data == {}
-    assert error is not None
+    with pytest.raises(ExternalAPIError) as exc:
+        cache.fetch_fx_rates()
+    assert "FX provider failed" in str(exc.value)
 
 
 def test_build_iol_client_handles_network_error(monkeypatch):

--- a/infrastructure/iol/auth.py
+++ b/infrastructure/iol/auth.py
@@ -13,6 +13,7 @@ import requests
 from cryptography.fernet import Fernet, InvalidToken
 
 from shared.config import settings
+from shared.errors import NetworkError
 
 logger = logging.getLogger(__name__)
 
@@ -29,11 +30,6 @@ if settings.tokens_key:
 
 class InvalidCredentialsError(Exception):
     """Se lanza cuando el usuario o contraseña son inválidos."""
-
-
-class NetworkError(Exception):
-    """Se lanza ante problemas de conectividad con la API."""
-
 @dataclass
 class IOLAuth:
     user: str

--- a/services/test/test_cache_error_paths.py
+++ b/services/test/test_cache_error_paths.py
@@ -6,6 +6,7 @@ import pytest
 import requests
 
 from services import cache as svc_cache
+from shared.errors import NetworkError
 
 # --- _trigger_logout ---
 
@@ -57,8 +58,8 @@ def test_fetch_portfolio_handles_request_exception(monkeypatch):
 
     svc_cache.fetch_portfolio.clear()
     cli = DummyCli()
-    result = svc_cache.fetch_portfolio(cli)
-    assert result == {"_cached": True}
+    with pytest.raises(NetworkError):
+        svc_cache.fetch_portfolio(cli)
     logout_mock.assert_not_called()
 
 

--- a/shared/errors.py
+++ b/shared/errors.py
@@ -1,0 +1,12 @@
+"""Custom exception hierarchy shared across the application."""
+
+
+class NetworkError(Exception):
+    """Se lanza ante problemas de conectividad con servicios externos."""
+
+
+class ExternalAPIError(Exception):
+    """Se lanza cuando un proveedor externo responde con error o está inaccesible."""
+
+
+__all__ = ["NetworkError", "ExternalAPIError"]


### PR DESCRIPTION
## Summary
- add shared NetworkError and ExternalAPIError classes
- update cache services to raise shared errors on request failures
- adjust tests to assert the new exceptions

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a66b77608332908f35840ef95660