### PR TITLE
Extend opportunities health telemetry

### DIFF
--- a/controllers/opportunities.py
+++ b/controllers/opportunities.py
@@ -6,7 +6,7 @@ import re
 import time
 from collections import OrderedDict
 from threading import Lock
-from typing import Any, Iterable, List, Mapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
 
 import pandas as pd
 
@@ -544,6 +544,51 @@ def _as_optional_bool(value: Any) -> Optional[bool]:
     return None
 
 
+def _extract_opportunities_metrics(payload: Mapping[str, Any]) -> Dict[str, Any]:
+    metrics: Dict[str, Any] = {}
+    raw_metrics = payload.get("metrics")
+    if isinstance(raw_metrics, Mapping):
+        metrics.update(raw_metrics)
+
+    for key in (
+        "universe_initial",
+        "universe_final",
+        "discard_ratio",
+        "highlighted_sectors",
+        "counts_by_origin",
+    ):
+        if key in payload and key not in metrics:
+            metrics[key] = payload[key]
+
+    return metrics
+
+
+def _normalise_controller_payload(
+    payload: Any,
+) -> Tuple[pd.DataFrame, List[str], str, Dict[str, Any]]:
+    if isinstance(payload, Mapping):
+        table = payload.get("table")
+        if isinstance(table, pd.DataFrame):
+            df = table
+        else:
+            try:
+                df = pd.DataFrame(table)
+            except Exception:
+                df = pd.DataFrame()
+
+        notes = _normalize_notes(payload.get("notes"))
+        source = str(payload.get("source") or "desconocido")
+        metrics = _extract_opportunities_metrics(payload)
+        return df, notes, source, metrics
+
+    if isinstance(payload, tuple) and len(payload) == 3:
+        df, notes, source = payload
+        normalized_notes = _normalize_notes(notes)
+        return df, normalized_notes, source, {}
+
+    return pd.DataFrame(), [], "desconocido", {}
+
+
 def generate_opportunities_report(
     filters: Optional[Mapping[str, Any]] = None,
 ) -> Mapping[str, object]:
@@ -583,20 +628,32 @@ def generate_opportunities_report(
     cached_entry = _get_cached_result(cache_key)
     if cached_entry is not None:
         cached_result, baseline_elapsed = cached_entry
+        metrics_payload: Dict[str, Any] = {}
+        if isinstance(cached_result, Mapping):
+            metrics_payload = _extract_opportunities_metrics(cached_result)
         elapsed_ms = (time.perf_counter() - start) * 1000
         record_opportunities_report(
             mode="hit",
             elapsed_ms=elapsed_ms,
             cached_elapsed_ms=baseline_elapsed,
+            **metrics_payload,
         )
         return cached_result
 
     compute_start = time.perf_counter()
-    df, notes, source = run_opportunities_controller(**controller_args)
+    raw_payload = run_opportunities_controller(**controller_args)
+    df, notes, source, metrics_payload = _normalise_controller_payload(raw_payload)
     elapsed_ms = (time.perf_counter() - compute_start) * 1000
-    result: Mapping[str, object] = {"table": df, "notes": notes, "source": source}
+    result: Dict[str, object] = {"table": df, "notes": notes, "source": source}
+    if metrics_payload:
+        result["metrics"] = metrics_payload
     _store_cached_result(cache_key, result, elapsed_ms)
-    record_opportunities_report(mode="miss", elapsed_ms=elapsed_ms, cached_elapsed_ms=None)
+    record_opportunities_report(
+        mode="miss",
+        elapsed_ms=elapsed_ms,
+        cached_elapsed_ms=None,
+        **metrics_payload,
+    )
     return result
 
 

--- a/tests/controllers/test_opportunities_controller.py
+++ b/tests/controllers/test_opportunities_controller.py
@@ -409,6 +409,48 @@ def test_generate_report_parses_string_bool(monkeypatch: pytest.MonkeyPatch) -> 
     assert "exclude_tickers" not in captured or captured["exclude_tickers"] is None
 
 
+def test_generate_report_records_extended_metrics(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame([_make_sample_row()])
+
+    payload = {
+        "table": df,
+        "notes": ["note"],
+        "source": "stub",
+        "universe_initial": "100",
+        "universe_final": 25,
+        "discard_ratio": "0.5",
+        "highlighted_sectors": ("Energy", "Utilities"),
+        "counts_by_origin": {"nyse": "10", "nasdaq": 15},
+    }
+
+    recorded: list[Dict[str, Any]] = []
+
+    sut._clear_opportunities_cache()
+    monkeypatch.setattr(sut, "run_opportunities_controller", lambda **_: payload)
+    monkeypatch.setattr(
+        sut,
+        "record_opportunities_report",
+        lambda **kwargs: recorded.append(kwargs),
+    )
+
+    result = sut.generate_opportunities_report({})
+
+    assert result["metrics"] == {
+        "universe_initial": "100",
+        "universe_final": 25,
+        "discard_ratio": "0.5",
+        "highlighted_sectors": ("Energy", "Utilities"),
+        "counts_by_origin": {"nyse": "10", "nasdaq": 15},
+    }
+    assert recorded, "Health metrics should be recorded"
+    forwarded = recorded[0]
+    assert forwarded["universe_initial"] == "100"
+    assert forwarded["universe_final"] == 25
+    assert forwarded["discard_ratio"] == "0.5"
+    assert forwarded["highlighted_sectors"] == ("Energy", "Utilities")
+    assert forwarded["counts_by_origin"] == {"nyse": "10", "nasdaq": 15}
+
+
 def test_generate_report_reuses_cached_result(monkeypatch: pytest.MonkeyPatch) -> None:
     sut._clear_opportunities_cache()
     df = pd.DataFrame([_make_sample_row()])

--- a/tests/test_health_sidebar_rendering.py
+++ b/tests/test_health_sidebar_rendering.py
@@ -148,6 +148,11 @@ def test_sidebar_formats_populated_metrics(monkeypatch) -> None:
                 "mode": "hit",
                 "elapsed_ms": 12.3,
                 "cached_elapsed_ms": 45.6,
+                "universe_initial": 150,
+                "universe_final": 90,
+                "discard_ratio": 0.4,
+                "highlighted_sectors": ["Energy", "Utilities"],
+                "counts_by_origin": {"nyse": 45, "nasdaq": 45},
                 "ts": timestamps[4],
             },
             "portfolio": {
@@ -186,6 +191,8 @@ def test_sidebar_formats_populated_metrics(monkeypatch) -> None:
         "#### 🔎 Screening de oportunidades",
         shared_notes.format_note(
             f"✅ Cache reutilizada • {formatted[4]} (12 ms • previo 46 ms)"
+            " — universo 150→90 | descartes 40% | sectores: Energy, Utilities"
+            " | origen: nyse=45, nasdaq=45"
         ),
         "#### ⏱️ Latencias",
         f"- Portafolio: 457 ms • fuente: api • fresh • {formatted[5]}",

--- a/tests/ui/test_health_sidebar.py
+++ b/tests/ui/test_health_sidebar.py
@@ -77,6 +77,11 @@ def _dummy_metrics() -> dict[str, dict[str, object]]:
             "mode": "miss",
             "elapsed_ms": 321.0,
             "cached_elapsed_ms": None,
+            "universe_initial": 120,
+            "universe_final": 48,
+            "discard_ratio": 0.6,
+            "highlighted_sectors": ["Energy", "Utilities"],
+            "counts_by_origin": {"nyse": 30, "nasdaq": 18},
             "ts": None,
         },
         "portfolio": {
@@ -158,6 +163,30 @@ def test_render_health_sidebar_uses_shared_note_formatter(
     ]
 
     assert dummy_streamlit.sidebar.markdown_calls == expected_markdown_sequence
+
+
+def test_format_opportunities_status_handles_partial_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(health_sidebar, "format_note", lambda text: text)
+    data = {
+        "mode": "miss",
+        "elapsed_ms": None,
+        "cached_elapsed_ms": None,
+        "universe_final": "15",
+        "discard_ratio": "not-a-number",
+        "highlighted_sectors": "Energy",
+        "counts_by_origin": {"nyse": "10", "": 5, "invalid": "oops"},
+        "ts": None,
+    }
+
+    note = health_sidebar._format_opportunities_status(data)
+
+    assert "universo final 15" in note
+    assert "descartes" not in note
+    assert "sectores: Energy" in note
+    assert "origen: nyse=10" in note
+    assert "s/d" in note
 
 
 _SMOKE_SCRIPT = textwrap.dedent(


### PR DESCRIPTION
## Summary
- persist optional universe, discard and origin metrics when recording opportunities health
- propagate telemetry from the opportunities controller cache and render it in the sidebar
- cover the extended metrics with controller and UI tests, including graceful degradation cases

## Testing
- pytest tests/ui/test_health_sidebar.py tests/test_health_sidebar_rendering.py tests/controllers/test_opportunities_controller.py

------
https://chatgpt.com/codex/tasks/task_e_68ddcd33d5ec8332943f8a7812fa61c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Opportunities reports now include richer metrics: initial/final universe, discard ratio, highlighted sectors, and counts by origin.
  - Health sidebar displays these metrics with clearer, localized formatting, including when using cached results.
  - Robust handling of varied and partial inputs (strings, lists, mappings) for metrics.

- Tests
  - Added tests for end-to-end metrics propagation and recording.
  - Added UI tests to verify rendering of extended metrics and resilience to partial/malformed data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->