### PR TITLE
Update footer timestamp rendering and tests

### DIFF
--- a/tests/test_version_display.py
+++ b/tests/test_version_display.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import re
+from datetime import datetime
 import sys
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
@@ -16,19 +18,52 @@ class DummyCtx:
         return False
 
 
+class FixedDatetime:
+    def __init__(self, value: datetime):
+        self._value = value
+        self.calls: list[str | None] = []
+
+    def now(self, tz=None):
+        self.calls.append(tz)
+        return self._value
+
+
+def setup_footer_mocks(monkeypatch):
+    fixed_dt = datetime(2024, 1, 2, 3, 4, 5)
+    datetime_stub = FixedDatetime(fixed_dt)
+    monkeypatch.setattr(ui.footer, "datetime", datetime_stub)
+
+    captured_timezones: list[str] = []
+
+    def fake_zoneinfo(name: str):
+        captured_timezones.append(name)
+        return name
+
+    monkeypatch.setattr(ui.footer, "ZoneInfo", fake_zoneinfo, raising=False)
+    monkeypatch.setattr(ui.footer, "get_version", lambda: __version__)
+    mock_markdown = MagicMock()
+    monkeypatch.setattr(ui.footer.st, "markdown", mock_markdown)
+    return mock_markdown, datetime_stub, captured_timezones, fixed_dt
+
+
 def test_version_shown_in_login(monkeypatch):
     monkeypatch.setattr("ui.login.settings.tokens_key", "dummy")
     monkeypatch.setattr("ui.login.render_header", lambda *a, **k: None)
-    monkeypatch.setattr(ui.footer, "get_version", lambda: (__version__, "hoy"))
-    mock_markdown = MagicMock()
-    monkeypatch.setattr(ui.footer.st, "markdown", mock_markdown)
+    mock_markdown, datetime_stub, captured_timezones, fixed_dt = setup_footer_mocks(monkeypatch)
     monkeypatch.setattr("ui.login.st.warning", lambda *a, **k: None)
     monkeypatch.setattr("ui.login.st.error", lambda *a, **k: None)
     monkeypatch.setattr("ui.login.st.text_input", lambda *a, **k: "")
     monkeypatch.setattr("ui.login.st.form_submit_button", lambda *a, **k: False)
     monkeypatch.setattr("ui.login.st.form", lambda *a, **k: DummyCtx())
     render_login_page()
-    assert any(__version__ in str(call.args[0]) for call in mock_markdown.call_args_list)
+    rendered_blocks = [str(call.args[0]) for call in mock_markdown.call_args_list]
+    assert any(f"Versión {__version__}" in block for block in rendered_blocks)
+    timestamp_pattern = re.compile(r"\b\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}\b")
+    assert any(timestamp_pattern.search(block) for block in rendered_blocks)
+    expected_timestamp = fixed_dt.strftime("%d/%m/%Y %H:%M:%S")
+    assert any(expected_timestamp in block for block in rendered_blocks)
+    assert any(tz == "America/Argentina/Buenos_Aires" for tz in datetime_stub.calls)
+    assert captured_timezones == ["America/Argentina/Buenos_Aires"]
 
 
 def test_version_shown_in_main_app(monkeypatch):
@@ -39,13 +74,18 @@ def test_version_shown_in_main_app(monkeypatch):
     monkeypatch.setattr(main_app, "render_action_menu", lambda *a, **k: None)
     monkeypatch.setattr(main_app, "build_iol_client", lambda: None)
     monkeypatch.setattr(main_app, "render_portfolio_section", lambda *a, **k: None)
-    monkeypatch.setattr(ui.footer, "get_version", lambda: (__version__, "hoy"))
-    mock_markdown = MagicMock()
-    monkeypatch.setattr(ui.footer.st, "markdown", mock_markdown)
+    mock_markdown, datetime_stub, captured_timezones, fixed_dt = setup_footer_mocks(monkeypatch)
     monkeypatch.setattr(main_app.st, "session_state", {"authenticated": True})
     monkeypatch.setattr(main_app.st, "stop", lambda: None)
     monkeypatch.setattr(main_app.st, "columns", lambda *a, **k: (DummyCtx(), DummyCtx()))
     monkeypatch.setattr(main_app.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(main_app.st, "container", lambda: DummyCtx())
     main_app.main([])
-    assert any(__version__ in str(call.args[0]) for call in mock_markdown.call_args_list)
+    rendered_blocks = [str(call.args[0]) for call in mock_markdown.call_args_list]
+    assert any(f"Versión {__version__}" in block for block in rendered_blocks)
+    timestamp_pattern = re.compile(r"\b\d{2}/\d{2}/\d{4} \d{2}:\d{2}:\d{2}\b")
+    assert any(timestamp_pattern.search(block) for block in rendered_blocks)
+    expected_timestamp = fixed_dt.strftime("%d/%m/%Y %H:%M:%S")
+    assert any(expected_timestamp in block for block in rendered_blocks)
+    assert any(tz == "America/Argentina/Buenos_Aires" for tz in datetime_stub.calls)
+    assert captured_timezones == ["America/Argentina/Buenos_Aires"]

--- a/ui/footer.py
+++ b/ui/footer.py
@@ -1,36 +1,31 @@
-import subprocess
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 import streamlit as st
 from shared.version import __version__
 
 
-def get_version():
-    version = __version__
-    try:
-        date = (
-            subprocess.check_output(
-                ["git", "log", "-1", "--format=%cd", "--date=short"], stderr=subprocess.STDOUT
-            )
-            .decode()
-            .strip()
-        )
-    except Exception:
-        date = "desconocida"
+TIMEZONE = "America/Argentina/Buenos_Aires"
 
-    return version, date
+
+def get_version() -> str:
+    return __version__
 
 
 def render_footer():
-    version, commit_date = get_version()
-    year = datetime.now().year
+    version = get_version()
+    timezone = ZoneInfo(TIMEZONE)
+    now = datetime.now(timezone)
+    timestamp = now.strftime("%d/%m/%Y %H:%M:%S")
+    year = now.year
     st.markdown(
         f"""
         <hr>
         <div style='text-align:center; font-size:0.9em;'>
             Desarrollado por Nicolás K. ·
             <a href='https://github.com/caliari' target='_blank'>Portafolio</a><br>
-            Versión {version} ({commit_date})<br>
+            Versión {version}<br>
+            Actualizado {timestamp}<br>
             &copy; {year} - Los datos se ofrecen sin garantía. Uso bajo su responsabilidad.
         </div>
         """,


### PR DESCRIPTION
## Summary
- update the footer to show the app version and a timestamp using the Buenos Aires timezone
- refresh the login and main app version display tests to mock the timezone and assert the rendered version/timestamp text

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68c8d7193b988332a831ce0a703483ec