### PR TITLE
Documentar parámetros de score y recorte de oportunidades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
-- Se puede definir el universo automático de oportunidades mediante `config.json`, `OPPORTUNITIES_SYMBOL_POOL` o `OPPORTUNITIES_SYMBOL_POOL_FILE`, permitiendo ajustar los filtros sin tocar el código.
+- _No hay cambios destacados por el momento._
 
+## [3.0.1]
 ### Changed
-- Se amplió el conjunto determinista de emisores utilizados como fallback para cubrir más sectores de EE. UU. y LATAM.
+- El `score_compuesto` ahora se normaliza en escala 0-10 y se filtra automáticamente usando el umbral configurable `MIN_SCORE_THRESHOLD` (6.0 por defecto) para reducir ruido en los resultados de la pestaña beta.
+- El listado final de oportunidades respeta el límite configurable `MAX_RESULTS` (20 por defecto), manteniendo la tabla acotada incluso cuando Yahoo Finance devuelve universos extensos.
 
-### Tests
-- Las pruebas del controlador de oportunidades contemplan la parametrización del universo automático y los pools inyectados por entorno.
+### UI
+- La cabecera de "Empresas con oportunidad" indica cuándo se aplican el umbral mínimo y el recorte del top N, explicando al usuario por qué ciertos tickers quedan fuera del informe.
 
 ## [0.3.14]
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ La vista beta evoluciona hacia un universo dinámico que se recalcula en cada se
 
 El ranking final pondera criterios técnicos y fundamentales alineados con los parámetros disponibles en el backend. Los filtros actualmente soportados corresponden a los argumentos `max_payout`, `min_div_streak`, `min_cagr`, `min_market_cap`, `max_pe`, `min_revenue_growth`, `min_eps_growth`, `min_buyback`, `include_latam`, `sectors` e `include_technicals`, combinando métricas de dividendos, valuación, crecimiento y cobertura geográfica.
 
-La interfaz incorpora controles que permiten ajustar esos filtros sin modificar código:
+Cada oportunidad obtiene un **score normalizado en escala 0-10** que promedia aportes de payout, racha de dividendos, CAGR, recompras, RSI y MACD. Esta normalización permite comparar emisores de distintas fuentes con un criterio homogéneo. Los resultados que queden por debajo del umbral configurado se descartan automáticamente para reducir ruido.
+
+Los controles disponibles en la UI permiten ajustar esos filtros sin modificar código:
 
 - Multiselect de sectores para recortar el universo devuelto por la búsqueda.
 - Checkbox **Incluir indicadores técnicos** para agregar RSI y medias móviles al resultado.
 - Inputs dedicados a crecimiento mínimo de EPS y porcentaje mínimo de recompras (`buybacks`).
 - Sliders y number inputs para capitalización, payout, P/E, crecimiento de ingresos, racha/CAGR de dividendos e inclusión de Latinoamérica.
 
-La cabecera del listado diferencia la procedencia de los datos con un caption que alterna entre `yahoo` y `stub`, manteniendo la trazabilidad de la fuente durante los failovers.
+El umbral mínimo de score y el recorte del **top N** de oportunidades son parametrizables mediante las variables `MIN_SCORE_THRESHOLD` (valor por defecto: `6.0`) y `MAX_RESULTS` (valor por defecto: `20`). Puedes redefinirlos desde `.env`, `secrets.toml` o `config.json` para adaptar la severidad del filtro o ampliar/restringir el listado mostrado en la UI. La cabecera del listado muestra notas contextuales cuando se aplican estos recortes y sigue diferenciando la procedencia de los datos con un caption que alterna entre `yahoo` y `stub`, manteniendo la trazabilidad de la fuente durante los failovers.
 
 ## Integración con Yahoo Finance
 
@@ -119,6 +121,8 @@ CACHE_TTL_YF_FUNDAMENTALS=21600
 CACHE_TTL_YF_PORTFOLIO_FUNDAMENTALS=14400
 YAHOO_FUNDAMENTALS_TTL=3600
 YAHOO_QUOTES_TTL=300
+MIN_SCORE_THRESHOLD=6.0
+MAX_RESULTS=20
 ASSET_CATALOG_PATH="/ruta/a/assets_catalog.json"
 # Nivel de los logs ("DEBUG", "INFO", etc.; predeterminado: INFO)
 LOG_LEVEL="INFO"
@@ -128,6 +132,8 @@ LOG_FORMAT="plain"
 LOG_USER="usuario"
 ```
 Los parámetros `CACHE_TTL_YF_*` ajustan cuánto tiempo se reutiliza cada respuesta de Yahoo Finance antes de volver a consultar la API (indicadores técnicos, históricos, fundamentales individuales y ranking del portafolio, respectivamente). Las variables `YAHOO_FUNDAMENTALS_TTL` (3600 segundos por defecto) y `YAHOO_QUOTES_TTL` (300 segundos por defecto) controlan el TTL de la caché específica para fundamentales y cotizaciones de Yahoo; puedes redefinir estos valores en el `.env` o en `secrets.toml` según tus necesidades. Ambos parámetros también se exponen con alias en minúsculas (`yahoo_fundamentals_ttl` y `yahoo_quotes_ttl`) para facilitar su lectura desde `st.secrets`, y cualquier alias o nombre en mayúsculas puede sobrescribirse indistintamente mediante variables de entorno, archivos `.env` o secretos.
+
+`MIN_SCORE_THRESHOLD` (6.0 por defecto) define el puntaje mínimo aceptado para que una empresa aparezca en el listado beta, mientras que `MAX_RESULTS` (20 por defecto) determina cuántas filas finales mostrará la UI tras aplicar filtros y ordenar el score normalizado. Ambos valores pueden sobreescribirse desde el mismo `.env`, `secrets.toml` o `config.json` si necesitás afinar la agresividad del recorte.
 También puedes definir estos valores sensibles en `secrets.toml`,
 el cual `streamlit` expone a través de `st.secrets`. Los valores en
 `secrets.toml` tienen prioridad sobre las variables de entorno.


### PR DESCRIPTION
## Summary
- Document score normalisation, threshold handling and top-N trimming in the opportunities beta section of the README
- Reference the new MIN_SCORE_THRESHOLD and MAX_RESULTS defaults in the environment configuration examples
- Add the 3.0.1 changelog entry while cleaning outdated notes from the Unreleased section

## Testing
- No tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68da88b534308332aa37b59c05579af4