### PR TITLE
Add Yahoo screener truncation coverage and note formatting

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -385,6 +385,29 @@ def test_notes_block_highlights_scarcity_messages() -> None:
     assert f"- **{scarcity_note}**" in markdown_blocks
 
 
+def test_notes_block_formats_truncation_and_shortage_notes() -> None:
+    df = pd.DataFrame(
+        {
+            "ticker": ["META", "GOOGL"],
+            "price": [295.12, 138.45],
+            "score_compuesto": [83.5, 79.2],
+        }
+    )
+    truncation_note = "Se muestran 10 resultados de 240 tras aplicar el máximo solicitado (10)."
+    shortage_note = "Solo se encontraron 10 oportunidades (mínimo esperado: 25)."
+
+    app, _ = _run_app_with_result(
+        {"table": df, "notes": [truncation_note, shortage_note], "source": "yahoo"}
+    )
+
+    captions = [element.value for element in app.get("caption")]
+    assert any("Yahoo Finance" in caption for caption in captions)
+
+    markdown_blocks = [element.value for element in app.get("markdown")]
+    assert f"- **{truncation_note}**" in markdown_blocks
+    assert f"- **{shortage_note}**" in markdown_blocks
+
+
 def test_opportunities_tab_not_rendered_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("shared.settings.FEATURE_OPPORTUNITIES_TAB", False)
     monkeypatch.delenv("FEATURE_OPPORTUNITIES_TAB", raising=False)

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -35,6 +35,9 @@ def _format_note(note: str) -> str:
             for keyword in ("recort", "limit", "límite", "limite")
         )
     )
+    highlight_truncated_summary = (
+        "se muestran" in normalized and "máximo solicitado" in normalized
+    )
     highlight_threshold = (
         any(keyword in normalized for keyword in ("threshold", "umbral", "score"))
         and any(
@@ -56,6 +59,7 @@ def _format_note(note: str) -> str:
     highlight_simulated_data = normalized.startswith("⚠️ datos simulados")
     if (
         highlight_top_results
+        or highlight_truncated_summary
         or highlight_threshold
         or highlight_scarcity
         or highlight_min_expected


### PR DESCRIPTION
## Summary
- add a bulk Yahoo fake client generator that returns hundreds of synthetic tickers
- cover Yahoo screener truncation and scarcity messaging with a high-volume test
- ensure the UI highlights Yahoo truncation and shortage notes for Yahoo-sourced results

## Testing
- pytest tests/application/test_screener_yahoo.py::test_run_screener_yahoo_truncates_large_universe -q
- pytest tests/ui/test_opportunities_tab.py::test_notes_block_formats_truncation_and_shortage_notes -q

------
https://chatgpt.com/codex/tasks/task_e_68db5707ceac8332b59e50dd29bb3b65