### PR TITLE
Avoid duplicating fallback warning in opportunities tab

### DIFF
--- a/controllers/opportunities.py
+++ b/controllers/opportunities.py
@@ -368,10 +368,11 @@ def run_opportunities_controller(
             df, stub_notes = stub_result
         else:
             df = stub_result  # type: ignore[assignment]
-        fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
+        fallback_note: Optional[str] = None
         if failure_reason:
-            fallback_note = f"{fallback_note} — Causa: {failure_reason}"
-        notes.append(fallback_note)
+            fallback_note = f"⚠️ Yahoo no disponible — Causa: {failure_reason}"
+        if fallback_note:
+            notes.append(fallback_note)
         if filters_note:
             notes.append(filters_note)
         if stub_notes:

--- a/tests/controllers/test_opportunities_controller.py
+++ b/tests/controllers/test_opportunities_controller.py
@@ -207,8 +207,7 @@ def test_fallback_to_stub_preserves_filters(monkeypatch: pytest.MonkeyPatch) -> 
     assert stub_calls["sectors"] is None
     assert list(df.columns) == _EXPECTED_COLUMNS
     assert "MSFT" not in set(df["ticker"])
-    assert notes[0].startswith("⚠️ Datos simulados (Yahoo no disponible)")
-    assert "boom" in notes[0]
+    assert notes[0] == "⚠️ Yahoo no disponible — Causa: boom"
     assert notes[1].startswith("ℹ️ Filtros aplicados:")
     assert "score ≥30" in notes[1]
     assert notes[2] == "Stub note"
@@ -303,7 +302,7 @@ def test_excluded_tickers_are_removed_from_stub_results(monkeypatch: pytest.Monk
 
     assert "MSFT" not in set(df["ticker"])
     assert any(ticker == "AAPL" for ticker in df["ticker"])
-    assert notes[0].startswith("⚠️ Datos simulados (Yahoo no disponible)")
+    assert notes[0] == "⚠️ Yahoo no disponible — Causa: boom"
     assert notes[1].startswith("ℹ️ Filtros aplicados:")
     assert "excluye" in notes[1]
     assert source == "stub"
@@ -328,8 +327,7 @@ def test_fallback_includes_unexpected_error_reason(monkeypatch: pytest.MonkeyPat
 
     assert "ticker" in df.columns
     assert source == "stub"
-    assert notes[0].startswith("⚠️ Datos simulados (Yahoo no disponible)")
-    assert "service offline" in notes[0]
+    assert notes[0] == "⚠️ Yahoo no disponible — Causa: service offline"
     assert notes[1].startswith("ℹ️ Filtros aplicados:")
     assert notes[2] == "Stub note"
 

--- a/tests/integration/test_opportunities_flow.py
+++ b/tests/integration/test_opportunities_flow.py
@@ -897,7 +897,7 @@ def test_opportunities_flow_uses_preset_with_stub_fallback(
     assert (scores >= 72).all()
 
     markdown_blocks = [element.value for element in app.get("markdown")]
-    assert any("Datos simulados" in block for block in markdown_blocks)
+    assert any("Yahoo no disponible" in block for block in markdown_blocks)
     assert any("Filtros aplicados" in block for block in markdown_blocks)
     assert any("Stub procesó" in block for block in markdown_blocks)
 

--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -416,10 +416,9 @@ def test_fallback_legend_and_notes_displayed_when_stub_source() -> None:
             "score_compuesto": [61.0],
         }
     )
-    fallback_note = "⚠️ Datos simulados (Yahoo no disponible)"
     extra_note = "ℹ️ Recuerda validar con fuentes oficiales"
     app, _ = _run_app_with_result(
-        {"table": df, "notes": [fallback_note, extra_note], "source": "stub"}
+        {"table": df, "notes": [extra_note], "source": "stub"}
     )
     captions = [element.value for element in app.get("caption")]
     expected_stub_caption = shared_notes.format_note(
@@ -427,10 +426,9 @@ def test_fallback_legend_and_notes_displayed_when_stub_source() -> None:
     )
     assert expected_stub_caption in captions
     markdown_blocks = [element.value for element in app.get("markdown")]
-    formatted_fallback = shared_notes.format_note(fallback_note)
     formatted_extra = shared_notes.format_note(extra_note)
-    assert any(formatted_fallback in block for block in markdown_blocks)
     assert any(formatted_extra in block for block in markdown_blocks)
+    assert not any("Resultados simulados" in block for block in markdown_blocks)
 
 
 def test_stub_source_displays_warning_caption_and_notes() -> None:
@@ -473,7 +471,7 @@ def test_fallback_note_with_cause_highlighted() -> None:
             "score_compuesto": [61.0],
         }
     )
-    fallback_note = "⚠️ Datos simulados — Causa: Yahoo timeout"
+    fallback_note = "⚠️ Yahoo no disponible — Causa: Yahoo timeout"
 
     app, _ = _run_app_with_result(
         {"table": df, "notes": [fallback_note], "source": "stub"}


### PR DESCRIPTION
## Summary
- avoid appending the generic fallback note when the stub data caption already communicates the warning
- update UI and integration tests to expect a single warning message while still surfacing failure causes

## Testing
- pytest tests/ui/test_opportunities_tab.py -q
- pytest tests/integration/test_opportunities_flow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd92928574833294cb27f1b0decac4