### PR TITLE
Add telemetry summary to stub screener notes

### DIFF
--- a/application/screener/opportunities.py
+++ b/application/screener/opportunities.py
@@ -1278,6 +1278,8 @@ def run_screener_stub(
 
     elapsed = time.perf_counter() - loop_start
     result_count = int(result.index.size)
+    discarded_count = max(universe_count - result_count, 0)
+    discarded_ratio = (discarded_count / universe_count) if universe_count else 0.0
 
     filter_metrics: list[str] = []
     drop_summary_entries: list[tuple[str, str, int]] = []
@@ -1320,11 +1322,10 @@ def run_screener_stub(
     note_prefix = "⚠️" if elapsed > warn_threshold else "ℹ️"
     telemetry_note = (
         f"{note_prefix} Stub procesó {universe_count} tickers en {elapsed:.2f} segundos "
-        f"({drop_summary}, resultado: {result_count})"
+        f"({discarded_ratio:.0%} descartados, resultado: {result_count}; {drop_summary})"
     )
 
-    log_method = LOGGER.warning if note_prefix == "⚠️" else LOGGER.info
-    log_method("%s. Descartes: %s", telemetry_note, metrics_summary)
+    LOGGER.info("%s. Descartes: %s", telemetry_note, metrics_summary)
 
     notes_attr = result.attrs.setdefault("_notes", [])
     notes_attr.append(telemetry_note)

--- a/tests/application/test_screener_stub.py
+++ b/tests/application/test_screener_stub.py
@@ -56,7 +56,14 @@ def _assert_has_stub_note(notes: list[str], expected_severity: str = "info") -> 
     assert severity == expected_severity
     assert matched, "La nota del stub debería clasificarse por prefijo"
     assert content.startswith("Stub procesó "), "La nota debería describir la telemetría"
-    assert "descartados" in note or "sin descartes" in note
+    telemetry_match = re.search(
+        r"Stub procesó (\d+) tickers en (\d+\.\d{2}) segundos \((\d+)% descartados, resultado: (\d+); (.+)\)",
+        note,
+    )
+    assert telemetry_match, note
+    universe = int(telemetry_match.group(1))
+    result = int(telemetry_match.group(4))
+    assert universe >= result >= 0
     return note
 
 

--- a/tests/integration/test_opportunities_flow.py
+++ b/tests/integration/test_opportunities_flow.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import importlib.util
+import re
 import sys
 import time
 from pathlib import Path
@@ -733,7 +734,10 @@ def test_fallback_stub_emits_runtime_telemetry_note(
     severity_fast, _, matched_fast = shared_notes.classify_note(fast_note)
     assert severity_fast == "info"
     assert matched_fast
-    assert "descartados" in fast_note or "sin descartes" in fast_note
+    assert re.search(
+        r"Stub procesó \d+ tickers en \d+\.\d{2} segundos \(\d+% descartados, resultado: \d+; .+\)",
+        fast_note,
+    )
     assert df_fast.attrs["_notes"][-1] == fast_note
 
     _configure_perf_counter([20.0, 20.5])
@@ -759,7 +763,10 @@ def test_fallback_stub_emits_runtime_telemetry_note(
     severity_slow, _, matched_slow = shared_notes.classify_note(slow_note)
     assert severity_slow == "warning"
     assert matched_slow
-    assert "descartados" in slow_note or "sin descartes" in slow_note
+    assert re.search(
+        r"Stub procesó \d+ tickers en \d+\.\d{2} segundos \(\d+% descartados, resultado: \d+; .+\)",
+        slow_note,
+    )
     assert df_slow.attrs["_notes"][-1] == slow_note
 
 


### PR DESCRIPTION
## Summary
- add runtime discard telemetry to the stub screener note and log it via info
- propagate the stub telemetry note through dataframe attributes for UI parity
- update stub and integration tests to assert the new telemetry format and severity handling

## Testing
- pytest tests/application/test_screener_stub.py tests/integration/test_opportunities_flow.py


------
https://chatgpt.com/codex/tasks/task_e_68dd2d8fc9dc8332916f2c51e12bc458