### PR TITLE
Add CSV export option to opportunities screening results

### DIFF
--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -407,6 +407,14 @@ def render_opportunities_tab() -> None:
         else:
             st.subheader("Resultados del screening")
             st.dataframe(table, use_container_width=True)
+            csv_payload = table.to_csv(index=False).encode("utf-8")
+            st.download_button(
+                "Descargar resultados (.csv)",
+                data=csv_payload,
+                file_name="oportunidades.csv",
+                mime="text/csv",
+                key="download_opportunities_csv",
+            )
 
         if notes:
             st.markdown("### Notas del screening")


### PR DESCRIPTION
## Summary
- add a CSV download button for non-empty screenings in the opportunities tab
- serialize filtered results to UTF-8 CSV including Yahoo Finance links
- extend the UI test suite to verify the download payload headers and link preservation

## Testing
- pytest tests/ui/test_opportunities_tab.py::test_download_button_exports_screening_results_csv

------
https://chatgpt.com/codex/tasks/task_e_68dd82faec28833287b7c1e104da1eed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added CSV export for Opportunities results. When results are available, users can download them via a “Descargar resultados (.csv)” button (file: oportunidades.csv, MIME: text/csv).

* **Tests**
  * Added UI test to verify the download button exports the screening results as a CSV with the expected headers (e.g., ticker, score_compuesto, Yahoo Finance Link) and correct data payload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->