### PR TITLE
Add checkbox to toggle technical indicators in opportunities screener

### DIFF
--- a/controllers/opportunities.py
+++ b/controllers/opportunities.py
@@ -268,7 +268,14 @@ def generate_opportunities_report(
 
     filters = filters or {}
     manual = filters.get("manual_tickers") or filters.get("tickers")
-    include_technicals = bool(filters.get("include_technicals", False))
+    include_technicals_value = filters.get("include_technicals")
+    include_technicals_parsed = _as_optional_bool(include_technicals_value)
+    if include_technicals_parsed is not None:
+        include_technicals = include_technicals_parsed
+    elif isinstance(include_technicals_value, bool):
+        include_technicals = include_technicals_value
+    else:
+        include_technicals = False
 
     df, notes, source = run_opportunities_controller(
         manual_tickers=manual,

--- a/tests/controllers/test_opportunities_controller.py
+++ b/tests/controllers/test_opportunities_controller.py
@@ -180,10 +180,29 @@ def test_generate_report_includes_source(monkeypatch: pytest.MonkeyPatch) -> Non
 
     def fake_controller(**kwargs: Any) -> Tuple[pd.DataFrame, List[str], str]:
         assert kwargs["manual_tickers"] == ["abc"]
+        assert kwargs["include_technicals"] is True
         return df, ["note"], "stub"
 
     monkeypatch.setattr(sut, "run_opportunities_controller", fake_controller)
 
-    result = sut.generate_opportunities_report({"manual_tickers": ["abc"]})
+    result = sut.generate_opportunities_report(
+        {"manual_tickers": ["abc"], "include_technicals": True}
+    )
 
     assert result == {"table": df, "notes": ["note"], "source": "stub"}
+
+
+def test_generate_report_parses_string_bool(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame([_make_sample_row()])
+
+    captured: Dict[str, Any] = {}
+
+    def fake_controller(**kwargs: Any) -> Tuple[pd.DataFrame, List[str], str]:
+        captured.update(kwargs)
+        return df, [], "yahoo"
+
+    monkeypatch.setattr(sut, "run_opportunities_controller", fake_controller)
+
+    sut.generate_opportunities_report({"include_technicals": "false"})
+
+    assert captured["include_technicals"] is False

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -149,6 +149,7 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
         "min_div_streak": 7,
         "min_cagr": 6.5,
         "include_latam": False,
+        "include_technicals": False,
     }
     dataframes = app.get("arrow_data_frame")
     assert dataframes, "Expected Streamlit dataframe component after execution"
@@ -161,6 +162,26 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
     fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
     markdown_blocks = [element.value for element in app.get("markdown")]
     assert not any(fallback_note in block for block in markdown_blocks)
+
+
+def test_checkbox_include_technicals_updates_params() -> None:
+    df = pd.DataFrame(
+        {
+            "ticker": ["AAPL"],
+            "price": [180.12],
+            "score_compuesto": [8.5],
+        }
+    )
+    overrides = {"Incluir indicadores técnicos": True}
+    app, mock = _run_app_with_result({"table": df, "notes": [], "source": "yahoo"}, overrides)
+
+    assert mock.call_count == 1
+    called_with = mock.call_args.args[0]
+    assert called_with["include_technicals"] is True
+    assert called_with["include_latam"] is True
+
+    dataframes = app.get("arrow_data_frame")
+    assert dataframes, "Expected Streamlit dataframe component after execution"
 
 
 def test_fallback_legend_and_notes_displayed_when_stub_source() -> None:

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -133,6 +133,11 @@ def render_opportunities_tab() -> None:
             value=True,
             help="Extiende el screening a emisores listados en Latinoamérica.",
         )
+        include_technicals = st.checkbox(
+            "Incluir indicadores técnicos",
+            value=False,
+            help="Agrega columnas con RSI y medias móviles de 50 y 200 ruedas.",
+        )
 
     st.markdown(
         "Seleccioná los parámetros deseados y presioná **Buscar oportunidades** para ejecutar "
@@ -163,6 +168,7 @@ def render_opportunities_tab() -> None:
             "min_div_streak": int(min_div_streak),
             "min_cagr": float(min_cagr),
             "include_latam": bool(include_latam),
+            "include_technicals": bool(include_technicals),
         }
 
         with st.spinner("Generando screening de oportunidades..."):


### PR DESCRIPTION
## Summary
- add a checkbox in the opportunities tab to toggle technical indicator columns and forward the flag to the controller
- ensure the controller preserves the include_technicals flag when calling Yahoo and the stub implementations
- extend UI, controller, and application tests to cover both technical indicator scenarios

## Testing
- pytest tests/ui/test_opportunities_tab.py tests/controllers/test_opportunities_controller.py tests/application/test_screener_yahoo.py

------
https://chatgpt.com/codex/tasks/task_e_68da130651a48332b44467c85dd1b699