### PR TITLE
Bump version to 0.3.3 and document TimeProvider usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2025-09-21
+### Fixed
+- Se corrigió `shared.time_provider.TimeProvider` para garantizar que los timestamps y objetos `datetime`
+  generados compartan la misma zona horaria y formato.
+### Changed
+- Se unificó la API de `TimeProvider` documentando explícitamente `now()` y `now_datetime()` para
+  elegir entre cadena formateada u objeto `datetime` según la necesidad.
+
 ## [0.3.2] - 2025-09-20
 ### Changed
 - Se unificó el manejo de hora mediante `shared.time_provider.TimeProvider` para mantener

--- a/README.md
+++ b/README.md
@@ -6,6 +6,23 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
+## Uso del proveedor de tiempo
+
+Para generar fechas consistentes en toda la aplicación, importa la clase `TimeProvider`:
+
+```python
+from shared.time_provider import TimeProvider
+
+timestamp = TimeProvider.now()          # "2025-09-21 10:15:42"
+moment = TimeProvider.now_datetime()    # datetime consciente de zona (UTC-3)
+```
+
+- `TimeProvider.now()` devuelve la representación en texto lista para mostrar en la interfaz.
+- `TimeProvider.now_datetime()` expone el mismo instante como un objeto `datetime` con zona horaria de Buenos Aires.
+
+Ambos métodos apuntan al mismo reloj centralizado, por lo que los valores son intercambiables según si necesitas una cadena o un
+`datetime` para cálculos adicionales.
+
 Desde Streamlit 1.30 se reemplazó el parámetro `use_container_width` y se realizaron ajustes mínimos de diseño.
 
 ## Seguridad de credenciales

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.2"
+version = "0.3.3"

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,14 +4,19 @@ from pathlib import Path
 import tomllib
 
 
+DEFAULT_VERSION = "0.3.3"
+PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
+
+
 def _read_version() -> str:
-    project_file = Path(__file__).resolve().parent.parent / "pyproject.toml"
     try:
-        with project_file.open("rb") as f:
+        with PROJECT_FILE.open("rb") as f:
             data = tomllib.load(f)
-        return data.get("project", {}).get("version", "0.0.0")
     except Exception:
-        return "0.0.0"
+        return DEFAULT_VERSION
+
+    version = data.get("project", {}).get("version", DEFAULT_VERSION)
+    return version if isinstance(version, str) and version else DEFAULT_VERSION
 
 
 __version__ = _read_version()


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.3 and synchronise the fallback in shared/version
- document the unified TimeProvider API in the README and changelog

## Testing
- pytest tests/test_version_display.py

------
https://chatgpt.com/codex/tasks/task_e_68c9f10d88c48332842cb4c0beaea0dc