### PR TITLE
Documenta ejecución de pruebas live de Yahoo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - El valor por defecto de `MAX_RESULTS` se consolidó en `shared.config.Settings` (20) y la UI ahora inicializa el selector con ese número para respetar overrides de configuración.
+### Tests
+- Documentado el procedimiento para habilitar `pytest -m live_yahoo` mediante la variable `RUN_LIVE_YF` y advertir sobre su naturaleza no determinista.
 
 ## [3.0.1]
 ### Changed

--- a/README.md
+++ b/README.md
@@ -250,6 +250,15 @@ Para ejecutar solo un subconjunto por carpeta, indica la ruta deseada:
 pytest application/test
 ```
 
+Para habilitar las pruebas que consultan Yahoo Finance en vivo, exporta la
+variable `RUN_LIVE_YF=1` y ejecuta la etiqueta dedicada. Estas verificaciones
+descargan datos reales y, por tratarse de información del mercado en tiempo
+real, pueden arrojar resultados no deterministas entre corridas.
+
+```bash
+RUN_LIVE_YF=1 pytest -m live_yahoo
+```
+
 Para verificar el estilo del código:
 
 ```bash

--- a/tests/application/test_screener_yahoo.py
+++ b/tests/application/test_screener_yahoo.py
@@ -992,6 +992,7 @@ def test_run_opportunities_controller_applies_new_filters(
 _STUB_TICKERS = {"AAPL", "MSFT", "KO", "JNJ", "NUE", "MELI"}
 
 
+# Instrucciones completas en README.md#pruebas para habilitar la marca live_yahoo.
 @pytest.mark.live_yahoo
 @pytest.mark.skipif(
     os.getenv("RUN_LIVE_YF") != "1",


### PR DESCRIPTION
## Summary
- document the environment variable required to run the live Yahoo Finance test suite and warn about its non-deterministic nature
- record the new testing guideline in the changelog
- cross-reference the live Yahoo pytest marker with the README instructions from the test file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db54d03d3483328cfe5aa3a0bca060