### PR TITLE
Enhance stub screener telemetry reporting

### DIFF
--- a/tests/integration/test_opportunities_flow.py
+++ b/tests/integration/test_opportunities_flow.py
@@ -733,6 +733,7 @@ def test_fallback_stub_emits_runtime_telemetry_note(
     severity_fast, _, matched_fast = shared_notes.classify_note(fast_note)
     assert severity_fast == "info"
     assert matched_fast
+    assert "descartados" in fast_note or "sin descartes" in fast_note
     assert df_fast.attrs["_notes"][-1] == fast_note
 
     _configure_perf_counter([20.0, 20.5])
@@ -758,6 +759,7 @@ def test_fallback_stub_emits_runtime_telemetry_note(
     severity_slow, _, matched_slow = shared_notes.classify_note(slow_note)
     assert severity_slow == "warning"
     assert matched_slow
+    assert "descartados" in slow_note or "sin descartes" in slow_note
     assert df_slow.attrs["_notes"][-1] == slow_note
 
 


### PR DESCRIPTION
## Summary
- enrich the stub screener telemetry note with runtime and filter discard statistics
- log the telemetry through the existing logger and propagate it via dataframe attributes for UI display
- adjust unit and integration tests to assert the new telemetry format and classification

## Testing
- pytest tests/application/test_screener_stub.py::test_filters_apply_to_base_dataset tests/application/test_screener_stub.py::test_run_screener_stub_classifies_telemetry_by_runtime tests/integration/test_opportunities_flow.py::test_fallback_stub_emits_runtime_telemetry_note


------
https://chatgpt.com/codex/tasks/task_e_68dd273200d08332a8027acfe02f17c4