### PR TITLE
Add EPS and buyback filters to opportunities screening

### DIFF
--- a/application/screener/opportunities.py
+++ b/application/screener/opportunities.py
@@ -13,6 +13,7 @@ import os
 from collections.abc import Mapping, Sequence
 from typing import Callable, Iterable, List, Optional
 
+import numpy as np
 import pandas as pd
 
 from infrastructure.market import YahooFinanceClient
@@ -37,6 +38,9 @@ _BASE_OPPORTUNITIES = [
         "pe_ratio": 30.2,
         "revenue_growth": 7.4,
         "is_latam": False,
+        "trailing_eps": 6.1,
+        "forward_eps": 6.6,
+        "buyback": 1.8,
     },
     {
         "ticker": "MSFT",
@@ -52,6 +56,9 @@ _BASE_OPPORTUNITIES = [
         "pe_ratio": 33.5,
         "revenue_growth": 14.8,
         "is_latam": False,
+        "trailing_eps": 9.2,
+        "forward_eps": 9.8,
+        "buyback": 1.1,
     },
     {
         "ticker": "KO",
@@ -67,6 +74,9 @@ _BASE_OPPORTUNITIES = [
         "pe_ratio": 24.7,
         "revenue_growth": 4.3,
         "is_latam": False,
+        "trailing_eps": 2.3,
+        "forward_eps": 2.4,
+        "buyback": 0.3,
     },
     {
         "ticker": "JNJ",
@@ -82,6 +92,9 @@ _BASE_OPPORTUNITIES = [
         "pe_ratio": 21.4,
         "revenue_growth": 3.1,
         "is_latam": False,
+        "trailing_eps": 8.5,
+        "forward_eps": 8.7,
+        "buyback": 0.6,
     },
     {
         "ticker": "NUE",
@@ -97,6 +110,9 @@ _BASE_OPPORTUNITIES = [
         "pe_ratio": 8.9,
         "revenue_growth": -6.2,
         "is_latam": False,
+        "trailing_eps": 18.4,
+        "forward_eps": 18.6,
+        "buyback": 0.0,
     },
     {
         "ticker": "MELI",
@@ -112,6 +128,9 @@ _BASE_OPPORTUNITIES = [
         "pe_ratio": 76.4,
         "revenue_growth": 31.5,
         "is_latam": True,
+        "trailing_eps": 4.8,
+        "forward_eps": 6.2,
+        "buyback": 0.0,
     },
 ]
 
@@ -353,6 +372,8 @@ def _apply_filters_and_finalize(
     min_market_cap: Optional[float] = None,
     max_pe: Optional[float] = None,
     min_revenue_growth: Optional[float] = None,
+    min_eps_growth: Optional[float] = None,
+    min_buyback: Optional[float] = None,
     include_latam_flag: bool | None = True,
     include_technicals: bool,
     restrict_to_tickers: Sequence[str] | None = None,
@@ -361,6 +382,9 @@ def _apply_filters_and_finalize(
     pe_ratio_column: str = "pe_ratio",
     revenue_growth_column: str = "revenue_growth",
     latam_column: str = "is_latam",
+    trailing_eps_column: str = "trailing_eps",
+    forward_eps_column: str = "forward_eps",
+    buyback_column: str = "buyback",
     allow_na_filters: bool = False,
     extra_drop_columns: Sequence[str] | None = None,
 ) -> pd.DataFrame:
@@ -406,6 +430,42 @@ def _apply_filters_and_finalize(
     if min_revenue_growth is not None and revenue_growth_column in result.columns:
         series = result[revenue_growth_column]
         mask = series >= float(min_revenue_growth)
+        if allow_na_filters:
+            mask = series.isna() | mask
+        result = result[mask]
+
+    if trailing_eps_column in result.columns:
+        series = pd.to_numeric(result[trailing_eps_column], errors="coerce")
+        mask = series > 0
+        if allow_na_filters:
+            mask = series.isna() | mask
+        result = result[mask]
+
+    if forward_eps_column in result.columns:
+        series = pd.to_numeric(result[forward_eps_column], errors="coerce")
+        mask = series > 0
+        if allow_na_filters:
+            mask = series.isna() | mask
+        result = result[mask]
+
+    if (
+        min_eps_growth is not None
+        and trailing_eps_column in result.columns
+        and forward_eps_column in result.columns
+    ):
+        trailing = pd.to_numeric(result[trailing_eps_column], errors="coerce")
+        forward = pd.to_numeric(result[forward_eps_column], errors="coerce")
+        denominator = trailing.replace(0, pd.NA)
+        growth = (forward - trailing) / denominator
+        growth = growth.replace([np.inf, -np.inf], pd.NA) * 100.0
+        mask = (trailing > 0) & (forward > 0) & (growth >= float(min_eps_growth))
+        if allow_na_filters:
+            mask = trailing.isna() | forward.isna() | growth.isna() | mask
+        result = result[mask]
+
+    if min_buyback is not None and buyback_column in result.columns:
+        series = pd.to_numeric(result[buyback_column], errors="coerce")
+        mask = series >= float(min_buyback)
         if allow_na_filters:
             mask = series.isna() | mask
         result = result[mask]
@@ -501,6 +561,8 @@ def run_screener_stub(
     min_revenue_growth: Optional[float] = None,
     include_latam: bool = True,
     include_technicals: bool = False,
+    min_eps_growth: Optional[float] = None,
+    min_buyback: Optional[float] = None,
 ) -> pd.DataFrame:
     """Return a filtered sample dataset that mimics a screener output.
 
@@ -523,6 +585,13 @@ def run_screener_stub(
         Maximum price to earnings ratio allowed.
     min_revenue_growth:
         Minimum year-over-year revenue growth percentage required.
+    min_eps_growth:
+        Minimum EPS growth percentage (forward vs trailing) required when
+        available. When ``None`` the growth filter is skipped but EPS must be
+        positive to remain in the dataset.
+    min_buyback:
+        Minimum buyback percentage (share reduction) required. ``None`` keeps
+        companies regardless of their buyback ratio.
     include_latam:
         When ``False`` securities flagged as originating from Latin America are
         excluded from the results.
@@ -550,6 +619,8 @@ def run_screener_stub(
         min_market_cap=min_market_cap,
         max_pe=max_pe,
         min_revenue_growth=min_revenue_growth,
+        min_eps_growth=min_eps_growth,
+        min_buyback=min_buyback,
         include_latam_flag=include_latam,
         include_technicals=include_technicals,
         restrict_to_tickers=manual or None,
@@ -558,6 +629,11 @@ def run_screener_stub(
         pe_ratio_column="pe_ratio",
         revenue_growth_column="revenue_growth",
         latam_column="is_latam",
+        extra_drop_columns=(
+            "trailing_eps",
+            "forward_eps",
+            "buyback",
+        ),
     )
 
 
@@ -785,6 +861,8 @@ def run_screener_yahoo(
     max_pe: Optional[float] = None,
     min_revenue_growth: Optional[float] = None,
     include_latam: Optional[bool] = None,
+    min_eps_growth: Optional[float] = None,
+    min_buyback: Optional[float] = None,
     client: YahooFinanceClient | None = None,
 ) -> pd.DataFrame | tuple[pd.DataFrame, list[str]]:
     """Run the Yahoo-based screener returning the same schema as the stub."""
@@ -867,6 +945,16 @@ def run_screener_yahoo(
         revenue_growth = _as_optional_float(
             fundamentals.get("revenue_growth") if fundamentals else pd.NA
         )
+        trailing_eps = _as_optional_float(
+            fundamentals.get("trailing_eps") if fundamentals else pd.NA
+        )
+        if trailing_eps is pd.NA and fundamentals and "trailingEps" in fundamentals:
+            trailing_eps = _as_optional_float(fundamentals.get("trailingEps"))
+        forward_eps = _as_optional_float(
+            fundamentals.get("forward_eps") if fundamentals else pd.NA
+        )
+        if forward_eps is pd.NA and fundamentals and "forwardEps" in fundamentals:
+            forward_eps = _as_optional_float(fundamentals.get("forwardEps"))
         is_latam = False
         if fundamentals:
             country = fundamentals.get("country") or fundamentals.get("region")
@@ -887,6 +975,9 @@ def run_screener_yahoo(
             "_meta_pe_ratio": pe_ratio,
             "_meta_revenue_growth": revenue_growth,
             "_meta_is_latam": is_latam,
+            "_meta_trailing_eps": trailing_eps,
+            "_meta_forward_eps": forward_eps,
+            "_meta_buyback": _as_optional_float(buyback),
         }
 
         rows.append(row)
@@ -903,6 +994,8 @@ def run_screener_yahoo(
         min_market_cap=min_market_cap,
         max_pe=max_pe,
         min_revenue_growth=min_revenue_growth,
+        min_eps_growth=min_eps_growth,
+        min_buyback=min_buyback,
         include_latam_flag=include_latam_flag,
         include_technicals=include_technicals,
         placeholder_tickers=tickers,
@@ -910,12 +1003,18 @@ def run_screener_yahoo(
         pe_ratio_column="_meta_pe_ratio",
         revenue_growth_column="_meta_revenue_growth",
         latam_column="_meta_is_latam",
+        trailing_eps_column="_meta_trailing_eps",
+        forward_eps_column="_meta_forward_eps",
+        buyback_column="_meta_buyback",
         allow_na_filters=True,
         extra_drop_columns=(
             "_meta_market_cap",
             "_meta_pe_ratio",
             "_meta_revenue_growth",
             "_meta_is_latam",
+            "_meta_trailing_eps",
+            "_meta_forward_eps",
+            "_meta_buyback",
         ),
     )
 

--- a/controllers/opportunities.py
+++ b/controllers/opportunities.py
@@ -82,6 +82,8 @@ def run_opportunities_controller(
     max_pe: Optional[float] = None,
     min_revenue_growth: Optional[float] = None,
     include_latam: Optional[bool] = None,
+    min_eps_growth: Optional[float] = None,
+    min_buyback: Optional[float] = None,
 ) -> Tuple[pd.DataFrame, List[str], str]:
     """Run the opportunities screener and return the results, notes and source."""
 
@@ -105,6 +107,10 @@ def run_opportunities_controller(
         yahoo_kwargs["min_revenue_growth"] = float(min_revenue_growth)
     if include_latam is not None:
         yahoo_kwargs["include_latam"] = bool(include_latam)
+    if min_eps_growth is not None:
+        yahoo_kwargs["min_eps_growth"] = float(min_eps_growth)
+    if min_buyback is not None:
+        yahoo_kwargs["min_buyback"] = float(min_buyback)
 
     notes: List[str] = []
     fallback_used = False
@@ -144,6 +150,8 @@ def run_opportunities_controller(
             min_revenue_growth=min_revenue_growth,
             include_latam=True if include_latam is None else include_latam,
             include_technicals=include_technicals,
+            min_eps_growth=min_eps_growth,
+            min_buyback=min_buyback,
         )
         notes.append("⚠️ Datos simulados (Yahoo no disponible)")
         df = _ensure_columns(df, include_technicals)
@@ -280,6 +288,8 @@ def generate_opportunities_report(
         max_pe=_as_optional_float(filters.get("max_pe")),
         min_revenue_growth=_as_optional_float(filters.get("min_revenue_growth")),
         include_latam=_as_optional_bool(filters.get("include_latam")),
+        min_eps_growth=_as_optional_float(filters.get("min_eps_growth")),
+        min_buyback=_as_optional_float(filters.get("min_buyback")),
     )
 
     return {"table": df, "notes": notes, "source": source}

--- a/tests/application/test_screener_yahoo.py
+++ b/tests/application/test_screener_yahoo.py
@@ -91,6 +91,8 @@ def comprehensive_data() -> dict[str, dict[str, object]]:
         "pe_ratio": 18.0,
         "revenue_growth": 7.5,
         "country": "United States",
+        "trailing_eps": 5.2,
+        "forward_eps": 5.9,
     }
 
     return {
@@ -165,6 +167,8 @@ def test_run_screener_yahoo_filters_and_optional_columns(comprehensive_data):
         "pe_ratio": 30.0,
         "revenue_growth": -2.5,
         "country": "Canada",
+        "trailing_eps": -1.0,
+        "forward_eps": -0.5,
     }
 
     dividends_bad = pd.DataFrame(
@@ -219,6 +223,8 @@ def test_run_screener_yahoo_applies_extended_filters(comprehensive_data):
         "pe_ratio": 15.0,
         "revenue_growth": 6.0,
         "country": "Brazil",
+        "trailing_eps": 3.4,
+        "forward_eps": 3.6,
     }
     latam_dividends = comprehensive_data["ABC"]["dividends"].copy()
     latam_shares = comprehensive_data["ABC"]["shares"].copy()
@@ -231,6 +237,8 @@ def test_run_screener_yahoo_applies_extended_filters(comprehensive_data):
         "pe_ratio": 35.0,
         "revenue_growth": 1.0,
         "country": "United States",
+        "trailing_eps": 1.2,
+        "forward_eps": 1.1,
     }
     small_dividends = comprehensive_data["ABC"]["dividends"].copy()
     small_shares = comprehensive_data["ABC"]["shares"].copy()
@@ -280,6 +288,80 @@ def test_run_screener_yahoo_applies_extended_filters(comprehensive_data):
     assert df_latam.shape[0] == 1
     assert df_latam.iloc[0]["ticker"] == "LAT"
     assert df_latam.iloc[0]["payout_ratio"] == 55.0
+
+
+def test_run_screener_yahoo_filters_eps_and_buybacks(
+    comprehensive_data: dict[str, dict[str, object]]
+) -> None:
+    base = comprehensive_data["ABC"]
+    base_fundamentals = base["fundamentals"].copy()
+    base_dividends = base["dividends"].copy()
+    base_prices = base["prices"].copy()
+    base_shares = base["shares"].copy()
+
+    growth_fundamentals = base_fundamentals.copy()
+    growth_fundamentals.update({"ticker": "GRO", "trailing_eps": 4.0, "forward_eps": 4.4})
+
+    flat_fundamentals = base_fundamentals.copy()
+    flat_fundamentals.update({"ticker": "FLT", "trailing_eps": 4.0, "forward_eps": 4.1})
+
+    negative_fundamentals = base_fundamentals.copy()
+    negative_fundamentals.update({"ticker": "NEG", "trailing_eps": -0.5, "forward_eps": 0.2})
+
+    weak_buyback_fundamentals = base_fundamentals.copy()
+    weak_buyback_fundamentals.update({"ticker": "BUY", "trailing_eps": 4.2, "forward_eps": 4.5})
+
+    shares_negative = pd.DataFrame(
+        {
+            "date": base_shares["date"],
+            "shares": [1_000_000, 1_010_000, 1_015_000, 1_020_000, 1_025_000, 1_030_000],
+        }
+    )
+
+    data = {
+        "GRO": {
+            "fundamentals": growth_fundamentals,
+            "dividends": base_dividends,
+            "shares": base_shares,
+            "prices": base_prices,
+        },
+        "FLT": {
+            "fundamentals": flat_fundamentals,
+            "dividends": base_dividends,
+            "shares": base_shares,
+            "prices": base_prices,
+        },
+        "NEG": {
+            "fundamentals": negative_fundamentals,
+            "dividends": base_dividends,
+            "shares": base_shares,
+            "prices": base_prices,
+        },
+        "BUY": {
+            "fundamentals": weak_buyback_fundamentals,
+            "dividends": base_dividends,
+            "shares": shares_negative,
+            "prices": base_prices,
+        },
+    }
+
+    client = FakeYahooClient(data)
+
+    df = ops.run_screener_yahoo(
+        manual_tickers=["GRO", "FLT", "NEG", "BUY"],
+        client=client,
+        include_technicals=False,
+        min_eps_growth=5.0,
+        min_buyback=0.1,
+    )
+
+    assert list(df["ticker"]) == ["GRO", "FLT", "NEG", "BUY"]
+    results = {row["ticker"]: row for _, row in df.iterrows()}
+
+    assert not pd.isna(results["GRO"]["payout_ratio"])
+    assert pd.isna(results["FLT"]["payout_ratio"])
+    assert pd.isna(results["NEG"]["payout_ratio"])
+    assert pd.isna(results["BUY"]["payout_ratio"])
 
 
 def test_run_opportunities_controller_calls_yahoo(monkeypatch, comprehensive_data):

--- a/tests/controllers/test_opportunities_controller.py
+++ b/tests/controllers/test_opportunities_controller.py
@@ -89,6 +89,8 @@ def test_propagates_filters_and_uses_yahoo(monkeypatch: pytest.MonkeyPatch) -> N
         max_pe=25,
         min_revenue_growth=7.5,
         include_latam=True,
+        min_eps_growth=4.5,
+        min_buyback=0.5,
     )
 
     assert captured_kwargs == {
@@ -101,6 +103,8 @@ def test_propagates_filters_and_uses_yahoo(monkeypatch: pytest.MonkeyPatch) -> N
         "max_pe": pytest.approx(25.0),
         "min_revenue_growth": pytest.approx(7.5),
         "include_latam": True,
+        "min_eps_growth": pytest.approx(4.5),
+        "min_buyback": pytest.approx(0.5),
     }
     assert list(df.columns) == _EXPECTED_WITH_TECHNICALS
     assert notes == []
@@ -130,6 +134,8 @@ def test_fallback_to_stub_preserves_filters(monkeypatch: pytest.MonkeyPatch) -> 
         min_div_streak=8,
         min_cagr=4.2,
         include_technicals=False,
+        min_eps_growth=2.0,
+        min_buyback=0.0,
     )
 
     assert stub_calls["manual_tickers"] == ["AAPL"]
@@ -137,6 +143,8 @@ def test_fallback_to_stub_preserves_filters(monkeypatch: pytest.MonkeyPatch) -> 
     assert stub_calls["min_div_streak"] == 8
     assert stub_calls["min_cagr"] == 4.2
     assert stub_calls["include_technicals"] is False
+    assert stub_calls["min_eps_growth"] == 2.0
+    assert stub_calls["min_buyback"] == 0.0
     assert list(df.columns) == _EXPECTED_COLUMNS
     assert notes[0] == "⚠️ Datos simulados (Yahoo no disponible)"
     assert "AAPL" in notes[1]

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -136,6 +136,8 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
         "Payout máximo (%)": 65.0,
         "Racha mínima de dividendos (años)": 7,
         "CAGR mínimo de dividendos (%)": 6.5,
+        "Crecimiento mínimo de EPS (%)": 4.0,
+        "Buyback mínimo (%)": 1.5,
         "Incluir Latam": False,
     }
     app, mock = _run_app_with_result({"table": df, "notes": [], "source": "yahoo"}, overrides)
@@ -148,6 +150,8 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
         "max_payout": 65.0,
         "min_div_streak": 7,
         "min_cagr": 6.5,
+        "min_eps_growth": 4.0,
+        "min_buyback": 1.5,
         "include_latam": False,
     }
     dataframes = app.get("arrow_data_frame")
@@ -155,7 +159,7 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
     captions = [element.value for element in app.get("caption")]
     assert any("Yahoo Finance" in caption for caption in captions)
     assert (
-        "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento, payout, racha de dividendos, CAGR e inclusión de Latam requieren datos en vivo de Yahoo."
+        "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento de ingresos, payout, racha de dividendos, CAGR, crecimiento de EPS, buybacks e inclusión de Latam requieren datos en vivo de Yahoo."
         in captions
     )
     fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -128,6 +128,20 @@ def render_opportunities_tab() -> None:
             step=0.5,
             help="Filtra compañías con crecimiento anual compuesto inferior al valor indicado (predeterminado: 4%).",
         )
+        min_eps_growth = st.number_input(
+            "Crecimiento mínimo de EPS (%)",
+            min_value=-100.0,
+            value=0.0,
+            step=0.5,
+            help="Requiere que el EPS proyectado supere al actual por al menos el porcentaje indicado (predeterminado: 0%).",
+        )
+        min_buyback = st.number_input(
+            "Buyback mínimo (%)",
+            min_value=-100.0,
+            value=0.0,
+            step=0.5,
+            help="Exige una reducción mínima en el flotante. Usa valores positivos para requerir recompras netas.",
+        )
         include_latam = st.checkbox(
             "Incluir Latam",
             value=True,
@@ -162,6 +176,8 @@ def render_opportunities_tab() -> None:
             "max_payout": float(max_payout),
             "min_div_streak": int(min_div_streak),
             "min_cagr": float(min_cagr),
+            "min_eps_growth": float(min_eps_growth),
+            "min_buyback": float(min_buyback),
             "include_latam": bool(include_latam),
         }
 
@@ -181,7 +197,7 @@ def render_opportunities_tab() -> None:
         else:
             st.caption("Resultados obtenidos de Yahoo Finance")
         st.caption(
-            "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento, payout, racha de dividendos, CAGR e inclusión de Latam requieren datos en vivo de Yahoo."
+            "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento de ingresos, payout, racha de dividendos, CAGR, crecimiento de EPS, buybacks e inclusión de Latam requieren datos en vivo de Yahoo."
         )
 
         if notes:


### PR DESCRIPTION
## Summary
- add EPS positivity/growth and buyback filtering to the shared screener helper
- surface configurable min_eps_growth and min_buyback parameters through the controller and Streamlit tab
- extend Yahoo/controller/UI tests with EPS and buyback scenarios

## Testing
- pytest tests/application/test_screener_yahoo.py
- pytest tests/controllers/test_opportunities_controller.py
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68da130a719883328770b1c739df4751