### PR TITLE
Format opportunity notes by severity

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ Los controles disponibles en la UI permiten ajustar esos filtros sin modificar c
 
 El umbral mínimo de score y el recorte del **top N** de oportunidades son parametrizables mediante las variables `MIN_SCORE_THRESHOLD` (valor por defecto: `80`) y `MAX_RESULTS` (valor por defecto: `20`). La interfaz utiliza ese valor centralizado como punto de partida en el selector "Máximo de resultados" para reflejar cualquier override definido en la configuración. Puedes redefinirlos desde `.env`, `secrets.toml` o `config.json` para adaptar la severidad del filtro o ampliar/restringir el listado mostrado en la UI. La cabecera del listado muestra notas contextuales cuando se aplican estos recortes y sigue diferenciando la procedencia de los datos con un caption que alterna entre `yahoo` y `stub`, manteniendo la trazabilidad de la fuente durante los failovers.
 
+
+Las notas del listado utilizan iconos para indicar la severidad del mensaje:
+
+- `:warning:` señala datos simulados o problemas de disponibilidad remota.
+- `:information_source:` destaca mensajes de escasez o recordatorios operativos.
+- Las notas sin prefijo se muestran con formato neutro.
+
 ## Integración con Yahoo Finance
 
 La aplicación consulta [Yahoo Finance](https://finance.yahoo.com/) mediante la librería `yfinance` para enriquecer la vista de portafolio con series históricas, indicadores técnicos y métricas fundamentales/ESG. La barra lateral de healthcheck refleja si la última descarga provino de Yahoo o si fue necesario recurrir a un respaldo local, facilitando la observabilidad de esta dependencia externa.

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -290,8 +290,14 @@ def test_fallback_legend_and_notes_displayed_when_stub_source() -> None:
     captions = [element.value for element in app.get("caption")]
     assert any("Resultados simulados" in caption for caption in captions)
     markdown_blocks = [element.value for element in app.get("markdown")]
-    assert any(f"- **{fallback_note}**" in block for block in markdown_blocks)
-    assert any(extra_note in block for block in markdown_blocks)
+    assert any(
+        "- :warning: **Datos simulados (Yahoo no disponible)**" in block
+        for block in markdown_blocks
+    )
+    assert any(
+        "- :information_source: Recuerda validar con fuentes oficiales" in block
+        for block in markdown_blocks
+    )
 
 
 def test_stub_source_displays_warning_caption_and_notes() -> None:
@@ -334,7 +340,10 @@ def test_fallback_note_with_cause_highlighted() -> None:
 
     markdown_blocks = [element.value for element in app.get("markdown")]
 
-    assert any(f"- **{fallback_note}**" in block for block in markdown_blocks)
+    assert any(
+        "- :warning: **Datos simulados — Causa: Yahoo timeout**" in block
+        for block in markdown_blocks
+    )
 
 
 def test_notes_block_highlights_backend_messages() -> None:
@@ -374,7 +383,7 @@ def test_notes_block_highlights_scarcity_messages() -> None:
             "score_compuesto": [71.0],
         }
     )
-    scarcity_note = "Solo se encontraron 3 candidatos por debajo del mínimo esperado."
+    scarcity_note = "ℹ️ Solo se encontraron 3 candidatos por debajo del mínimo esperado."
 
     app, _ = _run_app_with_result(
         {"table": df, "notes": [scarcity_note], "source": "yahoo"}
@@ -382,7 +391,10 @@ def test_notes_block_highlights_scarcity_messages() -> None:
 
     markdown_blocks = [element.value for element in app.get("markdown")]
 
-    assert f"- **{scarcity_note}**" in markdown_blocks
+    assert (
+        "- :information_source: Solo se encontraron 3 candidatos por debajo del mínimo esperado."
+        in markdown_blocks
+    )
 
 
 def test_opportunities_tab_not_rendered_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -27,7 +27,20 @@ _SECTOR_OPTIONS: Sequence[str] = (
 def _format_note(note: str) -> str:
     """Return a formatted representation for notes that need emphasis."""
 
-    normalized = note.casefold()
+    stripped = note.strip()
+    for prefix, icon, emphasize in (
+        ("⚠️", ":warning:", True),
+        ("ℹ️", ":information_source:", False),
+    ):
+        if stripped.startswith(prefix):
+            content = stripped[len(prefix) :].lstrip()
+            if not content:
+                return icon
+            if emphasize:
+                return f"{icon} **{content}**"
+            return f"{icon} {content}"
+
+    normalized = stripped.casefold()
     highlight_top_results = (
         any(keyword in normalized for keyword in ("top", "mejores"))
         and any(
@@ -61,8 +74,8 @@ def _format_note(note: str) -> str:
         or highlight_min_expected
         or highlight_simulated_data
     ):
-        return f"**{note}**"
-    return note
+        return f"**{stripped}**"
+    return stripped
 
 
 def _normalize_notes(notes: object) -> list[str]:


### PR DESCRIPTION
## Summary
- map warning and informational note prefixes in the opportunities tab to consistent markdown icons and emphasis
- extend the opportunities tab UI tests to cover warning, scarcity, and neutral note formatting
- document the meaning of note icons in the README for future consistency

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68db570929748332add5aefd919aea89