### PR TITLE
Configure Streamlit server watcher

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,5 @@
 [theme]
 base = "dark"
+
+[server]
+fileWatcherType = "poll"


### PR DESCRIPTION
## Summary
- add a Streamlit server configuration that forces use of the poll-based file watcher to improve compatibility

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c9fe0f03c48332a4a022caf384c70c