### PR TITLE
Add summary metrics to opportunities tab

### DIFF
--- a/tests/controllers/test_opportunities_controller.py
+++ b/tests/controllers/test_opportunities_controller.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Mapping, Tuple
 
 import sys
 
@@ -389,7 +389,12 @@ def test_generate_report_includes_source(monkeypatch: pytest.MonkeyPatch) -> Non
         }
     )
 
-    assert result == {"table": df, "notes": ["note"], "source": "stub"}
+    assert result["table"] is df
+    assert result["notes"] == ["note"]
+    assert result["source"] == "stub"
+    summary = result.get("summary")
+    assert isinstance(summary, Mapping)
+    assert summary["result_count"] == len(df.index)
 
 
 def test_generate_report_parses_string_bool(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- expose filter telemetry metadata from the controller to build UI summaries
- render a metrics and sector distribution block on the opportunities tab
- exercise new UI behaviour with snapshot-style tests

## Testing
- pytest tests/controllers/test_opportunities_controller.py
- pytest tests/ui/test_opportunities_tab.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcd3353dc8332b147083c1be362d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a summary panel showing Universo analizado, Candidatos finales, and Sectores activos.
  - Introduced a sector distribution chart within the summary.
  - Improved screening notes with human‑readable filter descriptions and a drop summary.

- Refactor
  - Standardized summary payload generation and propagation for consistent reporting across flows.
  - Normalized sector handling and preserved result metadata for reliability.

- Tests
  - Added UI test to verify summary metrics and sector distribution rendering.
  - Updated controller tests to assert presence and correctness of the new summary field.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->