### PR TITLE
Centralize timestamp formatting

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import argparse
 import time
-from datetime import datetime
 import logging
 from uuid import uuid4
 
 import streamlit as st
 
 from shared.config import configure_logging, ensure_tokens_key
+from shared.time_provider import TimeProvider
 from ui.ui_settings import init_ui
 from ui.header import render_header
 from ui.actions import render_action_menu
@@ -60,8 +60,7 @@ def main(argv: list[str] | None = None):
     render_header(rates=fx_rates)
     _, hcol2 = st.columns([4, 1])
     with hcol2:
-        now = datetime.now()
-        st.caption(f"🕒 {now.strftime('%d/%m/%Y %H:%M:%S')}")
+        st.caption(f"🕒 {TimeProvider.now()}")
         render_action_menu()
 
     # main_col, side_col = st.columns([4, 1])

--- a/infrastructure/iol/legacy/iol_client.py
+++ b/infrastructure/iol/legacy/iol_client.py
@@ -11,11 +11,11 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 import requests
 from iolConn import Iol
 from iolConn.common.exceptions import NoAuthException  # <- importante
-from datetime import datetime
 import streamlit as st
 
 from shared.config import settings
 from shared.utils import _to_float
+from shared.time_provider import TimeProvider
 from infrastructure.iol.auth import IOLAuth, InvalidCredentialsError
 PORTFOLIO_URL = "https://api.invertironline.com/api/v2/portafolio"
 
@@ -139,7 +139,7 @@ class IOLClient:
                 if bearer and refresh:
                     self.iol_market.bearer = bearer
                     self.iol_market.refresh_token = refresh
-                    self.iol_market.bearer_time = datetime.now()
+                    self.iol_market.bearer_time = TimeProvider.now_datetime()
                 else:
                     st.session_state["force_login"] = True
                     raise InvalidCredentialsError("Token inválido")

--- a/shared/time_provider.py
+++ b/shared/time_provider.py
@@ -1,0 +1,33 @@
+"""Centralised time utilities for the application."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+from typing import ClassVar
+
+
+class TimeProvider:
+    """Provide timezone-aware timestamps formatted consistently."""
+
+    TIMEZONE: ClassVar[ZoneInfo] = ZoneInfo("America/Argentina/Buenos_Aires")
+    DATETIME_FORMAT: ClassVar[str] = "%Y-%m-%d %H:%M:%S"
+
+    @classmethod
+    def now_datetime(cls) -> datetime:
+        """Return the current datetime aware of the configured timezone."""
+        return datetime.now(tz=cls.TIMEZONE)
+
+    @classmethod
+    def now(cls) -> str:
+        """Return the current datetime formatted with the standard format."""
+        return cls.now_datetime().strftime(cls.DATETIME_FORMAT)
+
+    @classmethod
+    def from_timestamp(cls, ts: float | int | str) -> str:
+        """Format a numeric timestamp using the configured timezone and format."""
+        moment = datetime.fromtimestamp(float(ts), tz=cls.TIMEZONE)
+        return moment.strftime(cls.DATETIME_FORMAT)
+
+
+__all__ = ["TimeProvider"]

--- a/tests/test_health_sidebar_rendering.py
+++ b/tests/test_health_sidebar_rendering.py
@@ -12,6 +12,7 @@ import streamlit as st
 from streamlit.runtime.secrets import Secrets
 from streamlit.testing.v1 import AppTest
 
+from shared.time_provider import TimeProvider
 from shared.version import __version__
 
 _ORIGINAL_STREAMLIT = st
@@ -129,17 +130,18 @@ def test_sidebar_formats_populated_metrics() -> None:
     )
 
     markdown = _collect(app, "markdown")
+    formatted = [TimeProvider.from_timestamp(ts) for ts in timestamps]
     expected_lines = {
         "#### 🔐 Conexión IOL",
-        "✅ Refresh correcto • 02/01/2024 03:04:05 — OK",
+        f"✅ Refresh correcto • {formatted[0]} — OK",
         "#### 📈 Yahoo Finance",
-        "♻️ Fallback local • 02/01/2024 03:04:06 — respaldo",
+        f"♻️ Fallback local • {formatted[1]} — respaldo",
         "#### 💱 FX",
-        "⚠️ API FX con errores • 02/01/2024 03:04:07 (123 ms) — boom",
-        "♻️ Uso de caché • 02/01/2024 03:04:08 (edad 46s)",
+        f"⚠️ API FX con errores • {formatted[2]} (123 ms) — boom",
+        f"♻️ Uso de caché • {formatted[3]} (edad 46s)",
         "#### ⏱️ Latencias",
-        "- Portafolio: 457 ms • fuente: api • fresh • 02/01/2024 03:04:09",
-        "- Cotizaciones: 789 ms • fuente: yfinance • items: 12 • with gaps • 02/01/2024 03:04:10",
+        f"- Portafolio: 457 ms • fuente: api • fresh • {formatted[4]}",
+        f"- Cotizaciones: 789 ms • fuente: yfinance • items: 12 • with gaps • {formatted[5]}",
     }
 
     missing = expected_lines.difference(markdown)

--- a/ui/footer.py
+++ b/ui/footer.py
@@ -1,10 +1,6 @@
-from datetime import datetime
-from zoneinfo import ZoneInfo
-
 import streamlit as st
 from shared.version import __version__
-
-TIMEZONE = "America/Argentina/Buenos_Aires"
+from shared.time_provider import TimeProvider
 
 
 def get_version() -> str:
@@ -13,9 +9,8 @@ def get_version() -> str:
 
 def render_footer():
     version = get_version()
-    timezone = ZoneInfo(TIMEZONE)
-    now = datetime.now(timezone)
-    timestamp = now.strftime("%d/%m/%Y %H:%M:%S")
+    now = TimeProvider.now_datetime()
+    timestamp = TimeProvider.now()
     year = now.year
     st.markdown(
         f"""

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -2,23 +2,22 @@ from __future__ import annotations
 
 """Sidebar panel summarising recent data source health."""
 
-from datetime import datetime
 from typing import Iterable, Optional
 
 import streamlit as st
 
 from services.health import get_health_metrics
 from shared.version import __version__
+from shared.time_provider import TimeProvider
 
 
 def _format_timestamp(ts: Optional[float]) -> str:
     if not ts:
         return "Sin registro"
     try:
-        dt = datetime.fromtimestamp(float(ts))
+        return TimeProvider.from_timestamp(ts)
     except (TypeError, ValueError, OSError):
         return "Sin registro"
-    return dt.strftime("%d/%m/%Y %H:%M:%S")
 
 
 def _format_iol_status(data: Optional[dict]) -> str:


### PR DESCRIPTION
## Summary
- add a shared TimeProvider utility to centralize timezone-aware timestamp formatting
- update UI components, health sidebar, and legacy IOL client to consume the new provider
- refresh tests to assert the standardized YYYY-MM-DD HH:MM:SS output

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9df75e6488332af23d70231db4957