### PR TITLE
Update health sidebar header with version info

### DIFF
--- a/tests/test_health_sidebar_rendering.py
+++ b/tests/test_health_sidebar_rendering.py
@@ -12,6 +12,7 @@ import streamlit as st
 from streamlit.runtime.secrets import Secrets
 from streamlit.testing.v1 import AppTest
 
+from shared.version import __version__
 
 _ORIGINAL_STREAMLIT = st
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -61,7 +62,9 @@ def test_sidebar_shows_empty_state_labels() -> None:
         }
     )
 
-    assert _collect(app, "header") == ["🩺 Salud de datos"]
+    assert _collect(app, "header") == [
+        f"🩺 Healthcheck (versión {__version__})"
+    ]
     assert "Monitorea la procedencia y el rendimiento de los datos cargados." in _collect(
         app, "caption"
     )

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -8,6 +8,7 @@ from typing import Iterable, Optional
 import streamlit as st
 
 from services.health import get_health_metrics
+from shared.version import __version__
 
 
 def _format_timestamp(ts: Optional[float]) -> str:
@@ -111,7 +112,7 @@ def render_health_sidebar() -> None:
     """Render the health summary panel inside the sidebar."""
     metrics = get_health_metrics()
     sidebar = st.sidebar
-    sidebar.header("🩺 Salud de datos")
+    sidebar.header(f"🩺 Healthcheck (versión {__version__})")
     sidebar.caption("Monitorea la procedencia y el rendimiento de los datos cargados.")
 
     sidebar.markdown("#### 🔐 Conexión IOL")

--- a/ui/test/test_health_sidebar.py
+++ b/ui/test/test_health_sidebar.py
@@ -9,6 +9,7 @@ if str(ROOT) not in sys.path:
 
 import services.health as health_service
 import ui.health_sidebar as health_sidebar
+from shared.version import __version__
 
 
 def _mock_sidebar(monkeypatch):
@@ -55,6 +56,10 @@ def test_render_health_sidebar_with_success_metrics(monkeypatch):
 
     health_sidebar.render_health_sidebar()
 
+    sidebar.header.assert_called_once_with(
+        f"🩺 Healthcheck (versión {__version__})"
+    )
+
     md_calls = _collect_markdown(sidebar)
     assert any("#### 🔐 Conexión IOL" in text for text in md_calls)
     assert any("✅ Refresh correcto" in text and "Tokens OK" in text for text in md_calls)
@@ -88,6 +93,10 @@ def test_render_health_sidebar_with_missing_metrics(monkeypatch):
     _mock_metrics(monkeypatch, metrics)
 
     health_sidebar.render_health_sidebar()
+
+    sidebar.header.assert_called_once_with(
+        f"🩺 Healthcheck (versión {__version__})"
+    )
 
     md_calls = _collect_markdown(sidebar)
     assert any("⚠️ Error al refrescar" in text and "Token inválido" in text for text in md_calls)


### PR DESCRIPTION
## Summary
- include the package version in the health sidebar header using `shared.version.__version__`
- adjust Streamlit sidebar tests to expect the versioned header text

## Testing
- pytest ui/test/test_health_sidebar.py tests/test_health_sidebar_rendering.py

------
https://chatgpt.com/codex/tasks/task_e_68c9409582f8833299a15f5bd53802b1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Health sidebar header now displays the app’s current version dynamically.
  - Updated header label to “Healthcheck (versión X.Y.Z)” for clearer status visibility.

- Tests
  - Updated test coverage to validate the new version-aware header in the health sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->