### PR TITLE
Bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2025-09-17
+### Added
+- Se incorporó un timestamp argentino en el footer para reflejar la hora local
+  de manera consistente.
+
 ## [0.2.0] - 2025-09-16
 ### Added
 - Centralized cache TTL configuration in `shared/settings` and documented the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "portafolio-iol"
-version = "0.2.0"
+version = "0.2.1"


### PR DESCRIPTION
## Summary
- bump the project version number to 0.2.1 in pyproject metadata
- document the footer's Argentine timestamp addition in the changelog

## Testing
- python - <<'PY'
from shared.version import __version__
print(__version__)
PY

------
https://chatgpt.com/codex/tasks/task_e_68c8d71d326483329b295b3be7c2bd2e