### PR TITLE
Integrate Yahoo screener with fallback and UI updates

### DIFF
--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -1,5 +1,5 @@
 """Controller package exports."""
 
-from .opportunities import run_opportunities_controller
+from .opportunities import generate_opportunities_report, run_opportunities_controller
 
-__all__ = ["run_opportunities_controller"]
+__all__ = ["run_opportunities_controller", "generate_opportunities_report"]

--- a/controllers/opportunities.py
+++ b/controllers/opportunities.py
@@ -1,12 +1,20 @@
 """Controller helpers for the opportunities screener."""
 from __future__ import annotations
 
+import logging
 import re
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import pandas as pd
 
 from application.screener.opportunities import run_screener_stub
+
+try:  # The Yahoo implementation may not be available in all environments.
+    from application.screener.opportunities import run_screener_yahoo
+except ImportError:  # pragma: no cover - fallback handled at runtime
+    run_screener_yahoo = None  # type: ignore[assignment]
+
+from shared.errors import AppError
 
 _EXPECTED_COLUMNS: Sequence[str] = (
     "ticker",
@@ -70,21 +78,66 @@ def run_opportunities_controller(
     min_div_streak: Optional[int] = None,
     min_cagr: Optional[float] = None,
     include_technicals: bool = False,
+    min_market_cap: Optional[float] = None,
+    max_pe: Optional[float] = None,
+    min_revenue_growth: Optional[float] = None,
+    include_latam: Optional[bool] = None,
 ) -> Tuple[pd.DataFrame, List[str]]:
     """Run the opportunities screener and return the results and notes."""
 
     tickers = _clean_manual_tickers(manual_tickers)
-    df = run_screener_stub(
-        manual_tickers=tickers,
-        max_payout=max_payout,
-        min_div_streak=min_div_streak,
-        min_cagr=min_cagr,
-        include_technicals=include_technicals,
-    )
 
-    df = _ensure_columns(df, include_technicals)
+    yahoo_kwargs: dict[str, Any] = {
+        "manual_tickers": tickers or None,
+        "include_technicals": include_technicals,
+    }
+    if min_market_cap is not None:
+        yahoo_kwargs["min_market_cap"] = float(min_market_cap)
+    if max_pe is not None:
+        yahoo_kwargs["max_pe"] = float(max_pe)
+    if min_revenue_growth is not None:
+        yahoo_kwargs["min_revenue_growth"] = float(min_revenue_growth)
+    if include_latam is not None:
+        yahoo_kwargs["include_latam"] = bool(include_latam)
 
     notes: List[str] = []
+    fallback_used = False
+
+    extra_notes: List[str] = []
+
+    if callable(run_screener_yahoo):
+        try:
+            raw_result = run_screener_yahoo(**yahoo_kwargs)
+        except AppError as exc:  # pragma: no cover - protective branch
+            logging.getLogger(__name__).warning(
+                "Yahoo screener failed with AppError: %s", exc
+            )
+            fallback_used = True
+        except Exception as exc:  # pragma: no cover - unexpected failure
+            logging.getLogger(__name__).exception(
+                "Unexpected error from Yahoo screener"
+            )
+            fallback_used = True
+        else:
+            df, extra_notes = _normalize_yahoo_response(
+                raw_result, include_technicals
+            )
+    else:
+        fallback_used = True
+
+    if fallback_used:
+        df = run_screener_stub(
+            manual_tickers=tickers,
+            max_payout=max_payout,
+            min_div_streak=min_div_streak,
+            min_cagr=min_cagr,
+            include_technicals=include_technicals,
+        )
+        notes.append("⚠️ Datos simulados (Yahoo no disponible)")
+        df = _ensure_columns(df, include_technicals)
+    else:
+        notes.extend(extra_notes)
+
     if tickers:
         missing = []
         for ticker in tickers:
@@ -103,4 +156,121 @@ def run_opportunities_controller(
     return df, notes
 
 
-__all__ = ["run_opportunities_controller"]
+def _normalize_yahoo_response(
+    result: object, include_technicals: bool
+) -> Tuple[pd.DataFrame, List[str]]:
+    """Convert different Yahoo screener payloads into a DataFrame and notes."""
+
+    notes: List[str] = []
+
+    if isinstance(result, tuple) and len(result) == 2:
+        table, raw_notes = result
+        df, nested_notes = _normalize_yahoo_response(table, include_technicals)
+        notes.extend(nested_notes)
+        notes.extend(_normalize_notes(raw_notes))
+        return df, notes
+
+    if isinstance(result, Mapping):
+        table = None
+        for key in ("table", "data", "df"):
+            if key in result:
+                table = result[key]
+                break
+        if table is not None:
+            df, nested_notes = _normalize_yahoo_response(table, include_technicals)
+            notes.extend(nested_notes)
+        else:
+            df = pd.DataFrame()
+        for key in ("notes", "messages", "warnings"):
+            value = result.get(key)
+            if value:
+                notes.extend(_normalize_notes(value))
+        return _ensure_columns(df, include_technicals), notes
+
+    if isinstance(result, pd.DataFrame):
+        return _ensure_columns(result, include_technicals), notes
+
+    try:
+        df = pd.DataFrame(result)
+    except Exception:  # pragma: no cover - defensive guard
+        df = pd.DataFrame()
+    return _ensure_columns(df, include_technicals), notes
+
+
+def _normalize_notes(value: object) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, Mapping):
+        notes: List[str] = []
+        for item in value.values():
+            notes.extend(_normalize_notes(item))
+        return notes
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray)):
+        notes: List[str] = []
+        for item in value:
+            notes.extend(_normalize_notes(item))
+        return notes
+    return [str(value)]
+
+
+def _as_optional_float(value: Any) -> Optional[float]:
+    if value is None or value == "":
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_optional_int(value: Any) -> Optional[int]:
+    if value is None or value == "":
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _as_optional_bool(value: Any) -> Optional[bool]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "y", "t"}:
+            return True
+        if lowered in {"false", "0", "no", "n", "f"}:
+            return False
+    return None
+
+
+def generate_opportunities_report(
+    filters: Optional[Mapping[str, Any]] = None,
+) -> Mapping[str, object]:
+    """Entry point used by the UI to produce the opportunities report."""
+
+    filters = filters or {}
+    manual = filters.get("manual_tickers") or filters.get("tickers")
+    include_technicals = bool(filters.get("include_technicals", False))
+
+    df, notes = run_opportunities_controller(
+        manual_tickers=manual,
+        max_payout=_as_optional_float(filters.get("max_payout")),
+        min_div_streak=_as_optional_int(filters.get("min_div_streak")),
+        min_cagr=_as_optional_float(filters.get("min_cagr")),
+        include_technicals=include_technicals,
+        min_market_cap=_as_optional_float(filters.get("min_market_cap")),
+        max_pe=_as_optional_float(filters.get("max_pe")),
+        min_revenue_growth=_as_optional_float(filters.get("min_revenue_growth")),
+        include_latam=_as_optional_bool(filters.get("include_latam")),
+    )
+
+    return {"table": df, "notes": notes}
+
+
+__all__ = ["run_opportunities_controller", "generate_opportunities_report"]

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -1,19 +1,20 @@
 from __future__ import annotations
 
-from multiprocessing import get_context
 from pathlib import Path
 from types import ModuleType
 import sys
 import textwrap
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import streamlit as _streamlit_module
-from streamlit.testing.v1 import AppTest
 from streamlit.runtime.secrets import Secrets
+from streamlit.testing.v1 import AppTest
 
 _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
+
 
 def _resolve_streamlit_module() -> ModuleType:
     """Ensure we use the real Streamlit implementation, not a test stub."""
@@ -31,14 +32,7 @@ def _resolve_streamlit_module() -> ModuleType:
     return real_streamlit
 
 
-st = _resolve_streamlit_module()
-sys.modules["streamlit"] = st
-
-
-_ORIGINAL_STREAMLIT = st
-
-
-def _ensure_real_streamlit_module() -> None:
+def _normalize_streamlit_module() -> None:
     global st
     if sys.modules.get("streamlit") is not _ORIGINAL_STREAMLIT:
         sys.modules["streamlit"] = _ORIGINAL_STREAMLIT
@@ -49,41 +43,8 @@ def _ensure_real_streamlit_module() -> None:
         setattr(ui_settings_mod, "st", _ORIGINAL_STREAMLIT)
 
 
-from controllers import opportunities as opportunities_ctrl
-from controllers.opportunities_spec import OPPORTUNITIES_SPEC
-from shared.version import __version__
-
-_SCRIPT = textwrap.dedent(
-    f"""
-    import sys
-    sys.path.insert(0, {repr(str(_PROJECT_ROOT))})
-    from ui.opportunities_tab import render_opportunities_tab
-    render_opportunities_tab()
-    """
-)
-
-
-def _collect_opportunities(queue: "Queue") -> None:
-    _ensure_real_streamlit_module()
-    if not hasattr(st, "secrets"):
-        st.secrets = Secrets({})
-    app = AppTest.from_string(_SCRIPT)
-    app.run()
-    buttons = app.get("button")
-    if not buttons:
-        queue.put({"columns": None, "has_df": False})
-        return
-    buttons[0].click()
-    app.run()
-    df = opportunities_ctrl.search_opportunities()
-    queue.put({
-        "columns": list(df.columns),
-        "has_df": bool(app.get("arrow_data_frame")),
-    })
-
-
 def _render_app() -> AppTest:
-    _ensure_real_streamlit_module()
+    _normalize_streamlit_module()
     if not hasattr(st, "secrets"):
         st.secrets = Secrets({})
     app = AppTest.from_string(_SCRIPT)
@@ -91,22 +52,79 @@ def _render_app() -> AppTest:
     return app
 
 
+def _run_app_with_result(result: dict[str, object]) -> tuple[AppTest, MagicMock]:
+    _normalize_streamlit_module()
+    if not hasattr(st, "secrets"):
+        st.secrets = Secrets({})
+    app = AppTest.from_string(_SCRIPT)
+    patch_target = "controllers.opportunities.generate_opportunities_report"
+    with patch(patch_target, return_value=result) as mock:
+        app.run()
+        buttons = app.get("button")
+        assert buttons, "Expected the action button to be rendered"
+        buttons[0].click()
+        app.run()
+    return app, mock
+
+
+st = _resolve_streamlit_module()
+sys.modules["streamlit"] = st
+_ORIGINAL_STREAMLIT = st
+
+from shared.version import __version__
+
+_SCRIPT = textwrap.dedent(
+    f"""
+    import sys
+    sys.path.insert(0, {repr(str(_PROJECT_ROOT))})
+    from ui.tabs.opportunities import render_opportunities_tab
+    render_opportunities_tab()
+    """
+)
+
+
 def test_header_displays_version() -> None:
     app = _render_app()
     headers = [element.value for element in app.get("header")]
-    expected_header = f"🚀 Oportunidades de mercado · versión {__version__}"
+    expected_header = f"🚀 Empresas con oportunidad · beta {__version__}"
     assert expected_header in headers
 
 
-def test_button_fetches_dataframe_with_spec_columns() -> None:
-    ctx = get_context("spawn")
-    queue = ctx.Queue()
-    proc = ctx.Process(target=_collect_opportunities, args=(queue,))
-    proc.start()
-    proc.join(timeout=15)
-    assert proc.exitcode == 0, "Child process running AppTest did not complete successfully"
-    result = queue.get()
-    columns = result["columns"]
-    assert columns is not None
-    assert list(columns) == OPPORTUNITIES_SPEC.columns
-    assert result["has_df"], "Expected a dataframe element after clicking the button"
+def test_button_executes_controller_and_shows_yahoo_note() -> None:
+    df = pd.DataFrame(
+        {
+            "ticker": ["AAPL", "MSFT"],
+            "price": [180.12, 325.74],
+            "score_compuesto": [8.5, 7.9],
+        }
+    )
+    app, mock = _run_app_with_result({"table": df, "notes": []})
+    assert mock.call_count == 1
+    called_with = mock.call_args.args[0]
+    assert called_with == {
+        "min_market_cap": 500.0,
+        "max_pe": 25.0,
+        "min_revenue_growth": 5.0,
+        "include_latam": True,
+    }
+    dataframes = app.get("arrow_data_frame")
+    assert dataframes, "Expected Streamlit dataframe component after execution"
+    captions = [element.value for element in app.get("caption")]
+    assert (
+        "Resultados obtenidos de Yahoo Finance (con fallback a datos simulados si falta información)."
+        in captions
+    )
+
+
+def test_fallback_note_is_displayed_when_present() -> None:
+    df = pd.DataFrame(
+        {
+            "ticker": ["KO"],
+            "price": [58.31],
+            "score_compuesto": [6.1],
+        }
+    )
+    fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
+    app, _ = _run_app_with_result({"table": df, "notes": [fallback_note]})
+    markdown_blocks = [element.value for element in app.get("markdown")]
+    assert any(fallback_note in block for block in markdown_blocks)

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -39,8 +39,16 @@ def _normalize_table(table: object) -> pd.DataFrame | None:
 
 def _extract_result(result: object) -> tuple[pd.DataFrame | None, list[str]]:
     if isinstance(result, Mapping):
-        table = result.get("table") or result.get("data") or result.get("df")
-        notes = result.get("notes") or result.get("messages") or result.get("warnings")
+        table = None
+        for key in ("table", "data", "df"):
+            if key in result and result[key] is not None:
+                table = result[key]
+                break
+        notes = None
+        for key in ("notes", "messages", "warnings"):
+            if key in result and result[key]:
+                notes = result[key]
+                break
         return _normalize_table(table), _normalize_notes(notes)
     if isinstance(result, Sequence) and len(result) == 2:
         table, notes = result  # type: ignore[assignment]
@@ -132,6 +140,10 @@ def render_opportunities_tab() -> None:
         else:
             st.subheader("Resultados del screening")
             st.dataframe(table, use_container_width=True)
+
+        st.caption(
+            "Resultados obtenidos de Yahoo Finance (con fallback a datos simulados si falta información)."
+        )
 
         if notes:
             st.markdown("### Notas")


### PR DESCRIPTION
## Summary
- call the Yahoo Finance screener when available while falling back to the stub dataset and preserving column normalization
- expose a controller entrypoint that returns structured tables/notes for the tab and surface the new data source caption in the UI
- refresh the opportunities tab tests to exercise the Yahoo flow parameters and the simulated data warning

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68d9cfc0cce88332aa1606c5a97c8602