### PR TITLE
Fix opportunities CSV download button call and dataframe formatting

### DIFF
--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -406,15 +406,15 @@ def render_opportunities_tab() -> None:
             st.info("No se encontraron oportunidades con los filtros seleccionados.")
         else:
             st.subheader("Resultados del screening")
-            st.dataframe(table, use_container_width=True)
-            csv_payload = table.to_csv(index=False).encode("utf-8")
+            display_table = table.copy()
+            csv_payload = display_table.to_csv(index=False).encode("utf-8")
             st.download_button(
                 "Descargar resultados (.csv)",
                 data=csv_payload,
                 file_name="oportunidades.csv",
                 mime="text/csv",
                 key="download_opportunities_csv",
-            display_table = table.copy()
+            )
             link_column = "Yahoo Finance Link"
             column_config: dict[str, st.column_config.Column | st.column_config.LinkColumn] | None = None
             column_order: list[str] | None = None


### PR DESCRIPTION
## Summary
- close the `st.download_button` call in the opportunities tab and restore the following block’s indentation
- reuse the display table for CSV export and rendering so the Yahoo ticker link column is always included

## Testing
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68dd89173b508332bfdcc758729b4f72