### PR TITLE
Ensure fallback note is hidden when no notes are returned

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -118,6 +118,9 @@ def test_button_executes_controller_and_shows_yahoo_note() -> None:
         "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento e inclusión de Latam requieren datos en vivo de Yahoo."
         in captions
     )
+    fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
+    markdown_blocks = [element.value for element in app.get("markdown")]
+    assert not any(fallback_note in block for block in markdown_blocks)
 
 
 def test_fallback_note_is_displayed_when_present() -> None:


### PR DESCRIPTION
## Summary
- extend the opportunities tab UI test to assert the Yahoo fallback note is not rendered when no notes are returned

## Testing
- `pytest tests/shared/test_settings.py tests/ui/test_opportunities_tab.py`
- `pytest` *(fails: existing suite failures in tests/shared/test_settings.py and tests/ui/test_opportunities_tab.py when run together)*

------
https://chatgpt.com/codex/tasks/task_e_68d9fa08ea548332ae43e6ef7178501a