### PR TITLE
Add security info block to login page

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 
 Desde Streamlit 1.30 se reemplazó el parámetro `use_container_width` y se realizaron ajustes mínimos de diseño.
 
+## Seguridad de credenciales
+
+### 🔒 Seguridad de tus credenciales
+
+- Cifrado de tokens con [Fernet](https://cryptography.io/en/latest/fernet/)
+- Almacenamiento de secretos con [Streamlit Secrets](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/secrets-management)
+- Tokens guardados en archivos cifrados locales (no en la nube)
+- Limpieza inmediata de contraseñas en `session_state`
+
+Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
+
 ## Requisitos de sistema
 
 - Python 3.10 o superior

--- a/tests/test_security_info.py
+++ b/tests/test_security_info.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+import sys
+from unittest.mock import MagicMock
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+import ui.security_info as security_info
+
+
+def test_security_info_contains_expected_text(monkeypatch):
+    mock_markdown = MagicMock()
+    monkeypatch.setattr(security_info.st, "markdown", mock_markdown)
+    security_info.render_security_info()
+    rendered = "\n".join(str(call.args[0]) for call in mock_markdown.call_args_list)
+    assert "Fernet" in rendered
+    assert "Streamlit Secrets" in rendered

--- a/ui/login.py
+++ b/ui/login.py
@@ -4,6 +4,7 @@ from application.auth_service import get_auth_provider
 from application.login_service import clear_password_keys, validate_tokens_key
 from ui.footer import render_footer
 from ui.header import render_header
+from ui.security_info import render_security_info
 from shared.config import settings  # Re-exported for backwards compatibility
 from shared.errors import AppError, InvalidCredentialsError, NetworkError
 
@@ -32,7 +33,9 @@ def render_login_page() -> None:
         user = st.text_input("Usuario")
         password = st.text_input("Contraseña", type="password")
         submitted = st.form_submit_button("Iniciar sesión")
-        render_footer()
+
+    render_security_info()
+    render_footer()
 
     if submitted:
         provider = get_auth_provider()

--- a/ui/security_info.py
+++ b/ui/security_info.py
@@ -1,0 +1,18 @@
+import streamlit as st
+
+
+def render_security_info() -> None:
+    """Render a block describing how credentials are protected."""
+    st.markdown(
+        (
+            "### 🔒 Seguridad de tus credenciales\n\n"
+            "- Cifrado de tokens con [Fernet](https://cryptography.io/en/latest/fernet/)\n"
+            "- Almacenamiento de secretos con [Streamlit Secrets](https://docs.streamlit.io/streamlit-community-cloud/get-started/deploy-an-app/secrets-management)\n"
+            "- Tokens guardados en archivos cifrados locales (no en la nube)\n"
+            "- Limpieza inmediata de contraseñas en `session_state`\n\n"
+            "Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación."
+        )
+    )
+
+
+__all__ = ["render_security_info"]


### PR DESCRIPTION
## Summary
- add `render_security_info` component and show it on login screen
- document credential protection measures in README
- test rendering of security info block

## Testing
- `pytest tests/test_security_info.py -q` *(fails: ModuleNotFoundError: No module named 'streamlit')*

------
https://chatgpt.com/codex/tasks/task_e_68c8deb22c508332add2c16a5ee0636e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a security information panel after the login form, explaining credential protection: encrypted tokens with Fernet, use of Streamlit Secrets, local encrypted token storage, and immediate password clearing. Clarifies no external server storage; IOL access uses locally managed encrypted tokens. Footer now appears after this section.
- Documentation
  - Added “Seguridad de credenciales” to README with the above details.
- Tests
  - Introduced a unit test verifying the security info mentions “Fernet” and “Streamlit Secrets.”

<!-- end of auto-generated comment: release notes by coderabbit.ai -->