### PR TITLE
fix: include logging and numpy imports

### DIFF
--- a/controllers/portfolio/risk.py
+++ b/controllers/portfolio/risk.py
@@ -1,5 +1,6 @@
-import numpy as np
 import logging
+
+import numpy as np
 import pandas as pd
 import plotly.express as px
 import streamlit as st


### PR DESCRIPTION
## Summary
- ensure the risk controller explicitly imports the logging module
- group numpy with other third-party dependencies at the top of the file

## Testing
- pytest controllers/test/test_portfolio_controller.py application/test/test_risk_service.py application/test/test_risk_service_edge_cases.py

------
https://chatgpt.com/codex/tasks/task_e_68c8c72306648332a5cc17ad13f1ea5a