### PR TITLE
Bump version to 0.3.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.3"
+version = "0.3.4"

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import tomllib
 
 
-DEFAULT_VERSION = "0.3.3"
+DEFAULT_VERSION = "0.3.4"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version declared in pyproject.toml to 0.3.4
- update the DEFAULT_VERSION constant so runtime version checks stay in sync

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9f711ded88332839a20caf648fb18