### PR TITLE
Add Yahoo Finance client and screener implementation

### DIFF
--- a/infrastructure/market/__init__.py
+++ b/infrastructure/market/__init__.py
@@ -1,0 +1,5 @@
+"""Market data clients."""
+
+from .yahoo_client import YahooFinanceClient
+
+__all__ = ["YahooFinanceClient"]

--- a/infrastructure/market/yahoo_client.py
+++ b/infrastructure/market/yahoo_client.py
@@ -1,0 +1,155 @@
+"""Yahoo Finance market data client."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict, TypeVar
+
+import pandas as pd
+import requests
+import yfinance as yf
+
+from shared.cache import cached
+from shared.errors import AppError
+from shared.settings import YAHOO_FUNDAMENTALS_TTL, YAHOO_QUOTES_TTL
+
+T = TypeVar("T")
+
+
+def _normalise_symbol(symbol: str) -> str:
+    return str(symbol).strip().upper()
+
+
+def _normalise_percentage(value: Any) -> float | pd.NA:
+    if value is None:
+        return pd.NA
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:  # pragma: no cover - defensive
+        raise AppError("Valor numérico inválido en datos de Yahoo Finance") from exc
+    if pd.isna(number):
+        return pd.NA
+    if -1.0 <= number <= 1.0:
+        number *= 100.0
+    return float(number)
+
+
+class YahooFinanceClient:
+    """Wrapper around :mod:`yfinance` with consistent outputs."""
+
+    def _with_ticker(self, ticker: str, loader: Callable[[yf.Ticker], T]) -> T:
+        session = requests.Session()
+        symbol = _normalise_symbol(ticker)
+        try:
+            yft = yf.Ticker(symbol, session=session)
+            return loader(yft)
+        except AppError:
+            raise
+        except Exception as exc:  # pragma: no cover - network/parsing issues
+            raise AppError(f"Error al obtener datos para {symbol} desde Yahoo Finance") from exc
+        finally:
+            session.close()
+
+    @cached(ttl=YAHOO_FUNDAMENTALS_TTL)
+    def get_fundamentals(self, ticker: str) -> Dict[str, Any]:
+        """Return normalised fundamentals for a symbol."""
+
+        def _load(yft: yf.Ticker) -> Dict[str, Any]:
+            info: Dict[str, Any] = yft.get_info()
+            if not info:
+                raise AppError(f"Yahoo Finance no devolvió fundamentals para {ticker}")
+
+            dividend_yield = _normalise_percentage(info.get("dividendYield"))
+            payout_ratio = _normalise_percentage(info.get("payoutRatio"))
+
+            if dividend_yield is pd.NA or payout_ratio is pd.NA:
+                raise AppError(f"Faltan métricas esenciales de fundamentals para {ticker}")
+
+            result = {
+                "ticker": _normalise_symbol(ticker),
+                "long_name": info.get("longName"),
+                "sector": info.get("sector"),
+                "industry": info.get("industry"),
+                "currency": info.get("financialCurrency"),
+                "market_cap": info.get("marketCap"),
+                "dividend_yield": float(dividend_yield),
+                "payout_ratio": float(payout_ratio),
+            }
+            trailing_eps = info.get("trailingEps")
+            forward_eps = info.get("forwardEps")
+            if trailing_eps is not None:
+                result["trailing_eps"] = float(trailing_eps)
+            if forward_eps is not None:
+                result["forward_eps"] = float(forward_eps)
+            return result
+
+        return self._with_ticker(ticker, _load)
+
+    @cached(ttl=YAHOO_QUOTES_TTL)
+    def get_dividends(self, ticker: str) -> pd.DataFrame:
+        """Return historical dividends as a DataFrame."""
+
+        def _load(yft: yf.Ticker) -> pd.DataFrame:
+            div_series: pd.Series = yft.dividends
+            if div_series is None or div_series.empty:
+                raise AppError(f"Yahoo Finance no tiene dividendos para {ticker}")
+            df = div_series.rename("amount").to_frame().reset_index()
+            df = df.rename(columns={df.columns[0]: "date"})
+            df["date"] = pd.to_datetime(df["date"], utc=True)
+            df["amount"] = df["amount"].astype(float)
+            return df.sort_values("date").reset_index(drop=True)
+
+        return self._with_ticker(ticker, _load)
+
+    @cached(ttl=YAHOO_FUNDAMENTALS_TTL)
+    def get_shares_outstanding(self, ticker: str) -> pd.DataFrame:
+        """Return shares outstanding history."""
+
+        def _load(yft: yf.Ticker) -> pd.DataFrame:
+            shares = yft.get_shares_full(start="1900-01-01")
+            if shares is None:
+                raise AppError(f"Yahoo Finance no devolvió flotantes para {ticker}")
+            if isinstance(shares, pd.Series):
+                df = shares.rename("shares").to_frame()
+            else:
+                df = pd.DataFrame(shares)
+                if "shares" not in df.columns and df.shape[1] == 1:
+                    df.columns = ["shares"]
+            if df.empty:
+                raise AppError(f"Yahoo Finance no devolvió flotantes para {ticker}")
+            df = df.reset_index()
+            df = df.rename(columns={df.columns[0]: "date"})
+            df["date"] = pd.to_datetime(df["date"], utc=True)
+            df["shares"] = df["shares"].astype(float)
+            return df.sort_values("date").reset_index(drop=True)
+
+        return self._with_ticker(ticker, _load)
+
+    @cached(ttl=YAHOO_QUOTES_TTL)
+    def get_price_history(self, ticker: str) -> pd.DataFrame:
+        """Return OHLC history with adjusted close values."""
+
+        def _load(yft: yf.Ticker) -> pd.DataFrame:
+            history = yft.history(period="max", auto_adjust=False)
+            if history is None or history.empty:
+                raise AppError(f"Yahoo Finance no devolvió precios para {ticker}")
+            required = {"Close", "Adj Close", "Volume"}
+            if not required.issubset(history.columns):
+                missing = required.difference(history.columns)
+                raise AppError(
+                    f"Datos de precios incompletos para {ticker}: faltan columnas {sorted(missing)}"
+                )
+            df = history.reset_index()
+            rename_map = {"Date": "date", "Close": "close", "Adj Close": "adj_close", "Volume": "volume"}
+            if "index" in df.columns and "Date" not in df.columns:
+                rename_map["index"] = "date"
+            df = df.rename(columns=rename_map)
+            df["date"] = pd.to_datetime(df["date"], utc=True)
+            df["close"] = df["close"].astype(float)
+            df["adj_close"] = df["adj_close"].astype(float)
+            df["volume"] = df["volume"].astype(float)
+            return df.sort_values("date").reset_index(drop=True)
+
+        return self._with_ticker(ticker, _load)
+
+
+__all__ = ["YahooFinanceClient"]

--- a/shared/cache.py
+++ b/shared/cache.py
@@ -170,4 +170,32 @@ class Cache:
 # Global cache instance used across the application
 cache = Cache()
 
-__all__ = ["Cache", "cache"]
+
+def cached(func: Callable | None = None, *, ttl: int | None = None, maxsize: int | None = None) -> Callable:
+    """Convenience decorator wrapping :meth:`Cache.cache_data`.
+
+    Parameters
+    ----------
+    func:
+        Optional function being decorated when ``@cached`` is used without
+        arguments.
+    ttl:
+        Time-to-live for cached entries in seconds. ``None`` disables
+        expiration.
+    maxsize:
+        Maximum number of cached entries allowed. ``None`` keeps the cache
+        unbounded.
+    """
+
+    def _decorate(inner: Callable) -> Callable:
+        wrapped = cache.cache_data(ttl=ttl, maxsize=maxsize)(inner)
+        setattr(wrapped, "cache_ttl", ttl)
+        setattr(wrapped, "cache_maxsize", maxsize)
+        return wrapped
+
+    if func is not None and callable(func):
+        return _decorate(func)
+    return _decorate
+
+
+__all__ = ["Cache", "cache", "cached"]

--- a/shared/config.py
+++ b/shared/config.py
@@ -57,6 +57,12 @@ class Settings:
         self.cache_ttl_quotes: int = int(os.getenv("CACHE_TTL_QUOTES", cfg.get("CACHE_TTL_QUOTES", 8)))
         self.quotes_hist_maxlen: int = int(os.getenv("QUOTES_HIST_MAXLEN", cfg.get("QUOTES_HIST_MAXLEN", 500)))
         self.max_quote_workers: int = int(os.getenv("MAX_QUOTE_WORKERS", cfg.get("MAX_QUOTE_WORKERS", 12)))
+        self.YAHOO_FUNDAMENTALS_TTL: int = int(
+            os.getenv("YAHOO_FUNDAMENTALS_TTL", cfg.get("YAHOO_FUNDAMENTALS_TTL", 3600))
+        )
+        self.YAHOO_QUOTES_TTL: int = int(
+            os.getenv("YAHOO_QUOTES_TTL", cfg.get("YAHOO_QUOTES_TTL", 900))
+        )
 
         flag_value = os.getenv(
             "FEATURE_OPPORTUNITIES_TAB",

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -19,6 +19,8 @@ cache_ttl_fx: int = settings.cache_ttl_fx
 cache_ttl_quotes: int = settings.cache_ttl_quotes
 quotes_hist_maxlen: int = settings.quotes_hist_maxlen
 max_quote_workers: int = settings.max_quote_workers
+YAHOO_FUNDAMENTALS_TTL: int = settings.YAHOO_FUNDAMENTALS_TTL
+YAHOO_QUOTES_TTL: int = settings.YAHOO_QUOTES_TTL
 
 # Feature flags
 FEATURE_OPPORTUNITIES_TAB: bool = bool(
@@ -33,5 +35,7 @@ __all__ = [
     "cache_ttl_quotes",
     "quotes_hist_maxlen",
     "max_quote_workers",
+    "YAHOO_FUNDAMENTALS_TTL",
+    "YAHOO_QUOTES_TTL",
     "FEATURE_OPPORTUNITIES_TAB",
 ]

--- a/tests/application/test_screener_yahoo.py
+++ b/tests/application/test_screener_yahoo.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import numpy as np
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from application.screener import opportunities as ops
+from shared.errors import AppError
+
+
+class FakeYahooClient:
+    def __init__(self, data: dict[str, dict[str, object]]) -> None:
+        self._data = data
+
+    def get_fundamentals(self, ticker: str) -> dict[str, object]:
+        return self._data[ticker]["fundamentals"]
+
+    def get_dividends(self, ticker: str) -> pd.DataFrame:
+        return self._data[ticker]["dividends"]
+
+    def get_shares_outstanding(self, ticker: str) -> pd.DataFrame:
+        return self._data[ticker]["shares"]
+
+    def get_price_history(self, ticker: str) -> pd.DataFrame:
+        return self._data[ticker]["prices"]
+
+
+class MissingYahooClient:
+    def get_fundamentals(self, ticker: str) -> dict[str, object]:  # noqa: ARG002
+        raise AppError("missing fundamentals")
+
+    def get_dividends(self, ticker: str) -> pd.DataFrame:  # noqa: ARG002
+        raise AppError("missing dividends")
+
+    def get_shares_outstanding(self, ticker: str) -> pd.DataFrame:  # noqa: ARG002
+        raise AppError("missing shares")
+
+    def get_price_history(self, ticker: str) -> pd.DataFrame:  # noqa: ARG002
+        raise AppError("missing prices")
+
+
+@pytest.fixture
+def comprehensive_data() -> dict[str, dict[str, object]]:
+    dates = pd.date_range("2015-01-01", periods=8 * 365, freq="D", tz="UTC")
+    growth = 1.08 ** (np.arange(len(dates)) / 365)
+    close = 100 * growth
+    prices = pd.DataFrame(
+        {
+            "date": dates,
+            "close": close,
+            "adj_close": close,
+            "volume": np.linspace(1000, 2000, len(dates)),
+        }
+    )
+
+    dividend_dates = pd.to_datetime(
+        [
+            "2018-03-01",
+            "2019-03-01",
+            "2020-03-01",
+            "2021-03-01",
+            "2022-03-01",
+            "2023-03-01",
+        ],
+        utc=True,
+    )
+    dividends = pd.DataFrame({"date": dividend_dates, "amount": [1.0, 1.1, 1.2, 1.3, 1.4, 1.5]})
+
+    shares_dates = pd.to_datetime(
+        ["2018-01-01", "2019-01-01", "2020-01-01", "2021-01-01", "2022-01-01", "2023-01-01"],
+        utc=True,
+    )
+    shares = pd.DataFrame(
+        {
+            "date": shares_dates,
+            "shares": [1_000_000, 990_000, 980_000, 970_000, 960_000, 950_000],
+        }
+    )
+
+    fundamentals = {
+        "ticker": "ABC",
+        "dividend_yield": 2.0,
+        "payout_ratio": 40.0,
+    }
+
+    return {
+        "ABC": {
+            "fundamentals": fundamentals,
+            "dividends": dividends,
+            "shares": shares,
+            "prices": prices,
+        }
+    }
+
+
+def test_run_screener_yahoo_computes_metrics(comprehensive_data):
+    client = FakeYahooClient(comprehensive_data)
+    df = ops.run_screener_yahoo(
+        manual_tickers=["abc"], client=client, include_technicals=True
+    )
+
+    assert df.shape[0] == 1
+    row = df.iloc[0]
+
+    prices = comprehensive_data["ABC"]["prices"]
+    dividends = comprehensive_data["ABC"]["dividends"]
+    shares = comprehensive_data["ABC"]["shares"]
+
+    expected_cagrs = [
+        ops._compute_cagr(prices, years) for years in (3, 5)
+    ]
+    expected_cagrs = [val for val in expected_cagrs if ops._is_valid_number(val)]
+    expected_cagr = ops._safe_round(sum(expected_cagrs) / len(expected_cagrs))
+
+    assert row["ticker"] == "ABC"
+    assert row["payout_ratio"] == 40.0
+    assert row["dividend_yield"] == 2.0
+    assert row["dividend_streak"] == ops._compute_dividend_streak(dividends)
+    assert row["cagr"] == expected_cagr
+    assert row["rsi"] == ops._safe_round(ops._compute_rsi(prices))
+    assert row["sma_50"] == ops._safe_round(ops._compute_sma(prices, 50))
+    assert row["sma_200"] == ops._safe_round(ops._compute_sma(prices, 200))
+
+    _, macd_hist = ops._compute_macd(prices)
+    macd_hist = ops._safe_round(macd_hist, digits=4) if ops._is_valid_number(macd_hist) else pd.NA
+
+    metrics = {
+        "payout_ratio": row["payout_ratio"],
+        "dividend_streak": row["dividend_streak"],
+        "cagr": row["cagr"],
+        "buyback": ops._safe_round(ops._compute_buyback_ratio(shares)),
+        "rsi": row["rsi"],
+        "macd_hist": macd_hist,
+    }
+    assert row["score_compuesto"] == ops._compute_score(metrics)
+
+
+def test_run_screener_yahoo_marks_missing(caplog):
+    client = MissingYahooClient()
+    df = ops.run_screener_yahoo(manual_tickers=["zzz"], client=client, include_technicals=True)
+
+    assert df.iloc[0]["ticker"] == "ZZZ"
+    assert df.iloc[0]["score_compuesto"] is pd.NA
+    assert any("faltan datos" in record.getMessage().lower() for record in caplog.records)
+
+
+def test_run_screener_yahoo_filters_and_optional_columns(comprehensive_data):
+    other_prices = comprehensive_data["ABC"]["prices"].copy()
+    fundamentals_bad = {"ticker": "BAD", "dividend_yield": 1.0, "payout_ratio": 90.0}
+
+    dividends_bad = pd.DataFrame(
+        {
+            "date": pd.to_datetime(["2018-01-01", "2019-01-01"], utc=True),
+            "amount": [1.0, 0.9],
+        }
+    )
+    shares_bad = comprehensive_data["ABC"]["shares"].copy()
+
+    data = {
+        "ABC": comprehensive_data["ABC"],
+        "BAD": {
+            "fundamentals": fundamentals_bad,
+            "dividends": dividends_bad,
+            "shares": shares_bad,
+            "prices": other_prices,
+        },
+    }
+    client = FakeYahooClient(data)
+
+    df = ops.run_screener_yahoo(
+        manual_tickers=["ABC", "BAD"],
+        client=client,
+        max_payout=50,
+        min_div_streak=3,
+        min_cagr=5,
+        include_technicals=False,
+    )
+
+    assert list(df.columns) == [
+        "ticker",
+        "payout_ratio",
+        "dividend_streak",
+        "cagr",
+        "dividend_yield",
+        "price",
+        "score_compuesto",
+    ]
+    assert df.iloc[0]["ticker"] == "ABC"
+    assert pd.isna(df.iloc[1]["payout_ratio"])

--- a/tests/infrastructure/test_yahoo_client.py
+++ b/tests/infrastructure/test_yahoo_client.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[2]))
+
+from infrastructure.market.yahoo_client import YahooFinanceClient
+from shared.errors import AppError
+from shared.settings import YAHOO_FUNDAMENTALS_TTL, YAHOO_QUOTES_TTL
+
+
+class SessionFactory:
+    def __init__(self) -> None:
+        self.sessions: list[FakeSession] = []
+
+    def __call__(self) -> "FakeSession":
+        session = FakeSession()
+        self.sessions.append(session)
+        return session
+
+
+class FakeSession:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class FakeTicker:
+    def __init__(self, *, info=None, dividends=None, shares=None, history=None) -> None:
+        self._info = info or {}
+        self.dividends = dividends
+        self._shares = shares
+        self._history = history
+
+    def get_info(self):
+        return self._info
+
+    def get_shares_full(self, start=None):  # noqa: ARG002
+        return self._shares
+
+    def history(self, **kwargs):  # noqa: ARG002
+        return self._history
+
+
+@pytest.fixture(autouse=True)
+def clear_client_cache():
+    yield
+    YahooFinanceClient.get_fundamentals.clear()
+    YahooFinanceClient.get_dividends.clear()
+    YahooFinanceClient.get_shares_outstanding.clear()
+    YahooFinanceClient.get_price_history.clear()
+
+
+@pytest.fixture
+def setup_fake_environment(monkeypatch):
+    from infrastructure.market import yahoo_client as module
+
+    session_factory = SessionFactory()
+    monkeypatch.setattr(module.requests, "Session", session_factory)
+
+    def factory(*, info=None, dividends=None, shares=None, history=None):
+        ticker = FakeTicker(info=info, dividends=dividends, shares=shares, history=history)
+        monkeypatch.setattr(module.yf, "Ticker", lambda symbol, session=None: ticker)
+        return ticker, session_factory
+
+    return factory
+
+
+def test_get_fundamentals_normalises_output(setup_fake_environment):
+    info = {
+        "dividendYield": 0.025,
+        "payoutRatio": 0.42,
+        "longName": "Test Corp",
+        "sector": "Technology",
+        "industry": "Software",
+        "financialCurrency": "USD",
+        "marketCap": 123456,
+        "trailingEps": 5.5,
+    }
+    _, session_factory = setup_fake_environment(info=info)
+
+    client = YahooFinanceClient()
+    fundamentals = client.get_fundamentals("tst")
+
+    assert fundamentals["ticker"] == "TST"
+    assert fundamentals["dividend_yield"] == pytest.approx(2.5)
+    assert fundamentals["payout_ratio"] == pytest.approx(42.0)
+    assert fundamentals["market_cap"] == 123456
+    assert all(session.closed for session in session_factory.sessions)
+    assert YahooFinanceClient.get_fundamentals.cache_ttl == YAHOO_FUNDAMENTALS_TTL
+
+
+def test_get_dividends_returns_dataframe(setup_fake_environment):
+    dates = pd.to_datetime(["2020-01-01", "2021-01-01"])
+    series = pd.Series([0.5, 0.55], index=dates)
+    _, session_factory = setup_fake_environment(dividends=series)
+
+    client = YahooFinanceClient()
+    df = client.get_dividends("abc")
+
+    assert list(df.columns) == ["date", "amount"]
+    assert df["amount"].tolist() == [0.5, 0.55]
+    assert df["date"].dt.tz is not None
+    assert all(session.closed for session in session_factory.sessions)
+    assert YahooFinanceClient.get_dividends.cache_ttl == YAHOO_QUOTES_TTL
+
+
+def test_get_shares_outstanding_parses_series(setup_fake_environment):
+    dates = pd.to_datetime(["2020-01-01", "2022-01-01"])
+    series = pd.Series([1_000_000, 950_000], index=dates)
+    _, session_factory = setup_fake_environment(shares=series)
+
+    client = YahooFinanceClient()
+    df = client.get_shares_outstanding("def")
+
+    assert list(df.columns) == ["date", "shares"]
+    assert df["shares"].tolist() == [1_000_000.0, 950_000.0]
+    assert df["date"].dt.tz is not None
+    assert all(session.closed for session in session_factory.sessions)
+
+
+def test_get_price_history_validates_columns(setup_fake_environment):
+    dates = pd.to_datetime(["2023-01-01", "2023-01-02"])
+    history = pd.DataFrame(
+        {
+            "Close": [10.0, 11.0],
+            "Adj Close": [9.5, 10.5],
+            "Volume": [1000, 1100],
+        },
+        index=dates,
+    )
+    history.index.name = "Date"
+    _, session_factory = setup_fake_environment(history=history)
+
+    client = YahooFinanceClient()
+    df = client.get_price_history("ghi")
+
+    assert list(df.columns) == ["date", "close", "adj_close", "volume"]
+    assert df["close"].tolist() == [10.0, 11.0]
+    assert all(session.closed for session in session_factory.sessions)
+
+
+def test_missing_dividends_raise_app_error(setup_fake_environment):
+    _, _ = setup_fake_environment(dividends=pd.Series(dtype=float))
+    client = YahooFinanceClient()
+
+    with pytest.raises(AppError):
+        client.get_dividends("xyz")


### PR DESCRIPTION
## Summary
- add a Yahoo Finance market client with caching, normalization and error handling
- implement a Yahoo-backed opportunities screener that computes valuation and technical metrics
- cover the new client and screener with dedicated unit tests

## Testing
- pytest tests/infrastructure/test_yahoo_client.py tests/application/test_screener_yahoo.py

------
https://chatgpt.com/codex/tasks/task_e_68d9cfc0b4d88332b80c28a6304becba

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced a Yahoo Finance–powered stock screener that computes key fundamentals and technicals (e.g., dividend yield/streak, CAGR, RSI, SMA, MACD) and outputs a composite score.
  - Added optional filters (payout ratio, dividend streak, CAGR) and the ability to include/exclude technical indicators.
  - Integrated a market data client for fundamentals, dividends, shares outstanding, and price history.
  - Implemented caching with configurable TTLs to improve performance.

- Tests
  - Added comprehensive unit tests for the screener and market data client, covering data normalization, metric calculations, filtering, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->