### PR TITLE
Align opportunities score slider with backend scale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [3.0.1]
 ### Changed
-- El `score_compuesto` ahora se normaliza en escala 0-10 y se filtra automáticamente usando el umbral configurable `MIN_SCORE_THRESHOLD` (6.0 por defecto) para reducir ruido en los resultados de la pestaña beta.
+- El `score_compuesto` ahora se normaliza en escala 0-100 y se filtra automáticamente usando el umbral configurable `MIN_SCORE_THRESHOLD` (80 por defecto) para reducir ruido en los resultados de la pestaña beta.
 - El listado final de oportunidades respeta el límite configurable `MAX_RESULTS` (20 por defecto), manteniendo la tabla acotada incluso cuando Yahoo Finance devuelve universos extensos.
 
 ### UI

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ La vista beta evoluciona hacia un universo dinámico que se recalcula en cada se
 
 El ranking final pondera criterios técnicos y fundamentales alineados con los parámetros disponibles en el backend. Los filtros actualmente soportados corresponden a los argumentos `max_payout`, `min_div_streak`, `min_cagr`, `min_market_cap`, `max_pe`, `min_revenue_growth`, `min_eps_growth`, `min_buyback`, `include_latam`, `sectors` e `include_technicals`, combinando métricas de dividendos, valuación, crecimiento y cobertura geográfica.
 
-Cada oportunidad obtiene un **score normalizado en escala 0-10** que promedia aportes de payout, racha de dividendos, CAGR, recompras, RSI y MACD. Esta normalización permite comparar emisores de distintas fuentes con un criterio homogéneo. Los resultados que queden por debajo del umbral configurado se descartan automáticamente para reducir ruido.
+Cada oportunidad obtiene un **score normalizado en escala 0-100** que promedia aportes de payout, racha de dividendos, CAGR, recompras, RSI y MACD. Esta normalización permite comparar emisores de distintas fuentes con un criterio homogéneo. Los resultados que queden por debajo del umbral configurado se descartan automáticamente para reducir ruido.
 
 Los controles disponibles en la UI permiten ajustar esos filtros sin modificar código:
 
@@ -45,7 +45,7 @@ Los controles disponibles en la UI permiten ajustar esos filtros sin modificar c
 - Inputs dedicados a crecimiento mínimo de EPS y porcentaje mínimo de recompras (`buybacks`).
 - Sliders y number inputs para capitalización, payout, P/E, crecimiento de ingresos, racha/CAGR de dividendos e inclusión de Latinoamérica.
 
-El umbral mínimo de score y el recorte del **top N** de oportunidades son parametrizables mediante las variables `MIN_SCORE_THRESHOLD` (valor por defecto: `6.0`) y `MAX_RESULTS` (valor por defecto: `20`). Puedes redefinirlos desde `.env`, `secrets.toml` o `config.json` para adaptar la severidad del filtro o ampliar/restringir el listado mostrado en la UI. La cabecera del listado muestra notas contextuales cuando se aplican estos recortes y sigue diferenciando la procedencia de los datos con un caption que alterna entre `yahoo` y `stub`, manteniendo la trazabilidad de la fuente durante los failovers.
+El umbral mínimo de score y el recorte del **top N** de oportunidades son parametrizables mediante las variables `MIN_SCORE_THRESHOLD` (valor por defecto: `80`) y `MAX_RESULTS` (valor por defecto: `20`). Puedes redefinirlos desde `.env`, `secrets.toml` o `config.json` para adaptar la severidad del filtro o ampliar/restringir el listado mostrado en la UI. La cabecera del listado muestra notas contextuales cuando se aplican estos recortes y sigue diferenciando la procedencia de los datos con un caption que alterna entre `yahoo` y `stub`, manteniendo la trazabilidad de la fuente durante los failovers.
 
 ## Integración con Yahoo Finance
 
@@ -121,7 +121,7 @@ CACHE_TTL_YF_FUNDAMENTALS=21600
 CACHE_TTL_YF_PORTFOLIO_FUNDAMENTALS=14400
 YAHOO_FUNDAMENTALS_TTL=3600
 YAHOO_QUOTES_TTL=300
-MIN_SCORE_THRESHOLD=6.0
+MIN_SCORE_THRESHOLD=80
 MAX_RESULTS=20
 ASSET_CATALOG_PATH="/ruta/a/assets_catalog.json"
 # Nivel de los logs ("DEBUG", "INFO", etc.; predeterminado: INFO)
@@ -133,7 +133,7 @@ LOG_USER="usuario"
 ```
 Los parámetros `CACHE_TTL_YF_*` ajustan cuánto tiempo se reutiliza cada respuesta de Yahoo Finance antes de volver a consultar la API (indicadores técnicos, históricos, fundamentales individuales y ranking del portafolio, respectivamente). Las variables `YAHOO_FUNDAMENTALS_TTL` (3600 segundos por defecto) y `YAHOO_QUOTES_TTL` (300 segundos por defecto) controlan el TTL de la caché específica para fundamentales y cotizaciones de Yahoo; puedes redefinir estos valores en el `.env` o en `secrets.toml` según tus necesidades. Ambos parámetros también se exponen con alias en minúsculas (`yahoo_fundamentals_ttl` y `yahoo_quotes_ttl`) para facilitar su lectura desde `st.secrets`, y cualquier alias o nombre en mayúsculas puede sobrescribirse indistintamente mediante variables de entorno, archivos `.env` o secretos.
 
-`MIN_SCORE_THRESHOLD` (6.0 por defecto) define el puntaje mínimo aceptado para que una empresa aparezca en el listado beta, mientras que `MAX_RESULTS` (20 por defecto) determina cuántas filas finales mostrará la UI tras aplicar filtros y ordenar el score normalizado. Ambos valores pueden sobreescribirse desde el mismo `.env`, `secrets.toml` o `config.json` si necesitás afinar la agresividad del recorte.
+`MIN_SCORE_THRESHOLD` (80 por defecto) define el puntaje mínimo aceptado para que una empresa aparezca en el listado beta, mientras que `MAX_RESULTS` (20 por defecto) determina cuántas filas finales mostrará la UI tras aplicar filtros y ordenar el score normalizado. Ambos valores pueden sobreescribirse desde el mismo `.env`, `secrets.toml` o `config.json` si necesitás afinar la agresividad del recorte.
 También puedes definir estos valores sensibles en `secrets.toml`,
 el cual `streamlit` expone a través de `st.secrets`. Los valores en
 `secrets.toml` tienen prioridad sobre las variables de entorno.

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -134,7 +134,7 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
         {
             "ticker": ["AAPL", "MSFT"],
             "price": [180.12, 325.74],
-            "score_compuesto": [8.5, 7.9],
+            "score_compuesto": [85.0, 79.0],
             "sector": ["Technology", "Technology"],
         }
     )
@@ -149,7 +149,7 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
         "Crecimiento mínimo de EPS (%)": 4.0,
         "Buyback mínimo (%)": 1.5,
         "Incluir Latam": False,
-        "Score mínimo": 7.2,
+        "Score mínimo": 72,
         "Máximo de resultados": 15,
         "Sectores": ["Technology"],
     }
@@ -167,7 +167,7 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
         "min_buyback": 1.5,
         "include_latam": False,
         "include_technicals": False,
-        "min_score_threshold": 7.2,
+        "min_score_threshold": 72.0,
         "max_results": 15,
         "sectors": ["Technology"],
     }
@@ -189,7 +189,7 @@ def test_checkbox_include_technicals_updates_params() -> None:
         {
             "ticker": ["AAPL"],
             "price": [180.12],
-            "score_compuesto": [8.5],
+            "score_compuesto": [85.0],
         }
     )
     overrides = {"Incluir indicadores técnicos": True}
@@ -229,6 +229,7 @@ def test_excluded_tickers_not_displayed_even_when_relaxing_filters(
     overrides = {
         "Capitalización mínima (US$ MM)": 0,
         "P/E máximo": 60.0,
+        "Score mínimo": 50,
     }
 
     app, mock = _run_app_with_result(fake_generate, overrides)
@@ -251,7 +252,7 @@ def test_fallback_legend_and_notes_displayed_when_stub_source() -> None:
         {
             "ticker": ["KO"],
             "price": [58.31],
-            "score_compuesto": [6.1],
+            "score_compuesto": [61.0],
         }
     )
     fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
@@ -271,7 +272,7 @@ def test_stub_source_displays_warning_caption_and_notes() -> None:
         {
             "ticker": ["PFE"],
             "price": [35.12],
-            "score_compuesto": [5.4],
+            "score_compuesto": [54.0],
         }
     )
     extra_note = "Dato adicional relevante"
@@ -295,11 +296,11 @@ def test_notes_block_highlights_backend_messages() -> None:
         {
             "ticker": ["AMZN"],
             "price": [140.25],
-            "score_compuesto": [7.8],
+            "score_compuesto": [78.0],
         }
     )
     top_note = "Se recortaron los resultados a los 5 mejores según el score compuesto."
-    threshold_note = "No se encontraron candidatos con score >= 7.5 tras aplicar el threshold."
+    threshold_note = "No se encontraron candidatos con score >= 75 tras aplicar el threshold."
     regular_note = "Considerar diversificación adicional."
 
     app, _ = _run_app_with_result(

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -190,10 +190,10 @@ def render_opportunities_tab() -> None:
         )
         min_score_threshold = st.slider(
             "Score mínimo",
-            min_value=0.0,
-            max_value=10.0,
-            value=6.0,
-            step=0.1,
+            min_value=0,
+            max_value=100,
+            value=80,
+            step=1,
             help="Define el puntaje mínimo requerido para considerar un candidato.",
         )
         max_results = st.number_input(


### PR DESCRIPTION
## Summary
- expand the opportunities tab "Score mínimo" slider to use the backend's 0-100 range
- update UI tests and sample payloads to validate the new score scale
- refresh documentation to reference the 0-100 normalization and default threshold of 80

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68db1b09f1e88332a8e6052460eccd3e