### PR TITLE
Update opportunities tab captions for Yahoo availability

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -170,7 +170,7 @@ def test_stub_source_displays_warning_caption_and_notes() -> None:
         {"table": df, "notes": [extra_note], "source": "stub"}
     )
     captions = [element.value for element in app.get("caption")]
-    assert "⚠️ Datos simulados (Yahoo no disponible)" in captions
+    assert "⚠️ Resultados simulados (Yahoo no disponible)" in captions
     assert not any(
         "Resultados obtenidos de Yahoo Finance" in caption for caption in captions
     )

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -152,11 +152,9 @@ def render_opportunities_tab() -> None:
             st.dataframe(table, use_container_width=True)
 
         if source == "stub":
-            st.caption("⚠️ Datos simulados (Yahoo no disponible)")
+            st.caption("⚠️ Resultados simulados (Yahoo no disponible)")
         else:
-            st.caption(
-                "Resultados obtenidos de Yahoo Finance (con fallback a datos simulados si falta información)."
-            )
+            st.caption("Resultados obtenidos de Yahoo Finance")
         st.caption(
             "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento e inclusión de Latam requieren datos en vivo de Yahoo."
         )


### PR DESCRIPTION
## Summary
- update the opportunities tab captions to use the new Yahoo Finance wording
- adjust the UI test expectation to match the updated stub caption

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68da0a7a199c8332a0ca106a6d065094