### PR TITLE
chore: bump version to 0.3.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.5"
+version = "0.3.6"

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import tomllib
 
 
-DEFAULT_VERSION = "0.3.5"
+DEFAULT_VERSION = "0.3.6"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.6 in pyproject metadata
- align the shared version default constant with the new release number

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ca0af192808332b6918499928f72ec