### PR TITLE
Use shared note formatter across health sidebar alerts

### DIFF
--- a/tests/test_health_sidebar_rendering.py
+++ b/tests/test_health_sidebar_rendering.py
@@ -20,6 +20,7 @@ from shared.time_provider import TIME_FORMAT, TimeProvider
 # <== De tu rama: Se importa TimeSnapshot para el stub.
 from shared.time_provider import TimeSnapshot
 from shared.version import __version__
+from shared.ui import notes as shared_notes
 
 _ORIGINAL_STREAMLIT = st
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
@@ -161,12 +162,16 @@ def test_sidebar_formats_populated_metrics(monkeypatch) -> None:
     formatted = [str(TimeProvider.from_timestamp(ts)) for ts in timestamps]
     expected_lines = {
         "#### 🔐 Conexión IOL",
-        f"✅ Refresh correcto • {formatted[0]} — OK",
+        shared_notes.format_note(f"✅ Refresh correcto • {formatted[0]} — OK"),
         "#### 📈 Yahoo Finance",
-        f"♻️ Fallback local • {formatted[1]} — respaldo",
+        shared_notes.format_note(f"ℹ️ Fallback local • {formatted[1]} — respaldo"),
         "#### 💱 FX",
-        f"⚠️ API FX con errores • {formatted[2]} (123 ms) — boom",
-        f"♻️ Uso de caché • {formatted[3]} (edad 46s)",
+        shared_notes.format_note(
+            f"⚠️ API FX con errores • {formatted[2]} (123 ms) — boom"
+        ),
+        shared_notes.format_note(
+            f"✅ Uso de caché • {formatted[3]} (edad 46s)"
+        ),
         "#### ⏱️ Latencias",
         f"- Portafolio: 457 ms • fuente: api • fresh • {formatted[4]}",
         f"- Cotizaciones: 789 ms • fuente: yfinance • items: 12 • with gaps • {formatted[5]}",

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -181,10 +181,10 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
     assert dataframes, "Expected Streamlit dataframe component after execution"
     captions = [element.value for element in app.get("caption")]
     assert any("Yahoo Finance" in caption for caption in captions)
-    assert (
+    expected_info_caption = shared_notes.format_note(
         "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento de ingresos, payout, racha de dividendos, CAGR, crecimiento de EPS, buybacks e inclusión de Latam requieren datos en vivo de Yahoo."
-        in captions
     )
+    assert expected_info_caption in captions
     fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
     markdown_blocks = [element.value for element in app.get("markdown")]
     assert not any(fallback_note in block for block in markdown_blocks)
@@ -289,7 +289,10 @@ def test_fallback_legend_and_notes_displayed_when_stub_source() -> None:
         {"table": df, "notes": [fallback_note, extra_note], "source": "stub"}
     )
     captions = [element.value for element in app.get("caption")]
-    assert any("Resultados simulados" in caption for caption in captions)
+    expected_stub_caption = shared_notes.format_note(
+        "⚠️ Resultados simulados (Yahoo no disponible)"
+    )
+    assert expected_stub_caption in captions
     markdown_blocks = [element.value for element in app.get("markdown")]
     formatted_fallback = shared_notes.format_note(fallback_note)
     formatted_extra = shared_notes.format_note(extra_note)
@@ -310,12 +313,18 @@ def test_stub_source_displays_warning_caption_and_notes() -> None:
         {"table": df, "notes": [extra_note], "source": "stub"}
     )
     captions = [element.value for element in app.get("caption")]
-    assert "⚠️ Resultados simulados (Yahoo no disponible)" in captions
+    expected_stub_caption = shared_notes.format_note(
+        "⚠️ Resultados simulados (Yahoo no disponible)"
+    )
+    expected_info_caption = shared_notes.format_note(
+        "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento de ingresos, payout, racha de dividendos, CAGR, crecimiento de EPS, buybacks e inclusión de Latam requieren datos en vivo de Yahoo."
+    )
+    assert expected_stub_caption in captions
     assert not any(
         "Resultados obtenidos de Yahoo Finance" in caption for caption in captions
     )
-    assert any(
-        "ℹ️ Los filtros avanzados" in caption for caption in captions
+    assert (
+        expected_info_caption in captions
     ), "Expected informational caption to remain visible"
     markdown_blocks = [element.value for element in app.get("markdown")]
     assert any(extra_note in block for block in markdown_blocks)

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -8,8 +8,8 @@ import streamlit as st
 
 from services.health import get_health_metrics
 from shared.time_provider import TimeProvider
+from shared.ui.notes import format_note
 from shared.version import __version__
-from shared.time_provider import TimeProvider
 
 
 def _format_timestamp(ts: Optional[float]) -> str:
@@ -25,12 +25,12 @@ def _format_iol_status(data: Optional[dict]) -> str:
     if not data:
         return "_Sin actividad registrada._"
     status = data.get("status")
-    icon = "✅" if status == "success" else "⚠️"
     label = "Refresh correcto" if status == "success" else "Error al refrescar"
     ts = _format_timestamp(data.get("ts"))
     detail = data.get("detail")
     detail_txt = f" — {detail}" if detail else ""
-    return f"{icon} {label} • {ts}{detail_txt}"
+    prefix = "✅" if status == "success" else "⚠️"
+    return format_note(f"{prefix} {label} • {ts}{detail_txt}")
 
 
 def _format_yfinance_status(data: Optional[dict]) -> str:
@@ -39,40 +39,40 @@ def _format_yfinance_status(data: Optional[dict]) -> str:
     source = data.get("source") or "desconocido"
     mapping = {
         "yfinance": ("✅", "Datos de Yahoo Finance"),
-        "fallback": ("♻️", "Fallback local"),
+        "fallback": ("ℹ️", "Fallback local"),
         "error": ("⚠️", "Error o sin datos"),
     }
     icon, label = mapping.get(source, ("ℹ️", f"Fuente: {source}"))
     ts = _format_timestamp(data.get("ts"))
     detail = data.get("detail")
     detail_txt = f" — {detail}" if detail else ""
-    return f"{icon} {label} • {ts}{detail_txt}"
+    return format_note(f"{icon} {label} • {ts}{detail_txt}")
 
 
 def _format_fx_api_status(data: Optional[dict]) -> str:
     if not data:
         return "_Sin llamadas a la API FX._"
     status = data.get("status")
-    icon = "✅" if status == "success" else "⚠️"
     label = "API FX OK" if status == "success" else "API FX con errores"
     ts = _format_timestamp(data.get("ts"))
     elapsed = data.get("elapsed_ms")
     elapsed_txt = f"{float(elapsed):.0f} ms" if isinstance(elapsed, (int, float)) else "s/d"
     detail = data.get("error")
     detail_txt = f" — {detail}" if detail else ""
-    return f"{icon} {label} • {ts} ({elapsed_txt}){detail_txt}"
+    prefix = "✅" if status == "success" else "⚠️"
+    return format_note(f"{prefix} {label} • {ts} ({elapsed_txt}){detail_txt}")
 
 
 def _format_fx_cache_status(data: Optional[dict]) -> str:
     if not data:
         return "_Sin uso de caché registrado._"
     mode = data.get("mode")
-    icon = "♻️" if mode == "hit" else "🔄"
+    icon = "✅" if mode == "hit" else "ℹ️"
     label = "Uso de caché" if mode == "hit" else "Actualización"
     ts = _format_timestamp(data.get("ts"))
     age = data.get("age")
     age_txt = f"{float(age):.0f}s" if isinstance(age, (int, float)) else "s/d"
-    return f"{icon} {label} • {ts} (edad {age_txt})"
+    return format_note(f"{icon} {label} • {ts} (edad {age_txt})")
 
 
 def _format_latency_line(label: str, data: Optional[dict]) -> str:

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -256,11 +256,13 @@ def render_opportunities_tab() -> None:
             st.dataframe(table, use_container_width=True)
 
         if source == "stub":
-            st.caption("⚠️ Resultados simulados (Yahoo no disponible)")
+            st.caption(shared_notes.format_note("⚠️ Resultados simulados (Yahoo no disponible)"))
         else:
             st.caption("Resultados obtenidos de Yahoo Finance")
         st.caption(
-            "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento de ingresos, payout, racha de dividendos, CAGR, crecimiento de EPS, buybacks e inclusión de Latam requieren datos en vivo de Yahoo."
+            shared_notes.format_note(
+                "ℹ️ Los filtros avanzados de capitalización, P/E, crecimiento de ingresos, payout, racha de dividendos, CAGR, crecimiento de EPS, buybacks e inclusión de Latam requieren datos en vivo de Yahoo."
+            )
         )
 
         if notes:


### PR DESCRIPTION
## Summary
- route health sidebar status messages through shared.ui.notes.format_note to standardize iconography
- update Streamlit UI helpers to reuse the shared formatter for alert captions and adjust tests to expect the new rendering

## Testing
- PYTHONPATH=. pytest tests/test_health_sidebar_rendering.py ui/test/test_health_sidebar.py tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68db61a76a508332bacc65d1d593e87d