### PR TITLE
feat: allow configuring opportunities symbol pool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Se puede definir el universo automático de oportunidades mediante `config.json`, `OPPORTUNITIES_SYMBOL_POOL` o `OPPORTUNITIES_SYMBOL_POOL_FILE`, permitiendo ajustar los filtros sin tocar el código.
+
+### Changed
+- Se amplió el conjunto determinista de emisores utilizados como fallback para cubrir más sectores de EE. UU. y LATAM.
+
+### Tests
+- Las pruebas del controlador de oportunidades contemplan la parametrización del universo automático y los pools inyectados por entorno.
 
 ## [0.3.13] - 2025-09-30
 ### Changed

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Esta pestaña experimental destaca emisores que cumplen criterios combinados de 
 
 La nota informativa sobre los filtros avanzados permanece visible en ambos escenarios para recordar que los criterios pueden ajustarse sin importar la fuente de datos. Los próximos pasos incluyen conectar con el servicio oficial de oportunidades, incorporar métricas en tiempo real y documentar el flujo de aprobación para publicar el módulo en la instancia principal.
 
+El universo automático que alimenta esta pestaña puede personalizarse sin modificar el código. Define la variable de entorno `OPPORTUNITIES_SYMBOL_POOL` con una lista JSON de tickers y métricas mínimas (`ticker`, `market_cap`, `pe`, `revenue_growth`, `region`) o apunta `OPPORTUNITIES_SYMBOL_POOL_FILE` a un archivo JSON externo con la misma estructura. Alternativamente, agrega la clave `"opportunities_symbol_pool"` en `config.json`. Si ninguno de estos valores está presente, la aplicación recurre a un conjunto determinista de emisores estadounidenses y latinoamericanos para mantener la estabilidad de los tests.
+
 ## Integración con Yahoo Finance
 
 La aplicación consulta [Yahoo Finance](https://finance.yahoo.com/) mediante la librería `yfinance` para enriquecer la vista de portafolio con series históricas, indicadores técnicos y métricas fundamentales/ESG. La barra lateral de healthcheck refleja si la última descarga provino de Yahoo o si fue necesario recurrir a un respaldo local, facilitando la observabilidad de esta dependencia externa.


### PR DESCRIPTION
## Summary
- expand the fallback opportunities universe with additional representative tickers
- allow loading the automatic symbol pool from environment variables or config.json
- document the new configuration knobs and extend the controller tests for configurable universes

## Testing
- PYTHONPATH=. pytest tests/controllers/test_opportunities_controller_auto.py

------
https://chatgpt.com/codex/tasks/task_e_68da0f2461ec83329b7c9d6bed8a46cc