### PR TITLE
Bump project version to 0.3.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,9 +190,9 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.18".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.19".
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.18)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.19)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
 
 ## Requisitos de sistema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.18"
+version = "0.3.19"
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     import tomli as _toml  # type: ignore[import-untyped]
 
 
-DEFAULT_VERSION = "0.3.18"
+DEFAULT_VERSION = "0.3.19"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.19 in pyproject and default loader
- update README references so the displayed version matches the new release

## Testing
- pytest tests/test_version_display.py tests/test_health_sidebar_rendering.py tests/test_security_info.py

------
https://chatgpt.com/codex/tasks/task_e_68ddb4c524c08332a925999ed9b70c05