### PR TITLE
Add warning severity to stub screener runtime telemetry

### DIFF
--- a/application/screener/opportunities.py
+++ b/application/screener/opportunities.py
@@ -1302,18 +1302,19 @@ def run_screener_stub(
     if filter_metrics:
         metrics_summary = ", ".join(filter_metrics)
 
-    LOGGER.info(
-        "Stub screener processed %s tickers in %.3f seconds (resultado: %s). Discards: %s",
-        universe_count,
-        elapsed,
-        result_count,
-        metrics_summary,
+    warn_threshold = getattr(
+        shared_settings,
+        "STUB_MAX_RUNTIME_WARN",
+        getattr(shared_settings, "stub_max_runtime_warn", 0.25),
     )
-
+    note_prefix = "⚠️" if elapsed > warn_threshold else "ℹ️"
     telemetry_note = (
-        f"ℹ️ Stub procesó {universe_count} tickers en {elapsed:.2f} segundos "
+        f"{note_prefix} Stub procesó {universe_count} tickers en {elapsed:.2f} segundos "
         f"(resultado: {result_count})"
     )
+
+    log_method = LOGGER.warning if note_prefix == "⚠️" else LOGGER.info
+    log_method("%s. Descartes: %s", telemetry_note, metrics_summary)
 
     notes_attr = result.attrs.setdefault("_notes", [])
     notes_attr.append(telemetry_note)

--- a/tests/integration/test_opportunities_flow.py
+++ b/tests/integration/test_opportunities_flow.py
@@ -705,7 +705,7 @@ def test_fallback_stub_emits_runtime_telemetry_note(
 
     def _extract_stub_note(notes: Iterable[str]) -> str:
         for note in notes:
-            if note.startswith("ℹ️ Stub procesó"):
+            if note.startswith("ℹ️ Stub procesó") or note.startswith("⚠️ Stub procesó"):
                 return note
         raise AssertionError("Se esperaba una nota del stub")
 
@@ -756,7 +756,7 @@ def test_fallback_stub_emits_runtime_telemetry_note(
 
     slow_note = _extract_stub_note(notes_slow)
     severity_slow, _, matched_slow = shared_notes.classify_note(slow_note)
-    assert severity_slow == "info"
+    assert severity_slow == "warning"
     assert matched_slow
     assert df_slow.attrs["_notes"][-1] == slow_note
 


### PR DESCRIPTION
## Summary
- add configurable runtime threshold to the stub screener and log the resulting telemetry note with matching severity
- ensure stub telemetry notes propagate with warning severity when runtime exceeds the threshold in application and integration tests

## Testing
- pytest tests/application/test_screener_stub.py tests/integration/test_opportunities_flow.py::test_fallback_stub_emits_runtime_telemetry_note

------
https://chatgpt.com/codex/tasks/task_e_68dd110cfcf08332827e4cf79f90772d