### PR TITLE
Add 0.3.6 entry to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.6] - 2025-09-17
+### Removed
+- Se eliminó la referencia obsoleta a `TimeProvider.now().moment` para evitar invocaciones inexistentes.
+### Fixed
+- Se corrigió el uso de `bearer_time` asegurando que utilice la clave actualizada.
+
 ## [0.3.5] - 2025-09-17
 ### Fixed
 - Se configuró `fileWatcherType = "poll"` en Streamlit para evitar bloqueos del recargador


### PR DESCRIPTION
## Summary
- document the 0.3.6 release beneath the Unreleased section
- note the removal of the obsolete TimeProvider.now().moment reference
- record the fix to the bearer_time usage

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca09a99f2083329d199a0023962d27