### PR TITLE
Bump release metadata to 0.3.21

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.20)
+## Quick-start (release 0.3.21)
 
-La versión **0.3.20** incorpora el mini-dashboard inicial con métricas clave de la cartera y una
+La versión **0.3.21** incorpora el mini-dashboard inicial con métricas clave de la cartera y una
 telemetría enriquecida que desglosa runtimes, *cache hits* y llamadas remotas, además de mantener
 los presets personalizados, la comparación lado a lado y la caché cooperativa introducidos en la
 release anterior. Sigue estos pasos para reproducir el flujo completo en minutos:
@@ -26,7 +26,7 @@ release anterior. Sigue estos pasos para reproducir el flujo completo en minutos
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar mostrará el número de versión `0.3.20`, confirmando que la actualización
+   La cabecera del sidebar mostrará el número de versión `0.3.21`, confirmando que la actualización
    quedó aplicada. Al mismo tiempo, el mini-dashboard superior renderizará tarjetas con el valor
    total de la cartera, la variación diaria y el cash disponible usando los datos stub incluidos.
 3. **Lanza un screening con presets personalizados y revisa la telemetría.**
@@ -50,7 +50,7 @@ release anterior. Sigue estos pasos para reproducir el flujo completo en minutos
 - La comparación de presets presenta dos columnas paralelas con indicadores verdes/rojos que señalan qué filtros fueron ajustados antes de confirmar la ejecución definitiva.
 - El bloque de telemetría enriquecida marca explícitamente los *cache hits*, diferencia el tiempo invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa durante la sesión.
 
-**Comportamiento del caché (0.3.20).** Cuando guardas un preset, la aplicación persiste la
+**Comportamiento del caché (0.3.21).** Cuando guardas un preset, la aplicación persiste la
 combinación de filtros y el resultado del último screening asociado. Al relanzarlo, el panel de
 telemetría ahora etiqueta cada corrida con un identificador incremental y agrega una tabla de
 componentes (descarga, normalización, render) para comparar tiempos:
@@ -64,7 +64,7 @@ componentes (descarga, normalización, render) para comparar tiempos:
   que reutiliza inmediatamente los resultados previos, dispara el contador de *cache hits* y confirma
   la integridad del guardado.
 
-Estas novedades convierten a la release 0.3.20 en la primera con mini-dashboard, telemetría
+Estas novedades convierten a la release 0.3.21 en la primera con mini-dashboard, telemetría
 enriquecida, presets persistentes, comparación visual y caché cooperativa, recortando tiempos de
 iteración cuando se prueban variaciones de filtros y dejando a la vista el impacto de cada cambio.
 
@@ -258,9 +258,9 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.20".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.21".
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.20)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.21)** que lista el estado de los servicios monitoreados, de modo que puedas validar de un vistazo la disponibilidad de las dependencias clave antes de operar.
 
 ## Requisitos de sistema
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.20"
+version = "0.3.21"
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     import tomli as _toml  # type: ignore[import-untyped]
 
 
-DEFAULT_VERSION = "0.3.20"
+DEFAULT_VERSION = "0.3.21"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.21 in the build metadata and shared version helper
- refresh README quick-start and version references to describe release 0.3.21

## Testing
- pytest tests/ui/test_health_sidebar.py
- pytest tests/test_version_display.py

------
https://chatgpt.com/codex/tasks/task_e_68dde75edd548332a330ceb621e986a1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated README to reflect release 0.3.21, including Quick-start header, cache behavior notes, telemetry descriptions, login messaging, and healthcheck/version references.
- Chores
  - Bumped project version to 0.3.21 and aligned default version fallback accordingly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->