### PR TITLE
Surface AppError handling in UI service interactions

### DIFF
--- a/application/auth_service.py
+++ b/application/auth_service.py
@@ -12,7 +12,8 @@ import time
 
 import streamlit as st
 
-from infrastructure.iol.auth import IOLAuth, InvalidCredentialsError, NetworkError
+from infrastructure.iol.auth import IOLAuth
+from shared.errors import InvalidCredentialsError, NetworkError
 from shared.cache import cache
 from shared.config import settings
 

--- a/controllers/portfolio/filters.py
+++ b/controllers/portfolio/filters.py
@@ -5,6 +5,7 @@ import streamlit as st
 
 from shared.config import settings
 from services.cache import fetch_quotes_bulk
+from shared.errors import AppError
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +23,15 @@ def apply_filters(df_pos, controls, cli, psvc):
         .astype({"mercado": str, "simbolo": str})
         .itertuples(index=False, name=None)
     )
-    quotes_map = fetch_quotes_bulk(cli, pairs)
+    try:
+        quotes_map = fetch_quotes_bulk(cli, pairs)
+    except AppError as err:
+        st.error(str(err))
+        st.stop()
+    except Exception:
+        logger.exception("Error al obtener cotizaciones")
+        st.error("No se pudieron obtener cotizaciones, intente más tarde")
+        st.stop()
     chg_cnt = sum(
         1
         for v in quotes_map.values()

--- a/controllers/portfolio/fundamentals.py
+++ b/controllers/portfolio/fundamentals.py
@@ -1,9 +1,14 @@
+import logging
 import streamlit as st
 
 from ui.fundamentals import (
     render_fundamental_ranking,
     render_sector_comparison,
 )
+from shared.errors import AppError
+
+
+logger = logging.getLogger(__name__)
 
 
 def render_fundamental_analysis(df_view, tasvc):
@@ -12,7 +17,15 @@ def render_fundamental_analysis(df_view, tasvc):
     portfolio_symbols = df_view["simbolo"].tolist()
     if portfolio_symbols:
         with st.spinner("Descargando datos fundamentales…"):
-            fund_df = tasvc.portfolio_fundamentals(portfolio_symbols)
+            try:
+                fund_df = tasvc.portfolio_fundamentals(portfolio_symbols)
+            except AppError as err:
+                st.error(str(err))
+                return
+            except Exception:
+                logger.exception("Error al obtener datos fundamentales del portafolio")
+                st.error("No se pudieron obtener datos fundamentales, intente más tarde")
+                return
         render_fundamental_ranking(fund_df)
         render_sector_comparison(fund_df)
     else:

--- a/controllers/portfolio/load_data.py
+++ b/controllers/portfolio/load_data.py
@@ -3,6 +3,7 @@ import pandas as pd
 import streamlit as st
 
 from services.cache import fetch_portfolio
+from shared.errors import AppError
 
 logger = logging.getLogger(__name__)
 
@@ -14,10 +15,12 @@ def load_portfolio_data(cli, psvc):
     with st.spinner("Cargando y actualizando portafolio... ⏳"):
         try:
             payload = fetch_portfolio(cli)
+        except AppError as err:
+            st.error(str(err))
+            st.stop()
         except Exception:  # pragma: no cover - streamlit error path
-            logger.error(
+            logger.exception(
                 "Error al consultar portafolio",
-                exc_info=True,
                 extra={"tokens_file": tokens_path},
             )
             st.error("No se pudo cargar el portafolio, intente más tarde")

--- a/controllers/test/test_portfolio_helpers.py
+++ b/controllers/test/test_portfolio_helpers.py
@@ -116,7 +116,7 @@ def test_load_portfolio_data_shows_generic_error(monkeypatch):
     msg = err_mock.call_args[0][0]
     assert msg == "No se pudo cargar el portafolio, intente más tarde"
     assert "detalle interno" not in msg
-    logger_mock.error.assert_called_once()
+    logger_mock.exception.assert_called_once()
 
 
 def test_load_portfolio_data_reruns_on_auth_error(monkeypatch):

--- a/infrastructure/iol/auth.py
+++ b/infrastructure/iol/auth.py
@@ -13,6 +13,7 @@ import requests
 from cryptography.fernet import Fernet, InvalidToken
 
 from shared.config import settings
+from shared.errors import InvalidCredentialsError, NetworkError
 
 logger = logging.getLogger(__name__)
 
@@ -25,14 +26,6 @@ if settings.tokens_key:
         FERNET = Fernet(settings.tokens_key.encode())
     except Exception as e:
         logger.warning("Clave de cifrado inválida: %s", e)
-
-
-class InvalidCredentialsError(Exception):
-    """Se lanza cuando el usuario o contraseña son inválidos."""
-
-
-class NetworkError(Exception):
-    """Se lanza ante problemas de conectividad con la API."""
 
 @dataclass
 class IOLAuth:

--- a/ui/actions.py
+++ b/ui/actions.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
+import logging
 import time
 import streamlit as st
 from application import auth_service
+from shared.errors import AppError
+
+
+logger = logging.getLogger(__name__)
 
 
 def render_action_menu() -> None:
@@ -26,7 +31,15 @@ def render_action_menu() -> None:
 
     if st.session_state.pop("logout_pending", False):
         with st.spinner("Cerrando sesión..."):
-            auth_service.logout(st.session_state.get("IOL_USERNAME", ""))
+            try:
+                auth_service.logout(st.session_state.get("IOL_USERNAME", ""))
+            except AppError as err:
+                st.error(str(err))
+                st.stop()
+            except Exception:
+                logger.exception("Error inesperado al cerrar sesión")
+                st.error("No se pudo cerrar sesión, intente nuevamente más tarde")
+                st.stop()
 
     if st.session_state.pop("show_refresh_toast", False):
         st.toast("Datos actualizados", icon="✅")


### PR DESCRIPTION
## Summary
- import shared error classes in the authentication layer so infrastructure and services share the same hierarchy
- show controlled AppError messages in the login flow and add defensive handling for service-triggered actions
- wrap portfolio controllers that call services with AppError branches and logger.exception logging, updating the related test

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8a66d7e788332bebc1c3a2cf45950