### PR TITLE
Add telemetry note for stub screener fallback

### DIFF
--- a/application/screener/opportunities.py
+++ b/application/screener/opportunities.py
@@ -828,6 +828,8 @@ def run_screener_stub(
         DataFrame. When ``False`` those columns are omitted.
     """
 
+    loop_start = time.perf_counter()
+
     df = pd.DataFrame(_BASE_OPPORTUNITIES)
     manual = _normalise_tickers(manual_tickers)
     excluded = set(_normalise_tickers(exclude_tickers))
@@ -879,8 +881,23 @@ def run_screener_stub(
         allowed_sectors=_normalize_sector_filters(sectors),
     )
 
+    elapsed = time.perf_counter() - loop_start
+    processed_count = int(len(result.index))
+
+    LOGGER.info(
+        "Stub screener processed %s tickers in %.3f seconds",
+        processed_count,
+        elapsed,
+    )
+
+    telemetry_note = (
+        f"ℹ️ Stub procesó {processed_count} tickers en {elapsed:.2f} segundos"
+    )
+
     notes = list(result.attrs.pop("_notes", []))
-    return (result, notes) if notes else result
+    notes.append(telemetry_note)
+
+    return result, notes
 
 
 def _is_valid_number(value: float | int | pd.NA | None) -> bool:

--- a/tests/integration/test_opportunities_flow.py
+++ b/tests/integration/test_opportunities_flow.py
@@ -631,6 +631,7 @@ def test_opportunities_flow_applies_critical_filters_with_stub_dataset(
     notes = [block for block in markdown_blocks if "Se muestran" in block]
     assert notes, "Expected truncation warning to be present in notes"
     assert any("máximo solicitado" in note for note in notes)
+    assert any("Stub procesó" in block for block in markdown_blocks)
 
     captions = [element.value for element in app.get("caption")]
     assert any("Resultados simulados" in caption for caption in captions)
@@ -769,6 +770,7 @@ def test_opportunities_flow_uses_preset_with_stub_fallback(
     markdown_blocks = [element.value for element in app.get("markdown")]
     assert any("Datos simulados" in block for block in markdown_blocks)
     assert any("Filtros aplicados" in block for block in markdown_blocks)
+    assert any("Stub procesó" in block for block in markdown_blocks)
 
     captions = [element.value for element in app.get("caption")]
     assert any("Resultados simulados" in caption for caption in captions)


### PR DESCRIPTION
## Summary
- log the number of processed tickers and execution time when running the stub screener
- append a telemetry note to the stub screener output and update tests to assert its presence

## Testing
- pytest tests/application/test_screener_stub.py
- pytest tests/integration/test_opportunities_flow.py::test_opportunities_flow_applies_critical_filters_with_stub_dataset tests/integration/test_opportunities_flow.py::test_opportunities_flow_uses_preset_with_stub_fallback

------
https://chatgpt.com/codex/tasks/task_e_68dc2e49385c8332932fd8f1fcf5f6a2