### PR TITLE
Render Yahoo link column directly

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -211,14 +211,19 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
     assert len(dataframes) == 1, "Expected a single dataframe rendered with link column configuration"
     component = dataframes[0]
     display_df = component.value
-    assert "Ticker (Yahoo)" in display_df.columns
+    assert "ticker" in display_df.columns
     assert "Yahoo Finance Link" in display_df.columns
     columns_config = json.loads(component.proto.columns or "{}")
-    ticker_config = columns_config.get("Ticker (Yahoo)")
-    assert ticker_config is not None, "Expected link column configuration for Yahoo ticker"
-    assert ticker_config["type_config"]["type"] == "link"
-    assert ticker_config["type_config"]["display_text"] == r"https://finance.yahoo.com/quote/(.*?)"
-    assert display_df["Ticker (Yahoo)"].tolist() == [
+    link_config = columns_config.get("Yahoo Finance Link")
+    assert link_config is not None, "Expected link column configuration for Yahoo Finance"
+    assert link_config["label"] == "Yahoo Finance Link"
+    assert link_config["type_config"]["type"] == "link"
+    assert link_config["type_config"]["display_text"] == r"https://finance.yahoo.com/quote/(.*?)"
+    column_order = list(component.proto.column_order)
+    assert "ticker" in column_order
+    assert "Yahoo Finance Link" in column_order
+    assert column_order.index("ticker") < column_order.index("Yahoo Finance Link")
+    assert display_df["Yahoo Finance Link"].tolist() == [
         "https://finance.yahoo.com/quote/AAPL",
         "https://finance.yahoo.com/quote/NEE",
     ]

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -411,10 +411,8 @@ def render_opportunities_tab() -> None:
             column_config: dict[str, st.column_config.Column | st.column_config.LinkColumn] | None = None
             column_order: list[str] | None = None
 
-            if {
-                "ticker",
-                link_column,
-            }.issubset(display_table.columns):
+            required_columns = ("ticker", link_column)
+            if set(required_columns).issubset(display_table.columns):
 
                 def _resolve_yahoo_url(row: pd.Series) -> str | None:
                     raw_url = row.get(link_column)
@@ -425,22 +423,22 @@ def render_opportunities_tab() -> None:
                         url = f"https://finance.yahoo.com/quote/{ticker_value}"
                     return url or None
 
-                display_column = "Ticker (Yahoo)"
-                display_table[display_column] = display_table.apply(_resolve_yahoo_url, axis=1)
+                display_table[link_column] = display_table.apply(
+                    _resolve_yahoo_url, axis=1
+                )
                 column_config = {
-                    display_column: st.column_config.LinkColumn(
-                        label="Ticker",
+                    link_column: st.column_config.LinkColumn(
+                        label="Yahoo Finance Link",
                         help="Abrí la ficha del activo en Yahoo Finance.",
                         display_text=r"https://finance.yahoo.com/quote/(.*?)",
                     )
                 }
-                excluded_columns = {"ticker", link_column, display_column}
                 column_order = [
-                    display_column,
+                    *required_columns,
                     *[
                         column
                         for column in display_table.columns
-                        if column not in excluded_columns
+                        if column not in required_columns
                     ],
                 ]
 


### PR DESCRIPTION
## Summary
- reuse the existing Yahoo Finance Link column as the clickable LinkColumn while keeping the ticker visible
- refresh the UI tests to assert the updated column configuration and order

## Testing
- pytest tests/ui/test_opportunities_tab.py -q
- pytest tests/integration/test_opportunities_flow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd929105208332b5f6f3c145da1e3d