### PR TITLE
Release 0.3.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Changed
-- El valor por defecto de `MAX_RESULTS` se consolidó en `shared.config.Settings` (20) y la UI ahora inicializa el selector con ese número para respetar overrides de configuración.
+
+## [0.3.15] - 2025-09-30
+### Fixed
+- El healthcheck del sidebar ahora respeta el valor por defecto de `MAX_RESULTS` consolidado en `shared.config.Settings` (20) y la UI inicializa el selector con ese número para mantener cualquier override de configuración.
 ### Tests
 - Documentado el procedimiento para habilitar `pytest -m live_yahoo` mediante la variable `RUN_LIVE_YF` y advertir sobre su naturaleza no determinista.
 ### Documentation

--- a/README.md
+++ b/README.md
@@ -95,9 +95,9 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión X.Y.Z".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.15".
 
-El sidebar finaliza con un bloque de **Healthcheck (versión X.Y.Z)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.15)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
 
 ## Requisitos de sistema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.14"
+version = "0.3.15"
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import tomllib
 
 
-DEFAULT_VERSION = "0.3.14"
+DEFAULT_VERSION = "0.3.15"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version metadata and fallback to 0.3.15
- record the 0.3.15 sidebar fix and related documentation updates in the changelog
- align README examples with the 0.3.15 healthcheck messaging

## Testing
- pytest tests/ui/test_health_sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68db6895a3748332ad594e554414e8e8