### PR TITLE
Update 0.3.15 changelog description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.15] - 2025-09-30
 ### Fixed
-- El healthcheck del sidebar ahora respeta el valor por defecto de `MAX_RESULTS` consolidado en `shared.config.Settings` (20) y la UI inicializa el selector con ese número para mantener cualquier override de configuración.
+- El healthcheck del sidebar reutiliza `shared.ui.notes.format_note` para unificar la iconografía y el énfasis de los mensajes con el resto de la UI, evitando divergencias en la presentación de severidades. ([ui/health_sidebar.py](ui/health_sidebar.py))
 ### Tests
-- Documentado el procedimiento para habilitar `pytest -m live_yahoo` mediante la variable `RUN_LIVE_YF` y advertir sobre su naturaleza no determinista.
+- Documentado el procedimiento para habilitar `pytest -m live_yahoo` mediante la variable `RUN_LIVE_YF` y advertir sobre su naturaleza no determinista. ([README.md](README.md#pruebas))
 ### Documentation
-- Documentadas las severidades soportadas por `shared.ui.notes.format_note`, sus prefijos (⚠️/ℹ️/✅/❌) y el helper compartido para mantener mensajes consistentes en la UI.
+- Documentadas las severidades soportadas por `shared.ui.notes.format_note`, sus prefijos (⚠️/ℹ️/✅/❌) y el helper compartido para mantener mensajes consistentes en la UI. ([README.md](README.md#notas-del-listado-y-severidades), [tests/shared/test_notes.py](tests/shared/test_notes.py))
 
 ## [3.0.1]
 ### Changed


### PR DESCRIPTION
## Summary
- align the 0.3.15 changelog entry with the actual sidebar refactor to reuse the shared note formatter
- link the release notes to the README guidance for `pytest -m live_yahoo` and the shared note severity documentation

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68db6aac22dc83328ce6741ba2f6b438