### PR TITLE
Bump project version to 0.3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.9"
+version = "0.3.10"

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import tomllib
 
 
-DEFAULT_VERSION = "0.3.9"
+DEFAULT_VERSION = "0.3.10"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version number to 0.3.10 in pyproject metadata
- align the shared version default with the new release number

## Testing
- pytest *(fails: missing shared.settings attributes required by application.ta_service imports)*

------
https://chatgpt.com/codex/tasks/task_e_68d9f3b37e8c83328b97f1deb0acd1e0