### PR TITLE
Add maxsize options to cache decorators

### DIFF
--- a/infrastructure/test/test_cache_hashable.py
+++ b/infrastructure/test/test_cache_hashable.py
@@ -1,6 +1,10 @@
-from shared.cache import cache
+import sys
 import time
 from threading import Thread
+
+from shared.cache import cache
+
+cache_module = sys.modules["shared.cache"]
 
 
 def test_cache_data_handles_list_arguments():
@@ -64,3 +68,60 @@ def test_cache_expiration_cleanup():
     assert key[0][0] == 2
 
     identity.clear()
+
+
+def test_cache_data_maxsize_evicts_old_entries():
+    calls = {"n": 0}
+
+    @cache.cache_data(maxsize=2)
+    def identity(x):
+        calls["n"] += 1
+        return x
+
+    assert identity(1) == 1
+    assert identity(2) == 2
+    assert calls["n"] == 2
+
+    assert identity(2) == 2
+    assert calls["n"] == 2
+
+    assert identity(3) == 3
+    assert calls["n"] == 3
+
+    assert identity(1) == 1
+    assert calls["n"] == 4
+
+    identity.clear()
+
+
+def test_cache_resource_maxsize_eviction(monkeypatch):
+    fake_session = {"session_id": "test"}
+    monkeypatch.setattr(cache_module.st, "session_state", fake_session)
+
+    calls = {"n": 0}
+
+    @cache.cache_resource(maxsize=2)
+    def build(name):
+        calls["n"] += 1
+        return {"name": name}
+
+    first = build("a")
+    second = build("b")
+
+    assert calls["n"] == 2
+    assert build("a") is first
+    assert calls["n"] == 2
+
+    third = build("c")
+    assert calls["n"] == 3
+    assert third == {"name": "c"}
+
+    assert build("b") is second
+    assert calls["n"] == 3
+
+    new_first = build("a")
+    assert calls["n"] == 4
+    assert new_first == {"name": "a"}
+    assert new_first is not first
+
+    build.clear()


### PR DESCRIPTION
## Summary
- allow both cache decorators to accept an optional maxsize and evict the oldest entries when the limit is exceeded
- add regression tests that fill the caches and assert that older entries are evicted once the size cap is reached

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8cc0b09ac83329c6e5068b7bb1712