### PR TITLE
Documentar uso de TimeProvider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2025-09-20
+### Changed
+- Se unificó el manejo de hora mediante `shared.time_provider.TimeProvider` para mantener
+  timestamps consistentes en formato `YYYY-MM-DD HH:MM:SS` (UTC-3).
+
 ## [0.3.1] - 2025-09-19
 ### Changed
 - El healthcheck del sidebar ahora expone la versión actual de la aplicación y se movió al final para concentrar en un único bloque el estado de los servicios monitoreados.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 
-> Nota: el footer de la aplicación muestra la hora de Argentina (UTC-3) y se actualiza en cada renderizado.
+> Nota: todos los timestamps visibles provienen de `shared.time_provider.TimeProvider` y se muestran
+> en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
+> renderizado con la hora de Argentina.
 
 Desde Streamlit 1.30 se reemplazó el parámetro `use_container_width` y se realizaron ajustes mínimos de diseño.
 


### PR DESCRIPTION
## Summary
- documentar en el README que todos los timestamps provienen de `shared.time_provider.TimeProvider` y el formato UTC-3 utilizado
- registrar en el changelog la versión 0.3.2 con la unificación del manejo horario

## Testing
- no tests were run (not needed)

------
https://chatgpt.com/codex/tasks/task_e_68c9df7982f483329533d3b223dc3437