### PR TITLE
Fix Yahoo link column display text

### DIFF
--- a/tests/ui/test_opportunities_tab.py
+++ b/tests/ui/test_opportunities_tab.py
@@ -217,8 +217,11 @@ def test_button_executes_controller_and_shows_yahoo_caption() -> None:
     link_config = columns_config.get("Yahoo Finance Link")
     assert link_config is not None, "Expected link column configuration for Yahoo Finance"
     assert link_config["label"] == "Yahoo Finance Link"
-    assert link_config["type_config"]["type"] == "link"
-    assert link_config["type_config"]["display_text"] == r"https://finance.yahoo.com/quote/(.*?)"
+    type_config = link_config["type_config"]
+    assert type_config["type"] == "link"
+    assert type_config.get("display_text") in (None, "")
+    columns_json = component.proto.columns or ""
+    assert r"https://finance.yahoo.com/quote/(.*?)" not in columns_json
     column_order = list(component.proto.column_order)
     assert "ticker" in column_order
     assert "Yahoo Finance Link" in column_order

--- a/ui/tabs/opportunities.py
+++ b/ui/tabs/opportunities.py
@@ -430,7 +430,7 @@ def render_opportunities_tab() -> None:
                     link_column: st.column_config.LinkColumn(
                         label="Yahoo Finance Link",
                         help="Abrí la ficha del activo en Yahoo Finance.",
-                        display_text=r"https://finance.yahoo.com/quote/(.*?)",
+                        display_text=None,
                     )
                 }
                 column_order = [
@@ -458,9 +458,15 @@ def render_opportunities_tab() -> None:
                 key="download_opportunities_csv",
             )
 
-        has_fallback_note = any(
+        has_stub_or_fallback_note = any(
             isinstance(note, str)
-            and note.strip().startswith("⚠️ Yahoo no disponible — Causa:")
+            and note.strip().startswith(
+                (
+                    "⚠️ Yahoo no disponible — Causa:",
+                    "⚠️ Stub procesó",
+                    "ℹ️ Stub procesó",
+                )
+            )
             for note in notes
         )
 
@@ -470,7 +476,7 @@ def render_opportunities_tab() -> None:
                 st.markdown(_format_note(note))
 
         if source == "stub":
-            if not has_fallback_note:
+            if not has_stub_or_fallback_note:
                 st.caption(
                     shared_notes.format_note(
                         "⚠️ Resultados simulados (Yahoo no disponible)"


### PR DESCRIPTION
## Summary
- allow the Yahoo Finance link column to display each row's actual URL and reuse stub-specific notes to suppress duplicate warnings
- adjust UI test expectations to ensure the rendered hyperlink text comes from the dataframe values instead of a regex placeholder

## Testing
- pytest tests/ui/test_opportunities_tab.py -q
- pytest tests/integration/test_opportunities_flow.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dd9948ceb083328862bf79eaee4775

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Yahoo Finance link column no longer shows placeholder text; links render correctly while keeping the existing column label and order.
  - The “Resultados simulados (Yahoo no disponible)” caption now appears only when stubbed or fallback data is detected, recognizing multiple note variants for more reliable messaging.

- Improvements
  - Enhanced detection of stub/fallback notes to better reflect data availability and reduce confusion in the Opportunities tab.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->