### PR TITLE
Document Controls dataclass defaults

### DIFF
--- a/domain/models.py
+++ b/domain/models.py
@@ -5,13 +5,27 @@ from typing import List
 
 @dataclass(frozen=True)
 class Controls:
+    """User interface controls and their default values.
+
+    Attributes:
+        refresh_secs: Number of seconds between data refreshes.
+        hide_cash: Whether cash positions are hidden from the portfolio view.
+        show_usd: Whether values are displayed in U.S. dollars alongside pesos.
+        order_by: Column or attribute name used to sort portfolio entries.
+        desc: Whether the sorting order is descending.
+        top_n: Maximum number of entries to display in summary tables.
+        selected_syms: Symbol identifiers currently filtered in the UI.
+        selected_types: Instrument types currently filtered in the UI.
+        symbol_query: Free-text query applied to symbol filtering.
+    """
+
     refresh_secs: int = 30
     hide_cash: bool = True
     show_usd: bool = False
     order_by: str = "valor_actual"
     desc: bool = True
     top_n: int = 20
-    selected_syms: List[str] = field(default_factory=list)
-    selected_types: List[str] = field(default_factory=list)
+    selected_syms: List[str] = field(default_factory=list)  # avoid shared mutable defaults
+    selected_types: List[str] = field(default_factory=list)  # avoid shared mutable defaults
     symbol_query: str = ""
 


### PR DESCRIPTION
## Summary
- document the Controls dataclass with a detailed docstring for each field
- clarify the intent of list default factories in Controls

## Testing
- PYTHONPATH=. pytest controllers/test/test_portfolio_controller.py controllers/test/test_portfolio_helpers.py test/test_sidebar_controls.py

------
https://chatgpt.com/codex/tasks/task_e_68c8cc0d29448332ab0121dc919e117b