### PR TITLE
Clamp default score slider value

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -219,6 +219,18 @@ def test_min_score_slider_uses_settings_default(monkeypatch: pytest.MonkeyPatch)
     assert int(sliders[0].value) == int(shared_settings.min_score_threshold)
 
 
+def test_min_score_slider_normalizes_out_of_range_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(shared_settings, "min_score_threshold", 150)
+
+    app = _render_app()
+
+    sliders = [element for element in app.get("slider") if element.label == "Score mínimo"]
+    assert sliders, "Expected to find slider for minimum score"
+    assert int(sliders[0].value) == 100
+
+
 def test_excluded_tickers_not_displayed_even_when_relaxing_filters(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -189,11 +189,13 @@ def render_opportunities_tab() -> None:
             value=False,
             help="Agrega columnas con RSI y medias móviles de 50 y 200 ruedas.",
         )
+        default_score = shared_settings.min_score_threshold
+        normalized_default_score = max(0, min(100, int(default_score)))
         min_score_threshold = st.slider(
             "Score mínimo",
             min_value=0,
             max_value=100,
-            value=int(shared_settings.min_score_threshold),
+            value=normalized_default_score,
             step=1,
             help="Define el puntaje mínimo requerido para considerar un candidato.",
         )


### PR DESCRIPTION
## Summary
- clamp the opportunities tab score slider default to the valid 0-100 range before rendering
- add a regression test to ensure out-of-range defaults are normalized to 100

## Testing
- pytest tests/ui/test_opportunities_tab.py -k min_score --maxfail=1

------
https://chatgpt.com/codex/tasks/task_e_68db3a2ffb4c833297e27b9550374279