### PR TITLE
Introduce TimeProvider coverage and update timestamp usage

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import argparse
 import time
-from datetime import datetime
 import logging
 from uuid import uuid4
 
 import streamlit as st
 
 from shared.config import configure_logging, ensure_tokens_key
+from shared.time_provider import TimeProvider
 from ui.ui_settings import init_ui
 from ui.header import render_header
 from ui.actions import render_action_menu
@@ -60,8 +60,8 @@ def main(argv: list[str] | None = None):
     render_header(rates=fx_rates)
     _, hcol2 = st.columns([4, 1])
     with hcol2:
-        now = datetime.now()
-        st.caption(f"🕒 {now.strftime('%d/%m/%Y %H:%M:%S')}")
+        snapshot = TimeProvider.now()
+        st.caption(f"🕒 {snapshot.text}")
         render_action_menu()
 
     # main_col, side_col = st.columns([4, 1])

--- a/shared/time_provider.py
+++ b/shared/time_provider.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Optional
+from zoneinfo import ZoneInfo
+
+TIMEZONE = "America/Argentina/Buenos_Aires"
+TIME_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+
+@dataclass(frozen=True)
+class TimeSnapshot:
+    """Container for a formatted timestamp and its datetime representation."""
+
+    text: str
+    moment: datetime
+
+
+class TimeProvider:
+    """Centralised time provider to generate formatted timestamps."""
+
+    _zone = ZoneInfo(TIMEZONE)
+
+    @classmethod
+    def timezone(cls) -> ZoneInfo:
+        """Return the zoneinfo instance used for timestamp generation."""
+        return cls._zone
+
+    @classmethod
+    def now(cls) -> TimeSnapshot:
+        """Return the current time in the configured timezone."""
+        moment = datetime.now(cls._zone)
+        return TimeSnapshot(moment.strftime(TIME_FORMAT), moment)
+
+    @classmethod
+    def from_timestamp(cls, ts: Optional[float | int | str]) -> Optional[TimeSnapshot]:
+        """Convert a POSIX timestamp into a formatted snapshot.
+
+        Invalid or missing values yield ``None`` to mirror previous behaviour
+        in formatting helpers.
+        """
+
+        if ts is None or ts == 0:
+            return None
+        try:
+            raw = float(ts)
+        except (TypeError, ValueError):
+            return None
+        try:
+            moment = datetime.fromtimestamp(raw, tz=cls._zone)
+        except (OverflowError, OSError, ValueError):
+            return None
+        return TimeSnapshot(moment.strftime(TIME_FORMAT), moment)
+
+
+__all__ = ["TIMEZONE", "TIME_FORMAT", "TimeProvider", "TimeSnapshot"]

--- a/tests/shared/test_time_provider.py
+++ b/tests/shared/test_time_provider.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import re
+from datetime import timedelta
+
+from zoneinfo import ZoneInfo
+
+from shared.time_provider import TIMEZONE, TimeProvider
+
+
+def test_time_provider_now_returns_formatted_string_and_timezone() -> None:
+    snapshot = TimeProvider.now()
+
+    assert re.fullmatch(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}", snapshot.text)
+
+    moment = snapshot.moment
+    assert isinstance(moment.tzinfo, ZoneInfo)
+    assert moment.tzinfo.key == TIMEZONE
+    assert moment.utcoffset() == timedelta(hours=-3)

--- a/ui/footer.py
+++ b/ui/footer.py
@@ -1,10 +1,6 @@
-from datetime import datetime
-from zoneinfo import ZoneInfo
-
 import streamlit as st
+from shared.time_provider import TimeProvider
 from shared.version import __version__
-
-TIMEZONE = "America/Argentina/Buenos_Aires"
 
 
 def get_version() -> str:
@@ -13,10 +9,9 @@ def get_version() -> str:
 
 def render_footer():
     version = get_version()
-    timezone = ZoneInfo(TIMEZONE)
-    now = datetime.now(timezone)
-    timestamp = now.strftime("%d/%m/%Y %H:%M:%S")
-    year = now.year
+    snapshot = TimeProvider.now()
+    timestamp = snapshot.text
+    year = snapshot.moment.year
     st.markdown(
         f"""
         <hr>

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -2,23 +2,22 @@ from __future__ import annotations
 
 """Sidebar panel summarising recent data source health."""
 
-from datetime import datetime
 from typing import Iterable, Optional
 
 import streamlit as st
 
 from services.health import get_health_metrics
+from shared.time_provider import TimeProvider
 from shared.version import __version__
 
 
 def _format_timestamp(ts: Optional[float]) -> str:
     if not ts:
         return "Sin registro"
-    try:
-        dt = datetime.fromtimestamp(float(ts))
-    except (TypeError, ValueError, OSError):
+    snapshot = TimeProvider.from_timestamp(ts)
+    if snapshot is None:
         return "Sin registro"
-    return dt.strftime("%d/%m/%Y %H:%M:%S")
+    return snapshot.text
 
 
 def _format_iol_status(data: Optional[dict]) -> str:


### PR DESCRIPTION
## Summary
- add a shared TimeProvider that yields formatted timestamps with the Buenos Aires timezone
- switch the footer, main app caption and health sidebar formatting to consume the new provider
- extend the test suite to cover TimeProvider behaviour and adapt existing UI tests to the new format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9df77f57c8332882c8c32d643440b

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Consistent, timezone-aware timestamps across header, footer, and health sidebar.
  - Unified display format: YYYY-MM-DD HH:MM:SS with a clock caption in the UI.
  - Graceful handling of missing/invalid timestamps in the sidebar.

- Refactor
  - Centralized time handling to a provider for uniform formatting and timezone use.

- Tests
  - Added coverage for time display, timezone correctness, and sidebar rendering with deterministic timestamps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->