### PR TITLE
Add nightly stub fallback sweep metrics job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,16 @@ name: CI
 on:
   push:
   pull_request:
+  schedule:
+    - cron: '0 3 * * *' # Ejecuta el barrido prolongado del stub diariamente a las 03:00 UTC.
   workflow_dispatch:
     inputs:
       run-live-yahoo:
         description: 'Run live Yahoo Finance smoke-test (uses RUN_LIVE_YF=1)'
+        type: boolean
+        default: false
+      run-stub-sweep:
+        description: 'Run prolonged stub fallback & preset sweep'
         type: boolean
         default: false
 
@@ -59,3 +65,101 @@ jobs:
           pip install pytest
       - name: Run live Yahoo Finance smoke-test
         run: pytest -m live_yahoo
+
+  stub-fallback-sweep:
+    name: stub-fallback-sweep
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run-stub-sweep == 'true')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+      - name: Run stub fallback preset sweep
+        id: stub_sweep
+        run: |
+          set -o pipefail
+          start="$(date +%s)"
+          pytest \
+            tests/application/test_screener_stub.py \
+            tests/integration/test_opportunities_flow.py::test_opportunities_flow_stub_failover_is_consistent_across_runs \
+            tests/integration/test_opportunities_flow.py::test_opportunities_flow_uses_preset_with_stub_fallback \
+            tests/ui/test_opportunities_tab.py::test_fallback_legend_and_notes_displayed_when_stub_source \
+            tests/ui/test_opportunities_tab.py::test_stub_source_displays_warning_caption_and_notes \
+            tests/ui/test_opportunities_tab.py::test_selectbox_preset_applies_recommended_values_and_allows_manual_override \
+            | tee stub_sweep.log
+          exit_code="${PIPESTATUS[0]}"
+          end="$(date +%s)"
+          duration=$((end - start))
+          echo "duration=$duration" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          echo "SWEEP_DURATION=$duration" >> "$GITHUB_ENV"
+          echo "SWEEP_EXIT_CODE=$exit_code" >> "$GITHUB_ENV"
+          exit "$exit_code"
+      - name: Extraer métricas del stub sweep
+        if: always()
+        run: |
+          python - <<'PY'
+import json
+import os
+import pathlib
+import re
+
+log_path = pathlib.Path('stub_sweep.log')
+summary_line = ''
+if log_path.exists():
+    for line in log_path.read_text(encoding='utf-8').splitlines():
+        if '==' in line and ' in ' in line:
+            summary_line = line.strip()
+    if not summary_line:
+        summary_line = log_path.read_text(encoding='utf-8').splitlines()[-1].strip()
+
+stats = {}
+match = re.search(r'==\s*(.+?)\s*==', summary_line)
+if match:
+    for chunk in match.group(1).split(','):
+        chunk = chunk.strip()
+        m = re.match(r'(\d+)\s+(\w+)', chunk)
+        if m:
+            stats[m.group(2).lower()] = int(m.group(1))
+
+metrics = {
+    'summary_line': summary_line,
+    'duration_seconds': int(os.getenv('SWEEP_DURATION', '0')),
+    'exit_code': int(os.getenv('SWEEP_EXIT_CODE', '0')),
+    **stats,
+}
+for key in ('passed', 'failed', 'errors', 'skipped'):
+    metrics.setdefault(key, 0)
+metrics_path = pathlib.Path('stub_sweep_metrics.json')
+metrics_path.write_text(json.dumps(metrics, indent=2), encoding='utf-8')
+print(metrics_path.read_text(encoding='utf-8'))
+
+step_summary = pathlib.Path(os.environ.get('GITHUB_STEP_SUMMARY', ''))
+if step_summary:
+    with step_summary.open('a', encoding='utf-8') as fh:
+        fh.write('## Stub fallback sweep metrics\n')
+        if summary_line:
+            fh.write(f"- Results: {summary_line}\n")
+        fh.write(f"- Duration: {metrics['duration_seconds']} s\n")
+        fh.write(f"- Exit code: {metrics['exit_code']}\n")
+        if stats:
+            fh.write(f"- Passed: {stats.get('passed', 0)}\n")
+            fh.write(f"- Failed: {stats.get('failed', 0)}\n")
+            fh.write(f"- Errors: {stats.get('errors', 0)}\n")
+            fh.write(f"- Skipped: {stats.get('skipped', 0)}\n")
+        fh.write('\n')
+PY
+      - name: Upload stub sweep artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: stub-sweep-logs
+          path: |
+            stub_sweep.log
+            stub_sweep_metrics.json

--- a/README.md
+++ b/README.md
@@ -362,6 +362,25 @@ Al hacerlo, GitHub Actions exportará `RUN_LIVE_YF=1` antes de invocar el
 marcador `live_yahoo`. Usa este job sólo cuando necesites verificar la
 integración en vivo o validar incidentes relacionados con Yahoo Finance.
 
+### Barrido prolongado del stub y presets en CI
+
+Adicionalmente, el workflow programa un job nocturno `stub-fallback-sweep`
+que se ejecuta todos los días a las **03:00 UTC** para ejercitar el stub y
+los presets recomendados. Este barrido ejecuta la batería prolongada de
+pruebas de fallback sobre el stub (incluye validaciones de notas, presets y
+consistencia entre corridas) y registra métricas de duración junto con los
+totales de `passed/failed/errors/skipped`.
+
+Para detonarlo manualmente:
+
+1. Ingresa a **Actions → CI → Run workflow**.
+2. Habilita el toggle **Run prolonged stub fallback & preset sweep**.
+3. Ejecuta el workflow.
+
+Al finalizar, revisa el resumen del job en GitHub Actions o descarga el
+artefacto `stub-sweep-logs`, que incluye `stub_sweep.log` y
+`stub_sweep_metrics.json` con las métricas necesarias para seguimiento de QA.
+
 ## Tiempos de referencia
 
 Los siguientes tiempos se observan en condiciones normales (aprox. 20 posiciones):


### PR DESCRIPTION
## Summary
- schedule a nightly stub fallback sweep job with a manual workflow_dispatch toggle
- capture duration, exit code, and pass/fail counts for the stub sweep and upload the logs as artifacts
- document how QA can trigger and consume the new job metrics in the README QA/CI section

## Testing
- not run (workflow updates only)


------
https://chatgpt.com/codex/tasks/task_e_68dc99e407708332ad18080c9207b7f7