### PR TITLE
Remove placeholder comment from TA service module

### DIFF
--- a/application/ta_service.py
+++ b/application/ta_service.py
@@ -530,10 +530,6 @@ def get_portfolio_history(simbolos: List[str], period: str = "1y") -> pd.DataFra
 
 get_portfolio_history.clear = _get_portfolio_history_cached.cache_clear  # type: ignore[attr-defined]
 
-
-# --- Agregar al final de application/ta_service.py ---
-
-
 class TAService:
     """Fachada de análisis técnico que envuelve las funciones existentes."""
 


### PR DESCRIPTION
## Summary
- remove the leftover placeholder comment from `application/ta_service.py`

## Testing
- pytest application/test/test_ta_service_*


------
https://chatgpt.com/codex/tasks/task_e_68c8c9f83328833289fc7309a6c8c780