### PR TITLE
Docs: highlight sidebar healthcheck version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2025-09-19
+### Changed
+- El healthcheck del sidebar ahora expone la versión actual de la aplicación y se movió al final para concentrar en un único bloque el estado de los servicios monitoreados.
+
 ## [0.3.0] - 2025-09-18
 ### Added
 - El bloque de seguridad del login ahora muestra dinámicamente la versión actual de la aplicación.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se r
 
 El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión X.Y.Z".
 
+El sidebar finaliza con un bloque de **Healthcheck (versión X.Y.Z)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
+
 ## Requisitos de sistema
 
 - Python 3.10 o superior


### PR DESCRIPTION
## Summary
- document the sidebar healthcheck block in the README, noting its placement at the end of the sidebar and that it shows the current version
- add a 0.3.1 changelog entry describing the healthcheck version display and relocation

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c940964f648332995aeefd1b049902