### PR TITLE
Handle missing critical fundamentals in Yahoo screener

### DIFF
--- a/application/screener/opportunities.py
+++ b/application/screener/opportunities.py
@@ -314,24 +314,21 @@ def _apply_filters_and_finalize(
         result = result[mask]
 
     if min_market_cap is not None and market_cap_column in result.columns:
-        series = result[market_cap_column]
-        mask = series >= float(min_market_cap)
-        if allow_na_filters:
-            mask = series.isna() | mask
+        series = pd.to_numeric(result[market_cap_column], errors="coerce")
+        register_missing(series.isna(), "capitalización bursátil")
+        mask = series.notna() & (series >= float(min_market_cap))
         result = result[mask]
 
     if max_pe is not None and pe_ratio_column in result.columns:
-        series = result[pe_ratio_column]
-        mask = series <= float(max_pe)
-        if allow_na_filters:
-            mask = series.isna() | mask
+        series = pd.to_numeric(result[pe_ratio_column], errors="coerce")
+        register_missing(series.isna(), "P/E")
+        mask = series.notna() & (series <= float(max_pe))
         result = result[mask]
 
     if min_revenue_growth is not None and revenue_growth_column in result.columns:
-        series = result[revenue_growth_column]
-        mask = series >= float(min_revenue_growth)
-        if allow_na_filters:
-            mask = series.isna() | mask
+        series = pd.to_numeric(result[revenue_growth_column], errors="coerce")
+        register_missing(series.isna(), "crecimiento de ingresos")
+        mask = series.notna() & (series >= float(min_revenue_growth))
         result = result[mask]
 
     if trailing_eps_column in result.columns:

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -519,6 +519,27 @@ def test_notes_block_formats_truncation_and_shortage_notes() -> None:
     assert f"- **{shortage_note}**" in markdown_blocks
 
 
+def test_notes_block_displays_critical_missing_fundamental_warning() -> None:
+    df = pd.DataFrame(
+        {
+            "ticker": ["AAPL"],
+            "price": [180.0],
+            "score_compuesto": [75.0],
+        }
+    )
+    critical_note = (
+        "Se descartó el ticker MISS por falta de datos críticos de capitalización bursátil."
+    )
+
+    app, _ = _run_app_with_result(
+        {"table": df, "notes": [critical_note], "source": "yahoo"}
+    )
+
+    markdown_blocks = [element.value for element in app.get("markdown")]
+    formatted_note = shared_notes.format_note(critical_note)
+    assert formatted_note in markdown_blocks
+
+
 def test_opportunities_tab_not_rendered_when_flag_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr("shared.settings.FEATURE_OPPORTUNITIES_TAB", False)
     monkeypatch.delenv("FEATURE_OPPORTUNITIES_TAB", raising=False)


### PR DESCRIPTION
## Summary
- ensure Yahoo filters drop rows with missing market cap, P/E and revenue growth while logging critical notes
- cover incomplete fundamentals with a dedicated screener test and expect critical notes
- assert the opportunities UI renders the critical warning generated by Yahoo

## Testing
- pytest tests/application/test_screener_yahoo.py::test_run_screener_yahoo_discards_rows_missing_critical_fundamentals -q
- pytest tests/ui/test_opportunities_tab.py::test_notes_block_displays_critical_missing_fundamental_warning -q

------
https://chatgpt.com/codex/tasks/task_e_68dbed95c1988332b6932f71d6b3e98d