### PR TITLE
Ensure health sidebar notes use shared formatter

### DIFF
--- a/tests/test_health_sidebar_rendering.py
+++ b/tests/test_health_sidebar_rendering.py
@@ -23,6 +23,8 @@ from shared.version import __version__
 
 _ORIGINAL_STREAMLIT = st
 _PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
 _SCRIPT = textwrap.dedent(
     f"""
     import sys
@@ -161,11 +163,11 @@ def test_sidebar_formats_populated_metrics(monkeypatch) -> None:
     formatted = [str(TimeProvider.from_timestamp(ts)) for ts in timestamps]
     expected_lines = {
         "#### 🔐 Conexión IOL",
-        f"✅ Refresh correcto • {formatted[0]} — OK",
+        f":white_check_mark: **Refresh correcto • {formatted[0]} — OK**",
         "#### 📈 Yahoo Finance",
         f"♻️ Fallback local • {formatted[1]} — respaldo",
         "#### 💱 FX",
-        f"⚠️ API FX con errores • {formatted[2]} (123 ms) — boom",
+        f":warning: **API FX con errores • {formatted[2]} (123 ms) — boom**",
         f"♻️ Uso de caché • {formatted[3]} (edad 46s)",
         "#### ⏱️ Latencias",
         f"- Portafolio: 457 ms • fuente: api • fresh • {formatted[4]}",

--- a/tests/ui/test_health_sidebar_notes.py
+++ b/tests/ui/test_health_sidebar_notes.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+import textwrap
+from typing import Iterable
+
+import streamlit as _streamlit_module
+from streamlit.runtime.secrets import Secrets
+from streamlit.testing.v1 import AppTest
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+import ui.health_sidebar as health_sidebar  # noqa: E402  - added to sys.path above
+
+
+def _resolve_streamlit_module():
+    if getattr(_streamlit_module, "__file__", None) and hasattr(_streamlit_module, "sidebar"):
+        return _streamlit_module
+
+    for name in list(sys.modules):
+        if name == "streamlit" or name.startswith("streamlit."):
+            sys.modules.pop(name, None)
+
+    import streamlit as real_streamlit
+
+    return real_streamlit
+
+
+def _normalize_streamlit_module() -> None:
+    global st
+    if sys.modules.get("streamlit") is not _ORIGINAL_STREAMLIT:
+        sys.modules["streamlit"] = _ORIGINAL_STREAMLIT
+    if st is not _ORIGINAL_STREAMLIT:
+        st = _ORIGINAL_STREAMLIT
+    if getattr(health_sidebar, "st", None) is not _ORIGINAL_STREAMLIT:
+        health_sidebar.st = _ORIGINAL_STREAMLIT
+
+
+st = _resolve_streamlit_module()
+sys.modules["streamlit"] = st
+_ORIGINAL_STREAMLIT = st
+
+
+class _DummySidebar:
+    def __init__(self) -> None:
+        self.headers: list[str] = []
+        self.captions: list[str] = []
+        self.markdown_calls: list[str] = []
+
+    def header(self, text: str) -> None:
+        self.headers.append(text)
+
+    def caption(self, text: str) -> None:
+        self.captions.append(text)
+
+    def markdown(self, text: str) -> None:
+        self.markdown_calls.append(text)
+
+
+class _DummyStreamlit:
+    def __init__(self) -> None:
+        self.sidebar = _DummySidebar()
+
+
+@pytest.fixture
+def _dummy_metrics() -> dict[str, dict[str, object]]:
+    return {
+        "iol_refresh": {"status": "success", "detail": "OK", "ts": None},
+        "yfinance": {"source": "yfinance", "detail": "cache", "ts": None},
+        "fx_api": {"status": "error", "error": "boom", "elapsed_ms": 250.5, "ts": None},
+        "fx_cache": {"mode": "hit", "age": 12.3, "ts": None},
+        "portfolio": {
+            "elapsed_ms": 123.4,
+            "source": "api",
+            "detail": "fresh",
+            "ts": None,
+        },
+        "quotes": {
+            "elapsed_ms": 456.7,
+            "source": "yfinance",
+            "count": 5,
+            "detail": "gap",
+            "ts": None,
+        },
+    }
+
+
+def test_render_health_sidebar_uses_shared_note_formatter(
+    monkeypatch: pytest.MonkeyPatch, _dummy_metrics: dict[str, dict[str, object]]
+) -> None:
+    dummy_streamlit = _DummyStreamlit()
+    monkeypatch.setattr(health_sidebar, "st", dummy_streamlit)
+    monkeypatch.setattr(health_sidebar, "get_health_metrics", lambda: _dummy_metrics)
+
+    captured: list[str] = []
+
+    def _fake_format(note: str) -> str:
+        captured.append(note)
+        return f"formatted::{note}"
+
+    monkeypatch.setattr(health_sidebar.shared_notes, "format_note", _fake_format)
+
+    health_sidebar.render_health_sidebar()
+
+    fx_lines = list(
+        health_sidebar._format_fx_section(
+            _dummy_metrics["fx_api"], _dummy_metrics["fx_cache"]
+        )
+    )
+    latency_lines = list(
+        health_sidebar._format_latency_section(
+            _dummy_metrics["portfolio"], _dummy_metrics["quotes"]
+        )
+    )
+    expected_notes: list[str] = [
+        health_sidebar._format_iol_status(_dummy_metrics["iol_refresh"]),
+        health_sidebar._format_yfinance_status(_dummy_metrics["yfinance"]),
+        *fx_lines,
+        *latency_lines,
+    ]
+
+    assert captured == expected_notes
+
+    expected_markdown_sequence: list[str] = [
+        "#### 🔐 Conexión IOL",
+        f"formatted::{expected_notes[0]}",
+        "#### 📈 Yahoo Finance",
+        f"formatted::{expected_notes[1]}",
+        "#### 💱 FX",
+        *(f"formatted::{line}" for line in fx_lines),
+        "#### ⏱️ Latencias",
+        *(f"formatted::{line}" for line in latency_lines),
+    ]
+
+    assert dummy_streamlit.sidebar.markdown_calls == expected_markdown_sequence
+
+
+_SMOKE_SCRIPT = textwrap.dedent(
+    f"""
+    import sys
+    sys.path.insert(0, {repr(str(_PROJECT_ROOT))})
+    import streamlit as st
+    from ui.health_sidebar import render_health_sidebar
+
+    tabs = st.tabs(["Resumen", "Detalle", "Histórico"])
+    for index, tab in enumerate(tabs):
+        with tab:
+            st.write(f"Tab {{index}}")
+
+    render_health_sidebar()
+    """
+)
+
+
+def test_health_sidebar_smoke_renders_across_tabs(
+    monkeypatch: pytest.MonkeyPatch, _dummy_metrics: dict[str, dict[str, object]]
+) -> None:
+    _normalize_streamlit_module()
+    if not hasattr(st, "secrets"):
+        st.secrets = Secrets({})
+
+    monkeypatch.setattr("services.health.get_health_metrics", lambda: _dummy_metrics)
+    monkeypatch.setattr(health_sidebar, "get_health_metrics", lambda: _dummy_metrics)
+
+    app = AppTest.from_string(_SMOKE_SCRIPT)
+    app.run()
+
+    sidebar_markdown = [element.value for element in app.sidebar if element.type == "markdown"]
+
+    def _collect_main_markdown() -> Iterable[str]:
+        return [element.value for element in app.get("markdown") if element.value.startswith("Tab ")]
+
+    assert any(value.startswith(":white_check_mark:") for value in sidebar_markdown)
+    assert any(value.startswith(":warning:") for value in sidebar_markdown)
+    assert len(list(_collect_main_markdown())) == 3

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -8,8 +8,8 @@ import streamlit as st
 
 from services.health import get_health_metrics
 from shared.time_provider import TimeProvider
+from shared.ui import notes as shared_notes
 from shared.version import __version__
-from shared.time_provider import TimeProvider
 
 
 def _format_timestamp(ts: Optional[float]) -> str:
@@ -116,18 +116,22 @@ def render_health_sidebar() -> None:
     sidebar.caption("Monitorea la procedencia y el rendimiento de los datos cargados.")
 
     sidebar.markdown("#### 🔐 Conexión IOL")
-    sidebar.markdown(_format_iol_status(metrics.get("iol_refresh")))
+    sidebar.markdown(
+        shared_notes.format_note(_format_iol_status(metrics.get("iol_refresh")))
+    )
 
     sidebar.markdown("#### 📈 Yahoo Finance")
-    sidebar.markdown(_format_yfinance_status(metrics.get("yfinance")))
+    sidebar.markdown(
+        shared_notes.format_note(_format_yfinance_status(metrics.get("yfinance")))
+    )
 
     sidebar.markdown("#### 💱 FX")
     for line in _format_fx_section(metrics.get("fx_api"), metrics.get("fx_cache")):
-        sidebar.markdown(line)
+        sidebar.markdown(shared_notes.format_note(line))
 
     sidebar.markdown("#### ⏱️ Latencias")
     for line in _format_latency_section(metrics.get("portfolio"), metrics.get("quotes")):
-        sidebar.markdown(line)
+        sidebar.markdown(shared_notes.format_note(line))
 
 
 __all__ = ["render_health_sidebar"]


### PR DESCRIPTION
## Summary
- wrap health sidebar note lines with the shared UI note formatter to unify styling
- adjust existing sidebar rendering expectations for the new formatting icons
- add focused and smoke Streamlit tests that spy on the formatter and exercise multiple tabs

## Testing
- pytest tests/ui/test_health_sidebar_notes.py tests/test_health_sidebar_rendering.py

------
https://chatgpt.com/codex/tasks/task_e_68db61a864208332af810c8f74ffa272