### PR TITLE
Integrate macro data from FRED with opportunities screener

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Cliente dedicado para FRED con autenticación, gestión de rate limiting y normalización de observaciones para enriquecer el screener de oportunidades con contexto macro/sectorial. ([`infrastructure/macro/fred_client.py`](infrastructure/macro/fred_client.py))
+- Métrica de salud que expone el estado de la nueva dependencia externa (`macro_api`) y tests que cubren los flujos de fallback del controlador. ([`services/health.py`](services/health.py), [`controllers/test/test_opportunities_macro.py`](controllers/test/test_opportunities_macro.py))
+### Changed
+- El controlador de oportunidades combina la información sectorial proveniente de FRED (o del fallback configurado) con los resultados del screening, agregando la columna `macro_outlook` y notas contextuales. ([`controllers/opportunities.py`](controllers/opportunities.py))
+### Documentation
+- README actualizado con los pasos para habilitar la integración macro, variables de entorno requeridas y consideraciones de failover. ([`README.md`](README.md#datos-macro-y-sectoriales-fred--fallback))
 
 ## [0.3.21] - 2025-10-05
 ### Changed

--- a/README.md
+++ b/README.md
@@ -117,6 +117,26 @@ Cada registro respeta los principios de la estrategia Andy: payout y P/E saludab
 
 Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas contextuales del caption principal. Los tests automatizados siguen apoyándose en este dataset extendido para validar diversidad sectorial, completitud de fundamentals y la presencia de la nueva columna `Score`.
 
+#### Datos macro y sectoriales (FRED + fallback)
+
+- La tabla incorpora la columna `macro_outlook`, alimentada por la API de [FRED](https://fred.stlouisfed.org/) cuando existe configuración válida. Cada celda combina el último valor publicado para la serie sectorial asociada y la fecha del dato (`1.75 (2023-09-01)`), facilitando la lectura del contexto macro sin abandonar la grilla del screening.
+- Para habilitar la integración se deben definir las siguientes variables (vía `.env`, `streamlit secrets` o `config.json`):
+
+  ```bash
+  export MACRO_API_PROVIDER=fred
+  export FRED_API_KEY="<tu-clave>"
+  export FRED_SECTOR_SERIES='{"Technology": "IPN31152N", "Finance": "IPN52300N"}'
+  # Opcional: tuning avanzado
+  export FRED_API_BASE_URL="https://api.stlouisfed.org/fred"
+  export FRED_API_RATE_LIMIT_PER_MINUTE=120
+  export MACRO_SECTOR_FALLBACK='{"Technology": {"value": 2.1, "as_of": "2023-06-30"}}'
+  ```
+
+  - `FRED_SECTOR_SERIES` mapea el nombre del sector que aparece en el screener con el identificador de serie en FRED. Es sensible a los sectores retornados por Yahoo/stub, por lo que conviene mantener la misma capitalización mostrada en la tabla.
+  - `MACRO_SECTOR_FALLBACK` permite declarar valores estáticos (por sector) que se aplican automáticamente cuando la API externa no está disponible, cuando el proveedor configurado no es soportado o cuando falta alguna serie en la configuración.
+- Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
+- El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
+
 #### Telemetría del barrido
 
 El panel muestra una nota de telemetría por cada barrido, tanto si la corrida proviene de Yahoo Finance como del stub local. El helper `shared.ui.notes.format_note` arma el texto en base a los campos reportados por cada origen y selecciona la severidad adecuada (`ℹ️` o `⚠️`) según los umbrales vigentes.

--- a/controllers/test/test_opportunities_macro.py
+++ b/controllers/test/test_opportunities_macro.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Dict
+
+import pandas as pd
+import pytest
+
+from controllers import opportunities
+from infrastructure.macro import FredSeriesObservation
+
+
+@pytest.fixture(autouse=True)
+def _reset_macro_caches(monkeypatch: pytest.MonkeyPatch) -> None:
+    opportunities._macro_series_lookup.cache_clear()
+    opportunities._macro_fallback_lookup.cache_clear()
+    opportunities._get_macro_client.cache_clear()
+    monkeypatch.setattr(opportunities, "record_macro_api_usage", lambda **_: None)
+
+
+def test_enrich_with_macro_uses_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"sector": ["Technology"]})
+
+    monkeypatch.setattr(opportunities, "macro_api_provider", "fred")
+    monkeypatch.setattr(opportunities, "fred_api_key", None)
+    monkeypatch.setattr(opportunities, "fred_sector_series", {})
+    monkeypatch.setattr(
+        opportunities,
+        "macro_sector_fallback",
+        {"Technology": {"value": 2.5, "as_of": "2023-08-01"}},
+    )
+
+    notes, metrics = opportunities._enrich_with_macro_context(df)
+
+    assert metrics["macro_source"] == "fallback"
+    assert "2.50" in df[opportunities._MACRO_COLUMN].iloc[0]
+    assert any("fallback" in note for note in notes)
+
+
+def test_enrich_with_macro_uses_fred(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"sector": ["Finance"], "ticker": ["FIN"]})
+
+    class DummyClient:
+        def get_latest_observations(self, mapping: Dict[str, str]) -> Dict[str, FredSeriesObservation]:
+            assert mapping == {"Finance": "SERIES"}
+            return {"Finance": FredSeriesObservation(series_id="SERIES", value=1.75, as_of="2023-09-01")}
+
+    monkeypatch.setattr(opportunities, "macro_api_provider", "fred")
+    monkeypatch.setattr(opportunities, "fred_api_key", "dummy")
+    monkeypatch.setattr(opportunities, "fred_sector_series", {"Finance": "SERIES"})
+    monkeypatch.setattr(opportunities, "macro_sector_fallback", {})
+    monkeypatch.setattr(opportunities, "_get_macro_client", lambda: DummyClient())
+
+    notes, metrics = opportunities._enrich_with_macro_context(df)
+
+    assert metrics["macro_source"] == "fred"
+    assert metrics["macro_sector_coverage"] == 1
+    assert "1.75" in df[opportunities._MACRO_COLUMN].iloc[0]
+    assert any("FRED" in note for note in notes)

--- a/infrastructure/macro/__init__.py
+++ b/infrastructure/macro/__init__.py
@@ -1,0 +1,11 @@
+"""Clients for macroeconomic and sector-level data providers."""
+
+from .fred_client import FredClient, FredSeriesObservation, MacroAPIError, MacroAuthenticationError, MacroRateLimitError
+
+__all__ = [
+    "FredClient",
+    "FredSeriesObservation",
+    "MacroAPIError",
+    "MacroAuthenticationError",
+    "MacroRateLimitError",
+]

--- a/infrastructure/macro/fred_client.py
+++ b/infrastructure/macro/fred_client.py
@@ -1,0 +1,192 @@
+"""HTTP client for the Federal Reserve Economic Data (FRED) API.
+
+The client centralizes authentication, error handling and rate limiting so the
+rest of the application can focus on business logic. It only exposes the
+minimal surface required for the opportunities screener enrichment but is
+extensible for future indicators.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import time
+from threading import Lock
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional
+
+import requests
+
+from infrastructure.http.session import build_session
+
+
+class MacroAPIError(RuntimeError):
+    """Base class for FRED related failures."""
+
+
+class MacroAuthenticationError(MacroAPIError):
+    """Raised when the provided credentials are rejected by the API."""
+
+
+class MacroRateLimitError(MacroAPIError):
+    """Raised when the upstream service signals that the rate limit was hit."""
+
+
+@dataclass(frozen=True)
+class FredSeriesObservation:
+    """Represents the most recent observation available for a series."""
+
+    series_id: str
+    value: float
+    as_of: str
+
+
+class _RateLimiter:
+    """Simple rate limiter that spaces out requests at a fixed interval."""
+
+    def __init__(
+        self,
+        *,
+        calls_per_minute: int,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if calls_per_minute < 0:
+            raise ValueError("calls_per_minute must be >= 0")
+        self._interval = 0.0
+        if calls_per_minute:
+            self._interval = 60.0 / float(calls_per_minute)
+        self._monotonic = monotonic
+        self._sleep = sleeper
+        self._lock = Lock()
+        self._next_time = 0.0
+
+    def acquire(self) -> None:
+        """Block until the caller is allowed to make another request."""
+
+        if self._interval <= 0:
+            return
+        with self._lock:
+            now = self._monotonic()
+            wait_for = self._next_time - now
+            if wait_for > 0:
+                self._sleep(wait_for)
+                now = self._monotonic()
+            self._next_time = now + self._interval
+
+
+class FredClient:
+    """Dedicated HTTP client for the FRED API."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        base_url: str = "https://api.stlouisfed.org/fred",
+        session: Optional[requests.Session] = None,
+        calls_per_minute: int = 120,
+        user_agent: Optional[str] = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if not api_key:
+            raise ValueError("api_key is required to talk with FRED")
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = session or build_session(user_agent or "Portafolio-IOL/1.0")
+        self._rate_limiter = _RateLimiter(
+            calls_per_minute=calls_per_minute, monotonic=monotonic, sleeper=sleeper
+        )
+
+    # Public API -----------------------------------------------------------
+    def get_latest_observation(
+        self, series_id: str, *, params: Optional[Mapping[str, Any]] = None
+    ) -> Optional[FredSeriesObservation]:
+        """Return the most recent valid observation for ``series_id``."""
+
+        payload = self._request_json(
+            "series/observations",
+            {
+                "series_id": series_id,
+                "sort_order": "desc",
+                "limit": 5,
+                "observation_start": params.get("observation_start")
+                if params
+                else None,
+                "observation_end": params.get("observation_end") if params else None,
+            },
+        )
+        observations = payload.get("observations")
+        if not isinstance(observations, Iterable):
+            return None
+        for item in observations:
+            if not isinstance(item, Mapping):
+                continue
+            raw_value = item.get("value")
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                continue
+            as_of = str(
+                item.get("observation_date") or item.get("date") or ""
+            ).strip()
+            if not as_of:
+                continue
+            return FredSeriesObservation(series_id=series_id, value=value, as_of=as_of)
+        return None
+
+    def get_latest_observations(
+        self, series_map: Mapping[str, str]
+    ) -> Dict[str, FredSeriesObservation]:
+        """Return observations for the provided mapping of label -> series ID."""
+
+        results: Dict[str, FredSeriesObservation] = {}
+        for label, series_id in series_map.items():
+            if not series_id:
+                continue
+            observation = self.get_latest_observation(series_id)
+            if observation is None:
+                continue
+            results[label] = observation
+        return results
+
+    # Internal helpers ----------------------------------------------------
+    def _request_json(
+        self, endpoint: str, params: Optional[MutableMapping[str, Any]] = None
+    ) -> Mapping[str, Any]:
+        url = f"{self._base_url}/{endpoint.lstrip('/')}"
+        query: Dict[str, Any] = {"file_type": "json", "api_key": self._api_key}
+        if params:
+            for key, value in params.items():
+                if value is None:
+                    continue
+                query[key] = value
+        self._rate_limiter.acquire()
+        response = self._session.get(url, params=query)
+        status = response.status_code
+        if status == 401 or status == 403:
+            raise MacroAuthenticationError("FRED API rejected the provided credentials")
+        if status == 429:
+            raise MacroRateLimitError("FRED API rate limit exceeded")
+        if status >= 500:
+            raise MacroAPIError(f"FRED API returned {status}")
+        if status >= 400:
+            detail = self._extract_error_detail(response)
+            raise MacroAPIError(f"FRED API error {status}: {detail}")
+        try:
+            data = response.json()
+        except (ValueError, json.JSONDecodeError) as exc:
+            raise MacroAPIError("Invalid JSON response from FRED") from exc
+        if not isinstance(data, Mapping):
+            raise MacroAPIError("Unexpected payload type from FRED")
+        return data
+
+    @staticmethod
+    def _extract_error_detail(response: requests.Response) -> str:
+        try:
+            data = response.json()
+        except Exception:  # pragma: no cover - best effort logging
+            return response.text or "unknown error"
+        if isinstance(data, Mapping):
+            message = data.get("error_message") or data.get("message")
+            if message:
+                return str(message)
+        return response.text or "unknown error"

--- a/infrastructure/test/test_macro_fred_client.py
+++ b/infrastructure/test/test_macro_fred_client.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import itertools
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from infrastructure.macro.fred_client import (
+    FredClient,
+    FredSeriesObservation,
+    MacroAPIError,
+    MacroAuthenticationError,
+    MacroRateLimitError,
+)
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: Optional[Dict[str, Any]] = None, text: str = "") -> None:
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self) -> Dict[str, Any]:
+        if self._payload is None:
+            raise ValueError("no payload")
+        return self._payload
+
+
+class DummySession:
+    def __init__(self, responses: List[DummyResponse]) -> None:
+        self._responses = itertools.cycle(responses)
+        self.calls: List[Dict[str, Any]] = []
+
+    def get(self, url: str, params: Dict[str, Any]) -> DummyResponse:
+        self.calls.append({"url": url, "params": params})
+        return next(self._responses)
+
+
+def test_client_adds_authentication_and_defaults() -> None:
+    responses = [
+        DummyResponse(
+            200,
+            {
+                "observations": [
+                    {"value": "1.5", "observation_date": "2023-07-01"},
+                    {"value": "nan", "observation_date": "2023-06-01"},
+                ]
+            },
+        )
+    ]
+    session = DummySession(responses)
+    client = FredClient(
+        "secret",
+        session=session,  # type: ignore[arg-type]
+        calls_per_minute=0,
+    )
+    observation = client.get_latest_observation("IPUSN")
+    assert observation == FredSeriesObservation(
+        series_id="IPUSN", value=1.5, as_of="2023-07-01"
+    )
+    assert session.calls
+    params = session.calls[0]["params"]
+    assert params["api_key"] == "secret"
+    assert params["file_type"] == "json"
+    assert params["series_id"] == "IPUSN"
+
+
+def test_client_handles_rate_limit_sleep() -> None:
+    responses = [
+        DummyResponse(200, {"observations": [{"value": "2", "observation_date": "2023-08-01"}]}),
+        DummyResponse(200, {"observations": [{"value": "3", "observation_date": "2023-09-01"}]}),
+    ]
+    session = DummySession(responses)
+
+    timeline = itertools.count(start=0, step=0.2)
+    sleeps: List[float] = []
+
+    def fake_monotonic() -> float:
+        return next(timeline)
+
+    def fake_sleep(duration: float) -> None:
+        sleeps.append(duration)
+
+    client = FredClient(
+        "key",
+        session=session,  # type: ignore[arg-type]
+        calls_per_minute=120,
+        monotonic=fake_monotonic,
+        sleeper=fake_sleep,
+    )
+
+    client.get_latest_observation("SERIES1")
+    client.get_latest_observation("SERIES2")
+
+    assert sleeps  # second call should have required sleeping
+    assert pytest.approx(sleeps[0], rel=1e-5) == max(0.0, 0.5 - 0.2)
+
+
+def test_client_raises_for_auth_and_rate_limit_errors() -> None:
+    auth_session = DummySession([DummyResponse(401, {"error_message": "Bad key"})])
+    client_auth = FredClient(
+        "bad",
+        session=auth_session,  # type: ignore[arg-type]
+        calls_per_minute=0,
+    )
+    with pytest.raises(MacroAuthenticationError):
+        client_auth.get_latest_observation("S")
+
+    rate_session = DummySession([DummyResponse(429, {"error_message": "Slow down"})])
+    client_rate = FredClient(
+        "slow",
+        session=rate_session,  # type: ignore[arg-type]
+        calls_per_minute=0,
+    )
+    with pytest.raises(MacroRateLimitError):
+        client_rate.get_latest_observation("S")
+
+
+def test_client_raises_for_invalid_payload() -> None:
+    session = DummySession([DummyResponse(200, None)])
+    client = FredClient(
+        "key",
+        session=session,  # type: ignore[arg-type]
+        calls_per_minute=0,
+    )
+    with pytest.raises(MacroAPIError):
+        client.get_latest_observation("S")

--- a/services/health.py
+++ b/services/health.py
@@ -59,6 +59,27 @@ def record_fx_api_response(
     }
 
 
+def record_macro_api_usage(
+    *,
+    provider: str,
+    status: str,
+    elapsed_ms: Optional[float] = None,
+    detail: Optional[str] = None,
+    fallback: bool = False,
+) -> None:
+    """Persist information about the macro/sector data provider."""
+
+    store = _store()
+    store["macro_api"] = {
+        "provider": str(provider or "unknown"),
+        "status": str(status or "unknown"),
+        "elapsed_ms": float(elapsed_ms) if elapsed_ms is not None else None,
+        "detail": _clean_detail(detail),
+        "fallback": bool(fallback),
+        "ts": time.time(),
+    }
+
+
 def record_fx_cache_usage(mode: str, *, age: Optional[float] = None) -> None:
     """Persist information about session cache usage for FX rates."""
     store = _store()

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -6,6 +6,8 @@ variables, `streamlit` secrets or ``config.json`` via ``shared.config``.
 """
 from __future__ import annotations
 
+from typing import Dict
+
 from shared.config import settings as _config_settings
 
 # Re-export the shared Settings instance so existing imports keep working.
@@ -41,6 +43,20 @@ FEATURE_OPPORTUNITIES_TAB: bool = bool(
     getattr(settings, "FEATURE_OPPORTUNITIES_TAB", False)
 )
 
+# Macro data provider configuration
+macro_api_provider: str = getattr(settings, "MACRO_API_PROVIDER", "fred")
+fred_api_key: str | None = getattr(settings, "FRED_API_KEY", None)
+fred_api_base_url: str = getattr(
+    settings, "FRED_API_BASE_URL", "https://api.stlouisfed.org/fred"
+)
+fred_api_rate_limit_per_minute: int = getattr(
+    settings, "FRED_API_RATE_LIMIT_PER_MINUTE", 120
+)
+fred_sector_series: Dict[str, str] = getattr(settings, "FRED_SECTOR_SERIES", {})
+macro_sector_fallback: Dict[str, Dict[str, object]] = getattr(
+    settings, "MACRO_SECTOR_FALLBACK", {}
+)
+
 __all__ = [
     "settings",
     "cache_ttl_portfolio",
@@ -64,4 +80,10 @@ __all__ = [
     "MIN_SCORE_THRESHOLD",
     "MAX_RESULTS",
     "FEATURE_OPPORTUNITIES_TAB",
+    "macro_api_provider",
+    "fred_api_key",
+    "fred_api_base_url",
+    "fred_api_rate_limit_per_minute",
+    "fred_sector_series",
+    "macro_sector_fallback",
 ]


### PR DESCRIPTION
## Summary
- add a dedicated FRED client with authentication, rate limiting and unit coverage
- enrich the opportunities controller with a macro_outlook column, fallback handling and health metrics
- expose macro provider settings and document the integration and failover workflow

## Testing
- PYTHONPATH=. pytest infrastructure/test/test_macro_fred_client.py controllers/test/test_opportunities_macro.py


------
https://chatgpt.com/codex/tasks/task_e_68ddf91ee8388332b20e0bde0eb4c19a