### PR TITLE
Ensure Streamlit import in FX controller

### DIFF
--- a/controllers/fx.py
+++ b/controllers/fx.py
@@ -1,4 +1,4 @@
-import streamlit as st
+import streamlit as st  # Streamlit UI components
 import pandas as pd
 
 from shared.config import settings


### PR DESCRIPTION
## Summary
- annotate the Streamlit import at the top of the FX controller to clarify its usage

## Testing
- python -m pytest controllers/test/test_fx_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68c8c7204728833288328a5a5acb3c76