### PR TITLE
Update opportunities module documentation and imports

### DIFF
--- a/application/screener/opportunities.py
+++ b/application/screener/opportunities.py
@@ -1,14 +1,13 @@
-"""Stub implementation for the opportunities screener.
+"""Opportunities screener helpers for both stub data and Yahoo integration.
 
-This module provides a small, deterministic dataset that emulates the
-structure returned by a future screener implementation. The goal is to
-allow UI components and controllers to be developed and tested without the
-final data provider in place.
+The module exposes a deterministic dataset used for local development as
+well as the functions that orchestrate the Yahoo Finance client, allowing UI
+components and controllers to rely on a single entry point regardless of the
+backing data source.
 """
 from __future__ import annotations
 
 import logging
-import math
 from collections.abc import Mapping, Sequence
 from typing import Callable, Iterable, List, Optional
 


### PR DESCRIPTION
## Summary
- update the opportunities screener module docstring to highlight both the stub dataset and the Yahoo Finance integration
- remove the unused `math` import from the opportunities screener module

## Testing
- poetry run pytest *(fails: multiple existing UI/controller tests expecting configured Streamlit context and Yahoo settings, e.g. `tests/ui/test_opportunities_tab.py::test_button_executes_controller_and_shows_yahoo_caption`)*

------
https://chatgpt.com/codex/tasks/task_e_68db319ecc0c83329136022761bc3d16