### PR TITLE
Add World Bank macro provider fallback

### DIFF
--- a/controllers/test/test_opportunities_macro.py
+++ b/controllers/test/test_opportunities_macro.py
@@ -23,6 +23,7 @@ def test_enrich_with_macro_uses_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
     monkeypatch.setattr(opportunities, "macro_api_provider", "fred")
     monkeypatch.setattr(opportunities, "fred_api_key", None)
     monkeypatch.setattr(opportunities, "fred_sector_series", {})
+    monkeypatch.setattr(opportunities, "world_bank_sector_series", {})
     monkeypatch.setattr(
         opportunities,
         "macro_sector_fallback",
@@ -34,6 +35,11 @@ def test_enrich_with_macro_uses_fallback(monkeypatch: pytest.MonkeyPatch) -> Non
     assert metrics["macro_source"] == "fallback"
     assert "2.50" in df[opportunities._MACRO_COLUMN].iloc[0]
     assert any("fallback" in note for note in notes)
+    attempts = metrics["macro_provider_attempts"]
+    assert attempts[0]["provider"] == "fred"
+    assert attempts[0]["status"] == "disabled"
+    assert attempts[-1]["provider"] == "fallback"
+    assert attempts[-1]["status"] == "success"
 
 
 def test_enrich_with_macro_uses_fred(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -48,7 +54,13 @@ def test_enrich_with_macro_uses_fred(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(opportunities, "fred_api_key", "dummy")
     monkeypatch.setattr(opportunities, "fred_sector_series", {"Finance": "SERIES"})
     monkeypatch.setattr(opportunities, "macro_sector_fallback", {})
-    monkeypatch.setattr(opportunities, "_get_macro_client", lambda: DummyClient())
+    monkeypatch.setattr(opportunities, "world_bank_sector_series", {})
+
+    def _fake_client(provider: str):
+        assert provider == "fred"
+        return DummyClient()
+
+    monkeypatch.setattr(opportunities, "_get_macro_client", _fake_client)
 
     notes, metrics = opportunities._enrich_with_macro_context(df)
 
@@ -56,3 +68,44 @@ def test_enrich_with_macro_uses_fred(monkeypatch: pytest.MonkeyPatch) -> None:
     assert metrics["macro_sector_coverage"] == 1
     assert "1.75" in df[opportunities._MACRO_COLUMN].iloc[0]
     assert any("FRED" in note for note in notes)
+    attempts = metrics["macro_provider_attempts"]
+    assert len(attempts) == 1
+    assert attempts[0]["provider"] == "fred"
+    assert attempts[0]["status"] == "success"
+
+
+def test_enrich_with_macro_uses_secondary_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    df = pd.DataFrame({"sector": ["Energy"]})
+
+    class DummyWorldBankClient:
+        def get_latest_observations(self, mapping: Dict[str, str]) -> Dict[str, FredSeriesObservation]:
+            assert mapping == {"Energy": "WB_SERIES"}
+            return {
+                "Energy": FredSeriesObservation(
+                    series_id="WB_SERIES", value=3.4, as_of="2023-07-01"
+                )
+            }
+
+    monkeypatch.setattr(opportunities, "macro_api_provider", "worldbank")
+    monkeypatch.setattr(opportunities, "fred_api_key", None)
+    monkeypatch.setattr(opportunities, "fred_sector_series", {})
+    monkeypatch.setattr(opportunities, "world_bank_sector_series", {"Energy": "WB_SERIES"})
+    monkeypatch.setattr(opportunities, "macro_sector_fallback", {})
+
+    def _fake_client(provider: str):
+        if provider == "fred":
+            return None
+        assert provider == "worldbank"
+        return DummyWorldBankClient()
+
+    monkeypatch.setattr(opportunities, "_get_macro_client", _fake_client)
+
+    notes, metrics = opportunities._enrich_with_macro_context(df)
+
+    assert metrics["macro_source"] == "worldbank"
+    assert "3.40" in df[opportunities._MACRO_COLUMN].iloc[0]
+    assert any("World Bank" in note for note in notes)
+    attempts = metrics["macro_provider_attempts"]
+    assert [attempt["status"] for attempt in attempts] == ["disabled", "success"]
+    assert attempts[0]["provider"] == "fred"
+    assert attempts[1]["provider"] == "worldbank"

--- a/infrastructure/macro/__init__.py
+++ b/infrastructure/macro/__init__.py
@@ -1,10 +1,20 @@
 """Clients for macroeconomic and sector-level data providers."""
 
-from .fred_client import FredClient, FredSeriesObservation, MacroAPIError, MacroAuthenticationError, MacroRateLimitError
+from .fred_client import (
+    FredClient,
+    FredSeriesObservation,
+    MacroAPIError,
+    MacroAuthenticationError,
+    MacroRateLimitError,
+    MacroSeriesObservation,
+)
+from .worldbank_client import WorldBankClient
 
 __all__ = [
     "FredClient",
+    "WorldBankClient",
     "FredSeriesObservation",
+    "MacroSeriesObservation",
     "MacroAPIError",
     "MacroAuthenticationError",
     "MacroRateLimitError",

--- a/infrastructure/macro/rate_limiter.py
+++ b/infrastructure/macro/rate_limiter.py
@@ -1,0 +1,43 @@
+"""Utility helpers shared across macro data providers."""
+from __future__ import annotations
+
+import time
+from threading import Lock
+from typing import Callable
+
+
+class RateLimiter:
+    """Simple rate limiter that spaces out requests at a fixed interval."""
+
+    def __init__(
+        self,
+        *,
+        calls_per_minute: int,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        if calls_per_minute < 0:
+            raise ValueError("calls_per_minute must be >= 0")
+        self._interval = 0.0
+        if calls_per_minute:
+            self._interval = 60.0 / float(calls_per_minute)
+        self._monotonic = monotonic
+        self._sleep = sleeper
+        self._lock = Lock()
+        self._next_time = 0.0
+
+    def acquire(self) -> None:
+        """Block until the caller is allowed to make another request."""
+
+        if self._interval <= 0:
+            return
+        with self._lock:
+            now = self._monotonic()
+            wait_for = self._next_time - now
+            if wait_for > 0:
+                self._sleep(wait_for)
+                now = self._monotonic()
+            self._next_time = now + self._interval
+
+
+__all__ = ["RateLimiter"]

--- a/infrastructure/macro/worldbank_client.py
+++ b/infrastructure/macro/worldbank_client.py
@@ -1,0 +1,152 @@
+"""HTTP client for the World Bank open data API."""
+from __future__ import annotations
+
+import json
+import time
+from typing import Any, Callable, Dict, Iterable, Mapping, MutableMapping, Optional
+
+import requests
+
+from infrastructure.http.session import build_session
+
+from .fred_client import MacroAPIError, MacroAuthenticationError, MacroRateLimitError, MacroSeriesObservation
+from .rate_limiter import RateLimiter
+
+
+class WorldBankClient:
+    """Dedicated HTTP client for the World Bank macro indicators API."""
+
+    def __init__(
+        self,
+        *,
+        api_key: Optional[str] = None,
+        base_url: str = "https://api.worldbank.org/v2",
+        session: Optional[requests.Session] = None,
+        calls_per_minute: int = 60,
+        user_agent: Optional[str] = None,
+        monotonic: Callable[[], float] = time.monotonic,
+        sleeper: Callable[[float], None] = time.sleep,
+    ) -> None:
+        self._api_key = api_key
+        self._base_url = base_url.rstrip("/")
+        self._session = session or build_session(user_agent or "Portafolio-IOL/1.0")
+        self._rate_limiter = RateLimiter(
+            calls_per_minute=calls_per_minute, monotonic=monotonic, sleeper=sleeper
+        )
+
+    # Public API -----------------------------------------------------------
+    def get_latest_observation(
+        self, indicator: str, *, params: Optional[Mapping[str, Any]] = None
+    ) -> Optional[MacroSeriesObservation]:
+        """Return the most recent valid observation for ``indicator``."""
+
+        payload = self._request_json(
+            f"country/all/indicator/{indicator}",
+            {
+                "format": "json",
+                "per_page": 5,
+                "date": params.get("date") if params else None,
+            },
+        )
+
+        if not isinstance(payload, Iterable):
+            return None
+
+        # The World Bank API typically returns a list: [metadata, [observations...]]
+        observations = None
+        for part in payload:
+            if isinstance(part, Iterable) and not isinstance(part, (str, bytes, bytearray)):
+                observations = part
+        if not isinstance(observations, Iterable):
+            return None
+
+        for item in observations:
+            if not isinstance(item, Mapping):
+                continue
+            raw_value = item.get("value")
+            try:
+                value = float(raw_value)
+            except (TypeError, ValueError):
+                continue
+            as_of = str(item.get("date") or item.get("observation_date") or "").strip()
+            if not as_of:
+                continue
+            return MacroSeriesObservation(series_id=indicator, value=value, as_of=as_of)
+        return None
+
+    def get_latest_observations(
+        self, indicators_map: Mapping[str, str]
+    ) -> Dict[str, MacroSeriesObservation]:
+        """Return observations for the provided mapping of label -> indicator."""
+
+        results: Dict[str, MacroSeriesObservation] = {}
+        for label, indicator in indicators_map.items():
+            if not indicator:
+                continue
+            observation = self.get_latest_observation(indicator)
+            if observation is None:
+                continue
+            results[label] = observation
+        return results
+
+    # Internal helpers ----------------------------------------------------
+    def _request_json(
+        self, endpoint: str, params: Optional[MutableMapping[str, Any]] = None
+    ) -> Any:
+        url = f"{self._base_url}/{endpoint.lstrip('/')}"
+        query: Dict[str, Any] = {}
+        headers: Dict[str, str] = {}
+        if params:
+            for key, value in params.items():
+                if value is None:
+                    continue
+                query[key] = value
+        if self._api_key:
+            headers["Authorization"] = f"Bearer {self._api_key}"
+
+        self._rate_limiter.acquire()
+        response = self._session.get(url, params=query, headers=headers)
+        status = response.status_code
+        if status in {401, 403}:
+            raise MacroAuthenticationError("World Bank API rejected the provided credentials")
+        if status == 429:
+            raise MacroRateLimitError("World Bank API rate limit exceeded")
+        if status >= 500:
+            raise MacroAPIError(f"World Bank API returned {status}")
+        if status >= 400:
+            detail = self._extract_error_detail(response)
+            raise MacroAPIError(f"World Bank API error {status}: {detail}")
+        try:
+            data = response.json()
+        except (ValueError, json.JSONDecodeError) as exc:
+            raise MacroAPIError("Invalid JSON response from World Bank") from exc
+        return data
+
+    @staticmethod
+    def _extract_error_detail(response: requests.Response) -> str:
+        try:
+            data = response.json()
+        except Exception:  # pragma: no cover - best effort logging
+            return response.text or "unknown error"
+        if isinstance(data, Iterable):
+            for part in data:
+                if isinstance(part, Mapping):
+                    message = part.get("message") or part.get("error")
+                    if message:
+                        if isinstance(message, Mapping):
+                            text = message.get("value")
+                            if text:
+                                return str(text)
+                        return str(message)
+        if isinstance(data, Mapping):
+            message = data.get("message")
+            if isinstance(message, Mapping):
+                text = message.get("value")
+                if text:
+                    return str(text)
+            if message:
+                return str(message)
+        return response.text or "unknown error"
+
+
+__all__ = ["WorldBankClient"]

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -56,6 +56,16 @@ fred_sector_series: Dict[str, str] = getattr(settings, "FRED_SECTOR_SERIES", {})
 macro_sector_fallback: Dict[str, Dict[str, object]] = getattr(
     settings, "MACRO_SECTOR_FALLBACK", {}
 )
+world_bank_api_key: str | None = getattr(settings, "WORLD_BANK_API_KEY", None)
+world_bank_api_base_url: str = getattr(
+    settings, "WORLD_BANK_API_BASE_URL", "https://api.worldbank.org/v2"
+)
+world_bank_api_rate_limit_per_minute: int = getattr(
+    settings, "WORLD_BANK_API_RATE_LIMIT_PER_MINUTE", 60
+)
+world_bank_sector_series: Dict[str, str] = getattr(
+    settings, "WORLD_BANK_SECTOR_SERIES", {}
+)
 
 __all__ = [
     "settings",
@@ -86,4 +96,8 @@ __all__ = [
     "fred_api_rate_limit_per_minute",
     "fred_sector_series",
     "macro_sector_fallback",
+    "world_bank_api_key",
+    "world_bank_api_base_url",
+    "world_bank_api_rate_limit_per_minute",
+    "world_bank_sector_series",
 ]


### PR DESCRIPTION
## Summary
- add a World Bank macro client and reusable rate limiter for macro providers
- extend the opportunities controller to try FRED, a configurable secondary provider, and the static fallback while recording telemetry
- document the new settings and update unit tests for FRED, secondary, and fallback flows

## Testing
- PYTHONPATH=. pytest controllers/test/test_opportunities_macro.py

------
https://chatgpt.com/codex/tasks/task_e_68de485f067c83329a3e16271ff412a9