### PR TITLE
Fix bearer timestamp using new TimeProvider API

### DIFF
--- a/infrastructure/iol/legacy/iol_client.py
+++ b/infrastructure/iol/legacy/iol_client.py
@@ -142,7 +142,7 @@ class IOLClient:
                     self.iol_market.refresh_token = refresh
                     # <== LÍNEA CORREGIDA: Usa la nueva API de TimeProvider
                     # iolConn requiere un datetime naive para compatibilidad
-                    bearer_time = TimeProvider.now().moment.replace(tzinfo=None)
+                    bearer_time = TimeProvider.now_datetime().replace(tzinfo=None)
                     self.iol_market.bearer_time = bearer_time
                 else:
                     st.session_state["force_login"] = True


### PR DESCRIPTION
## Summary
- switch the bearer reuse logic to use `TimeProvider.now_datetime()` while still stripping tzinfo to keep a naive datetime

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ca0530da4083329c96c2edeef80d6c