### PR TITLE
Add timezone-aware datetime helper for bearer tokens

### DIFF
--- a/infrastructure/iol/legacy/iol_client.py
+++ b/infrastructure/iol/legacy/iol_client.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from datetime import datetime
 from typing import Dict, Any, Optional, Iterable, Tuple
 import time
 import logging
@@ -139,7 +140,9 @@ class IOLClient:
                 if bearer and refresh:
                     self.iol_market.bearer = bearer
                     self.iol_market.refresh_token = refresh
-                    self.iol_market.bearer_time = TimeProvider.now_datetime()
+                    bearer_time: datetime = TimeProvider.now_datetime()
+                    # iolConn espera un datetime aware en UTC-3 para manejar expiración
+                    self.iol_market.bearer_time = bearer_time
                 else:
                     st.session_state["force_login"] = True
                     raise InvalidCredentialsError("Token inválido")

--- a/shared/time_provider.py
+++ b/shared/time_provider.py
@@ -16,6 +16,15 @@ class TimeSnapshot:
     text: str
     moment: datetime
 
+    def __post_init__(self) -> None:  # pragma: no cover - defensive normalisation
+        text, moment = self.text, self.moment
+        if isinstance(text, datetime) and isinstance(moment, str):
+            object.__setattr__(self, "text", moment)
+            object.__setattr__(self, "moment", text)
+
+    def __str__(self) -> str:
+        return self.text
+
 
 class TimeProvider:
     """Centralised time provider to generate formatted timestamps."""
@@ -28,9 +37,14 @@ class TimeProvider:
         return cls._zone
 
     @classmethod
+    def now_datetime(cls) -> datetime:
+        """Return the current datetime in the configured timezone."""
+        return datetime.now(cls._zone)
+
+    @classmethod
     def now(cls) -> TimeSnapshot:
-        """Return the current time in the configured timezone."""
-        moment = datetime.now(cls._zone)
+        """Return the formatted timestamp snapshot; use ``now_datetime`` for raw datetimes."""
+        moment = cls.now_datetime()
         return TimeSnapshot(moment.strftime(TIME_FORMAT), moment)
 
     @classmethod


### PR DESCRIPTION
## Summary
- add a `TimeProvider.now_datetime()` helper along with clearer documentation and string handling for `TimeSnapshot`
- update the legacy IOL client to feed a timezone-aware `datetime` into `iolConn.Iol.bearer_time`

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9eb94913483328d5cd2b073c60b22