### PR TITLE
Refactor screener filtering into shared helper

### DIFF
--- a/tests/application/test_screener_stub.py
+++ b/tests/application/test_screener_stub.py
@@ -28,12 +28,14 @@ def test_filters_apply_to_base_dataset() -> None:
     assert (df["pe_ratio"] <= 35.0).all()
     assert (df["revenue_growth"] >= 5.0).all()
     assert not df.get("is_latam", pd.Series(dtype=bool)).any()
+    assert {"rsi", "sma_50", "sma_200"}.isdisjoint(df.columns)
 
 
 def test_include_latam_flag_keeps_companies_when_enabled() -> None:
-    df = run_screener_stub(include_latam=True)
+    df = run_screener_stub(include_latam=True, include_technicals=True)
     assert "MELI" in _tickers(df)
     assert bool(df.loc[df["ticker"] == "MELI", "is_latam"].iloc[0])
+    assert {"rsi", "sma_50", "sma_200"}.issubset(df.columns)
 
 
 def test_manual_tickers_return_placeholder_after_filters() -> None:

--- a/tests/application/test_screener_yahoo.py
+++ b/tests/application/test_screener_yahoo.py
@@ -110,6 +110,7 @@ def test_run_screener_yahoo_computes_metrics(comprehensive_data):
     )
 
     assert df.shape[0] == 1
+    assert {"rsi", "sma_50", "sma_200"}.issubset(df.columns)
     row = df.iloc[0]
 
     prices = comprehensive_data["ABC"]["prices"]
@@ -203,6 +204,7 @@ def test_run_screener_yahoo_filters_and_optional_columns(comprehensive_data):
         "price",
         "score_compuesto",
     ]
+    assert not any(col.startswith("_meta") for col in df.columns)
     assert df.iloc[0]["ticker"] == "ABC"
     assert pd.isna(df.iloc[1]["payout_ratio"])
 


### PR DESCRIPTION
## Summary
- extract a shared `_apply_filters_and_finalize` helper for the screener workflows
- update the stub and Yahoo screener implementations to reuse the helper while preserving outputs
- expand the screener tests to assert technical column handling and meta column removal

## Testing
- pytest tests/application/test_screener_stub.py tests/application/test_screener_yahoo.py

------
https://chatgpt.com/codex/tasks/task_e_68d9eb6e28848332afc7023e4bbfe836