### PR TITLE
Propagate screener metrics through controller payload

### DIFF
--- a/tests/application/test_screener_yahoo.py
+++ b/tests/application/test_screener_yahoo.py
@@ -1139,7 +1139,7 @@ def test_run_opportunities_controller_calls_yahoo(monkeypatch, comprehensive_dat
 
     monkeypatch.setattr(ctrl, "run_screener_stub", _stub_not_expected)
 
-    df, notes, source = ctrl.run_opportunities_controller(
+    payload = ctrl.run_opportunities_controller(
         manual_tickers=["abc"],
         include_technicals=False,
         min_market_cap=500_000_000,
@@ -1147,6 +1147,10 @@ def test_run_opportunities_controller_calls_yahoo(monkeypatch, comprehensive_dat
         min_revenue_growth=5.0,
         include_latam=True,
     )
+
+    df = payload["table"]
+    notes = payload["notes"]
+    source = payload["source"]
 
     assert not any("Datos simulados" in note for note in notes)
     assert {ticker for ticker in df["ticker"]} == {"ABC"}
@@ -1164,10 +1168,14 @@ def test_run_opportunities_controller_exposes_technicals(monkeypatch, comprehens
         lambda **_kwargs: (_ for _ in ()).throw(AssertionError("fallback should not run")),
     )
 
-    df, notes, source = ctrl.run_opportunities_controller(
+    payload = ctrl.run_opportunities_controller(
         manual_tickers=["abc"],
         include_technicals=True,
     )
+
+    df = payload["table"]
+    notes = payload["notes"]
+    source = payload["source"]
 
     assert notes[0].startswith("ℹ️ Filtros aplicados:")
     assert any("Yahoo procesó" in note for note in notes)
@@ -1251,13 +1259,17 @@ def test_run_opportunities_controller_applies_new_filters(
 
     monkeypatch.setattr(ctrl, "run_screener_stub", _stub_not_expected)
 
-    df, notes, source = ctrl.run_opportunities_controller(
+    payload = ctrl.run_opportunities_controller(
         manual_tickers=["abc", "pay", "stk", "cgr"],
         max_payout=50.0,
         min_div_streak=3,
         min_cagr=5.0,
         include_technicals=False,
     )
+
+    df = payload["table"]
+    notes = payload["notes"]
+    source = payload["source"]
 
     assert list(df["ticker"]) == ["ABC", "PAY", "STK", "CGR"]
     results = {row["ticker"]: row for _, row in df.iterrows()}

--- a/tests/controllers/test_opportunities_controller_auto.py
+++ b/tests/controllers/test_opportunities_controller_auto.py
@@ -104,7 +104,7 @@ def test_controller_uses_auto_universe(monkeypatch, auto_dataset):
     monkeypatch.setattr(ops, "YahooFinanceClient", lambda: client)
     monkeypatch.setattr(ops, "_get_target_markets", lambda: ["TEST"])
 
-    df, notes, source = run_opportunities_controller(
+    payload = run_opportunities_controller(
         manual_tickers=None,
         include_technicals=False,
         min_market_cap=8_000_000_000,
@@ -112,6 +112,10 @@ def test_controller_uses_auto_universe(monkeypatch, auto_dataset):
         min_revenue_growth=10.0,
         include_latam=False,
     )
+
+    df = payload["table"]
+    notes = payload["notes"]
+    source = payload["source"]
 
     table = df.set_index("ticker")
     assert set(table.index) == {"AAA", "BBB", "CCC"}
@@ -128,7 +132,11 @@ def test_controller_reports_when_no_candidates(monkeypatch):
     monkeypatch.setattr(ops, "YahooFinanceClient", lambda: client)
     monkeypatch.setattr(ops, "_get_target_markets", lambda: ["TEST"])
 
-    df, notes, source = run_opportunities_controller(manual_tickers=None)
+    payload = run_opportunities_controller(manual_tickers=None)
+
+    df = payload["table"]
+    notes = payload["notes"]
+    source = payload["source"]
 
     assert df.empty
     assert any("No se encontraron símbolos" in note for note in notes)
@@ -145,11 +153,15 @@ def test_controller_uses_configured_markets(monkeypatch, auto_dataset):
     monkeypatch.setattr(ops, "YahooFinanceClient", lambda: client)
     monkeypatch.setattr(ops, "_get_target_markets", lambda: ["LATAM"])
 
-    df, notes, source = run_opportunities_controller(
+    payload = run_opportunities_controller(
         manual_tickers=None,
         include_technicals=False,
         include_latam=True,
     )
+
+    df = payload["table"]
+    notes = payload["notes"]
+    source = payload["source"]
 
     assert list(df["ticker"]) == ["BBB"]
     assert source == "yahoo"

--- a/tests/integration/test_opportunities_flow.py
+++ b/tests/integration/test_opportunities_flow.py
@@ -719,7 +719,7 @@ def test_fallback_stub_emits_runtime_telemetry_note(
         raise AssertionError("Se esperaba una nota del stub")
 
     _configure_perf_counter([10.0, 10.05])
-    df_fast, notes_fast, source_fast = controller_module.run_opportunities_controller(
+    payload_fast = controller_module.run_opportunities_controller(
         manual_tickers=None,
         exclude_tickers=None,
         max_payout=None,
@@ -736,6 +736,10 @@ def test_fallback_stub_emits_runtime_telemetry_note(
         max_results=None,
         sectors=None,
     )
+
+    df_fast = payload_fast["table"]
+    notes_fast = payload_fast["notes"]
+    source_fast = payload_fast["source"]
 
     fast_note = _extract_stub_note(notes_fast)
     assert source_fast == "stub"
@@ -749,7 +753,7 @@ def test_fallback_stub_emits_runtime_telemetry_note(
     assert df_fast.attrs["_notes"][-1] == fast_note
 
     _configure_perf_counter([20.0, 20.5])
-    df_slow, notes_slow, _ = controller_module.run_opportunities_controller(
+    payload_slow = controller_module.run_opportunities_controller(
         manual_tickers=None,
         exclude_tickers=None,
         max_payout=None,
@@ -766,6 +770,9 @@ def test_fallback_stub_emits_runtime_telemetry_note(
         max_results=None,
         sectors=None,
     )
+
+    df_slow = payload_slow["table"]
+    notes_slow = payload_slow["notes"]
 
     slow_note = _extract_stub_note(notes_slow)
     severity_slow, _, matched_slow = shared_notes.classify_note(slow_note)

--- a/tests/ui/test_health_sidebar.py
+++ b/tests/ui/test_health_sidebar.py
@@ -133,6 +133,10 @@ def test_render_health_sidebar_uses_shared_note_formatter(
     opportunities_note = health_sidebar._format_opportunities_status(
         _dummy_metrics["opportunities"]
     )
+    assert "universo 120→48" in opportunities_note
+    assert "descartes 60%" in opportunities_note
+    assert "sectores: Energy, Utilities" in opportunities_note
+    assert "origen: nyse=30, nasdaq=18" in opportunities_note
     formatted_latency_lines = [f"formatted::{line}" for line in latency_lines]
     expected_notes: list[str] = [
         health_sidebar._format_iol_status(_dummy_metrics["iol_refresh"]),


### PR DESCRIPTION
## Summary
- update `run_opportunities_controller` to return a mapping that includes derived screener metrics for the UI
- propagate those metrics through the controller normalization/cache pipeline and into the health recorder
- refresh controller, integration, and sidebar tests for the new payload shape and rendered metrics

## Testing
- pytest tests/controllers/test_opportunities_controller.py tests/ui/test_health_sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68dde136b0008332a89c39fe6133bd8a