### PR TITLE
Show single opportunities table with link column

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -208,6 +208,7 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
     assert int(max_results_inputs[0].value) == shared_settings.max_results
     dataframes = app.get("arrow_data_frame")
     assert dataframes, "Expected Streamlit dataframe component after execution"
+    assert len(dataframes) == 1, "Expected a single dataframe rendered with link column configuration"
     component = dataframes[0]
     display_df = component.value
     assert "Ticker (Yahoo)" in display_df.columns

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -406,14 +406,6 @@ def render_opportunities_tab() -> None:
             st.info("No se encontraron oportunidades con los filtros seleccionados.")
         else:
             st.subheader("Resultados del screening")
-            st.dataframe(table, use_container_width=True)
-            csv_payload = table.to_csv(index=False).encode("utf-8")
-            st.download_button(
-                "Descargar resultados (.csv)",
-                data=csv_payload,
-                file_name="oportunidades.csv",
-                mime="text/csv",
-                key="download_opportunities_csv",
             display_table = table.copy()
             link_column = "Yahoo Finance Link"
             column_config: dict[str, st.column_config.Column | st.column_config.LinkColumn] | None = None
@@ -457,6 +449,15 @@ def render_opportunities_tab() -> None:
                 use_container_width=True,
                 column_config=column_config,
                 column_order=column_order,
+            )
+
+            csv_payload = display_table.to_csv(index=False).encode("utf-8")
+            st.download_button(
+                "Descargar resultados (.csv)",
+                data=csv_payload,
+                file_name="oportunidades.csv",
+                mime="text/csv",
+                key="download_opportunities_csv",
             )
 
         if notes:


### PR DESCRIPTION
## Summary
- render only the enhanced opportunities table configured with the Yahoo link column
- generate the CSV export from the same data shown to the user
- update the UI test to expect a single dataframe render with link configuration

## Testing
- pytest tests/ui/test_opportunities_tab.py -k "button or download" -q

------
https://chatgpt.com/codex/tasks/task_e_68dd8918a60c833282d351d83f219c45