### PR TITLE
Ensure iolConn bearer timestamps are naive

### DIFF
--- a/infrastructure/iol/legacy/iol_client.py
+++ b/infrastructure/iol/legacy/iol_client.py
@@ -140,8 +140,8 @@ class IOLClient:
                 if bearer and refresh:
                     self.iol_market.bearer = bearer
                     self.iol_market.refresh_token = refresh
-                    bearer_time: datetime = TimeProvider.now_datetime()
-                    # iolConn espera un datetime aware en UTC-3 para manejar expiración
+                    bearer_time: datetime = TimeProvider.now_datetime().replace(tzinfo=None)
+                    # iolConn requiere un datetime naive para compatibilidad con su manejo de expiración
                     self.iol_market.bearer_time = bearer_time
                 else:
                     st.session_state["force_login"] = True


### PR DESCRIPTION
## Summary
- persist the bearer token timestamp as a naive datetime for iolConn compatibility
- document why the timezone information is stripped when updating the bearer timestamp

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68c9f6c34b38833287f3bc73df016bd3