### PR TITLE
Add opportunities tab UI and tests

### DIFF
--- a/controllers/opportunities.py
+++ b/controllers/opportunities.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+import pandas as pd
+
+from controllers.opportunities_spec import OPPORTUNITIES_SPEC
+
+
+def search_opportunities() -> pd.DataFrame:
+    """Return a static set of investment opportunities.
+
+    The data is deterministic to keep tests stable and focuses on
+    providing every column declared in :data:`OPPORTUNITIES_SPEC`.
+    """
+
+    data = [
+        {
+            "symbol": "AL30",
+            "name": "Bono AL30",
+            "market": "BCBA",
+            "instrument_type": "Bono",
+            "currency": "ARS",
+            "last_price": 12345.67,
+            "change_pct": 1.23,
+            "volume_24h": 1_500_000,
+            "turnover_24h": 925_000_000.0,
+            "score": 78,
+        },
+        {
+            "symbol": "NVDA",
+            "name": "NVIDIA Corp.",
+            "market": "NASDAQ",
+            "instrument_type": "Acción",
+            "currency": "USD",
+            "last_price": 904.12,
+            "change_pct": -0.42,
+            "volume_24h": 3_200_000,
+            "turnover_24h": 2_893_000_000.0,
+            "score": 82,
+        },
+    ]
+
+    return pd.DataFrame(data, columns=OPPORTUNITIES_SPEC.columns)
+
+
+__all__ = ["search_opportunities"]

--- a/controllers/opportunities_spec.py
+++ b/controllers/opportunities_spec.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass(frozen=True)
+class OpportunitySpec:
+    """Static specification describing the opportunities dataset."""
+
+    columns: List[str]
+
+
+OPPORTUNITIES_SPEC = OpportunitySpec(
+    columns=[
+        "symbol",
+        "name",
+        "market",
+        "instrument_type",
+        "currency",
+        "last_price",
+        "change_pct",
+        "volume_24h",
+        "turnover_24h",
+        "score",
+    ]
+)
+
+__all__ = ["OpportunitySpec", "OPPORTUNITIES_SPEC"]

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from multiprocessing import get_context
+from pathlib import Path
+from types import ModuleType
+import sys
+import textwrap
+
+import pandas as pd
+import streamlit as _streamlit_module
+from streamlit.testing.v1 import AppTest
+from streamlit.runtime.secrets import Secrets
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+def _resolve_streamlit_module() -> ModuleType:
+    """Ensure we use the real Streamlit implementation, not a test stub."""
+    if getattr(_streamlit_module, "__file__", None) and hasattr(
+        _streamlit_module, "button"
+    ):
+        return _streamlit_module
+
+    for name in list(sys.modules):
+        if name == "streamlit" or name.startswith("streamlit."):
+            sys.modules.pop(name, None)
+
+    import streamlit as real_streamlit
+
+    return real_streamlit
+
+
+st = _resolve_streamlit_module()
+sys.modules["streamlit"] = st
+
+
+_ORIGINAL_STREAMLIT = st
+
+
+def _ensure_real_streamlit_module() -> None:
+    global st
+    if sys.modules.get("streamlit") is not _ORIGINAL_STREAMLIT:
+        sys.modules["streamlit"] = _ORIGINAL_STREAMLIT
+    if st is not _ORIGINAL_STREAMLIT:
+        st = _ORIGINAL_STREAMLIT
+    ui_settings_mod = sys.modules.get("ui.ui_settings")
+    if ui_settings_mod is not None:
+        setattr(ui_settings_mod, "st", _ORIGINAL_STREAMLIT)
+
+
+from controllers import opportunities as opportunities_ctrl
+from controllers.opportunities_spec import OPPORTUNITIES_SPEC
+from shared.version import __version__
+
+_SCRIPT = textwrap.dedent(
+    f"""
+    import sys
+    sys.path.insert(0, {repr(str(_PROJECT_ROOT))})
+    from ui.opportunities_tab import render_opportunities_tab
+    render_opportunities_tab()
+    """
+)
+
+
+def _collect_opportunities(queue: "Queue") -> None:
+    _ensure_real_streamlit_module()
+    if not hasattr(st, "secrets"):
+        st.secrets = Secrets({})
+    app = AppTest.from_string(_SCRIPT)
+    app.run()
+    buttons = app.get("button")
+    if not buttons:
+        queue.put({"columns": None, "has_df": False})
+        return
+    buttons[0].click()
+    app.run()
+    df = opportunities_ctrl.search_opportunities()
+    queue.put({
+        "columns": list(df.columns),
+        "has_df": bool(app.get("arrow_data_frame")),
+    })
+
+
+def _render_app() -> AppTest:
+    _ensure_real_streamlit_module()
+    if not hasattr(st, "secrets"):
+        st.secrets = Secrets({})
+    app = AppTest.from_string(_SCRIPT)
+    app.run()
+    return app
+
+
+def test_header_displays_version() -> None:
+    app = _render_app()
+    headers = [element.value for element in app.get("header")]
+    expected_header = f"🚀 Oportunidades de mercado · versión {__version__}"
+    assert expected_header in headers
+
+
+def test_button_fetches_dataframe_with_spec_columns() -> None:
+    ctx = get_context("spawn")
+    queue = ctx.Queue()
+    proc = ctx.Process(target=_collect_opportunities, args=(queue,))
+    proc.start()
+    proc.join(timeout=15)
+    assert proc.exitcode == 0, "Child process running AppTest did not complete successfully"
+    result = queue.get()
+    columns = result["columns"]
+    assert columns is not None
+    assert list(columns) == OPPORTUNITIES_SPEC.columns
+    assert result["has_df"], "Expected a dataframe element after clicking the button"

--- a/ui/opportunities_tab.py
+++ b/ui/opportunities_tab.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from controllers.opportunities import search_opportunities
+from controllers.opportunities_spec import OPPORTUNITIES_SPEC
+from shared.version import __version__
+
+
+def _format_header() -> str:
+    return f"🚀 Oportunidades de mercado · versión {__version__}"
+
+
+def render_opportunities_tab() -> None:
+    """Render the opportunities exploration tab."""
+
+    st.header(_format_header())
+    st.caption(
+        "Explora ideas de inversión basadas en métricas cuantitativas y volumen de mercado."
+    )
+
+    if st.button("Buscar oportunidades", type="primary"):
+        df = search_opportunities()
+        if df is None or df.empty:
+            st.info("No se encontraron oportunidades disponibles.")
+            return
+
+        missing = [col for col in OPPORTUNITIES_SPEC.columns if col not in df.columns]
+        if missing:
+            st.error(
+                "Faltan columnas esperadas en el resultado: " + ", ".join(missing)
+            )
+            return
+
+        st.dataframe(df[OPPORTUNITIES_SPEC.columns], width="stretch")
+        st.caption(
+            "Los montos y volúmenes se expresan en sus monedas originales."
+        )
+    else:
+        st.caption("Usá el botón para obtener las oportunidades más recientes.")
+
+
+__all__ = ["render_opportunities_tab"]


### PR DESCRIPTION
## Summary
- add a small opportunities controller and column specification
- render a new opportunities tab that fetches the sample data set
- exercise the tab with a Streamlit AppTest to verify the header and data frame columns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d9c0e66564833280894e0d926e4bca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an Opportunities tab that displays a header with the app version and a caption.
  - Introduced a “Buscar oportunidades” button to fetch and display a standardized opportunities table with key fields (e.g., symbol, market, price, volume).
  - Built-in validation ensures required columns are present; informative messages appear for empty or invalid results.

- Tests
  - Added UI tests to verify the header shows the version and that clicking the button returns a table with the expected columns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->