### PR TITLE
Add key to opportunities search button

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -60,8 +60,12 @@ def _run_app_with_result(result: dict[str, object]) -> tuple[AppTest, MagicMock]
     patch_target = "controllers.opportunities.generate_opportunities_report"
     with patch(patch_target, return_value=result) as mock:
         app.run()
-        buttons = app.get("button")
-        assert buttons, "Expected the action button to be rendered"
+        buttons = [
+            button for button in app.get("button") if getattr(button, "key", None) == "search_opportunities"
+        ]
+        assert (
+            buttons
+        ), "Expected the search button with key 'search_opportunities' to be rendered"
         buttons[0].click()
         app.run()
     return app, mock

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -112,7 +112,12 @@ def render_opportunities_tab() -> None:
         "el análisis en modo beta."
     )
 
-    if st.button("Buscar oportunidades", type="primary", use_container_width=True):
+    if st.button(
+        "Buscar oportunidades",
+        key="search_opportunities",
+        type="primary",
+        use_container_width=True,
+    ):
         try:
             from controllers.opportunities import generate_opportunities_report
         except ImportError as err:  # pragma: no cover - fallback when controller missing


### PR DESCRIPTION
## Summary
- add a stable key to the opportunities search button so Streamlit tests can target it reliably
- update the opportunities tab tests to locate the button by key and assert it exists before clicking

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68d9fa0862ec8332bbdd18dae42bd5cc