### PR TITLE
docs: add 0.3.18 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.18] - 2025-10-02
+### Added
+- Los listados de oportunidades ahora incluyen enlaces clickeables hacia Yahoo Finance, permitiendo abrir la ficha del ticker directamente desde la UI o los reportes exportados.
+### Changed
+- Se unificó la tabla visible y el CSV descargable para compartir columnas, orden y formato de los enlaces, preservando la paridad entre ambas superficies.
+### Fixed
+- Se eliminaron las advertencias duplicadas que aparecían al regenerar el listado cuando coexistían datos de Yahoo y del stub.
+### Documentation
+- Se actualizaron las guías internas para describir los enlaces hacia Yahoo Finance y los criterios de sincronización entre la UI y el CSV exportable.
+
 ## [0.3.17] - 2025-10-01
 ### Added
 - La estrategia Andy fue promovida a release estable tras validar los filtros financieros activos, el score normalizado y la telemetría espejo entre Yahoo y el stub, dejando documentada la cobertura manual que respalda el corte.


### PR DESCRIPTION
## Summary
- add the 0.3.18 release notes covering clickable Yahoo links, UI/CSV parity, and duplicate warning cleanup

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd9cc43c8c8332bc802aad82594965