### PR TITLE
Respect configurable minimum score threshold

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -209,6 +209,16 @@ def test_checkbox_include_technicals_updates_params() -> None:
     assert dataframes, "Expected Streamlit dataframe component after execution"
 
 
+def test_min_score_slider_uses_settings_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(shared_settings, "min_score_threshold", 67)
+
+    app = _render_app()
+
+    sliders = [element for element in app.get("slider") if element.label == "Score mínimo"]
+    assert sliders, "Expected to find slider for minimum score"
+    assert int(sliders[0].value) == int(shared_settings.min_score_threshold)
+
+
 def test_excluded_tickers_not_displayed_even_when_relaxing_filters(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -193,7 +193,7 @@ def render_opportunities_tab() -> None:
             "Score mínimo",
             min_value=0,
             max_value=100,
-            value=80,
+            value=int(shared_settings.min_score_threshold),
             step=1,
             help="Define el puntaje mínimo requerido para considerar un candidato.",
         )


### PR DESCRIPTION
## Summary
- default the "Score mínimo" slider to the configured `shared_settings.min_score_threshold`
- extend UI tests to confirm the slider honors runtime overrides

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68db319866808332b00d8b8dc1859d47