### PR TITLE
Release 0.3.9: align screener filters and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.9] - 2025-09-29
+### Changed
+- Los filtros de payout ratio, racha de dividendos y CAGR mínima ahora se aplican
+  también en el screener de Yahoo para mantener una experiencia consistente con
+  el stub local.
+- Refactorización de `_apply_filters_and_finalize` para compartir la lógica de
+  filtrado entre la integración de Yahoo Finance y el stub de respaldo.
+### Tests
+- Refuerzo de pruebas que cubren el filtrado compartido y la alineación de
+  resultados entre ambas fuentes de datos.
+
 ## [0.3.8] - 2025-09-29
 ### Added
 - Integración con Yahoo Finance para descargar históricos, indicadores técnicos y

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Desde Streamlit 1.30 se reemplazó el parámetro `use_container_width` y se real
 
 ### Empresas con oportunidad (beta)
 
-Esta pestaña experimental destaca emisores que cumplen criterios combinados de liquidez mínima, spread ajustado y momentum de precio positivo observados en las últimas ruedas. El listado actual se genera a partir de un dataset simulado que replica patrones de mercado para validar la experiencia de usuario sin requerir aún el acceso a fuentes productivas. Los próximos pasos incluyen conectar con el servicio oficial de oportunidades, incorporar métricas en tiempo real y documentar el flujo de aprobación para publicar el módulo en la instancia principal.
+Esta pestaña experimental destaca emisores que cumplen criterios combinados de liquidez mínima, spread ajustado y momentum de precio positivo observados en las últimas ruedas. Además admite filtros avanzados como payout ratio máximo, racha mínima de dividendos y CAGR mínima para afinar la búsqueda. El listado actual se genera a partir de un dataset simulado que replica patrones de mercado mientras se evalúa la integración productiva; la lógica de filtrado es la misma tanto para los datos de Yahoo Finance como para el stub de respaldo, garantizando resultados consistentes durante los failovers. Los próximos pasos incluyen conectar con el servicio oficial de oportunidades, incorporar métricas en tiempo real y documentar el flujo de aprobación para publicar el módulo en la instancia principal.
 
 ## Integración con Yahoo Finance
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.8"
+version = "0.3.9"

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import tomllib
 
 
-DEFAULT_VERSION = "0.3.8"
+DEFAULT_VERSION = "0.3.9"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- document the 0.3.9 release covering shared payout/streak/CAGR filters and related tests
- clarify the opportunity screener docs with the new filters and consistent Yahoo/stub logic
- bump the packaged version to 0.3.9 while keeping the shared reader aligned

## Testing
- not run (documentation and version update only)

------
https://chatgpt.com/codex/tasks/task_e_68d9ef3ec8c88332b7c0d0c8d1d7f60e