### PR TITLE
Highlight scarcity notes in opportunities tab

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -347,6 +347,25 @@ def test_notes_block_highlights_backend_messages() -> None:
     assert f"- {regular_note}" in markdown_blocks
 
 
+def test_notes_block_highlights_scarcity_messages() -> None:
+    df = pd.DataFrame(
+        {
+            "ticker": ["NFLX"],
+            "price": [410.55],
+            "score_compuesto": [71.0],
+        }
+    )
+    scarcity_note = "Solo se encontraron 3 candidatos por debajo del mínimo esperado."
+
+    app, _ = _run_app_with_result(
+        {"table": df, "notes": [scarcity_note], "source": "yahoo"}
+    )
+
+    markdown_blocks = [element.value for element in app.get("markdown")]
+
+    assert f"- **{scarcity_note}**" in markdown_blocks
+
+
 def test_opportunities_tab_not_rendered_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("shared.settings.FEATURE_OPPORTUNITIES_TAB", False)
     monkeypatch.delenv("FEATURE_OPPORTUNITIES_TAB", raising=False)

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -41,7 +41,24 @@ def _format_note(note: str) -> str:
             keyword in normalized for keyword in ("no se encontraron", "sin candidatos")
         )
     )
-    if highlight_top_results or highlight_threshold:
+    highlight_scarcity = any(
+        phrase in normalized
+        for phrase in (
+            "solo se encontraron",
+            "solo se encontro",
+            "solo se encontró",
+            "solo encontramos",
+        )
+    )
+    highlight_min_expected = any(
+        phrase in normalized for phrase in ("mínimo esperado", "minimo esperado")
+    )
+    if (
+        highlight_top_results
+        or highlight_threshold
+        or highlight_scarcity
+        or highlight_min_expected
+    ):
         return f"**{note}**"
     return note
 


### PR DESCRIPTION
## Summary
- highlight additional backend notes mentioning scarce results or expected minimums
- add regression coverage ensuring the emphasized markdown renders for scarcity messages

## Testing
- pytest tests/ui/test_opportunities_tab.py::test_notes_block_highlights_scarcity_messages

------
https://chatgpt.com/codex/tasks/task_e_68db4eee22188332ad5193571e0cd478