### PR TITLE
Bump release metadata to 0.3.24

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.23"
+version = "0.3.24"
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -8,7 +8,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     import tomli as _toml  # type: ignore[import-untyped]
 
 
-DEFAULT_VERSION = "0.3.23"
+DEFAULT_VERSION = "0.3.24"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project metadata to version 0.3.24 and keep the runtime default in sync
- refresh the README quick-start and macro fallback sections to document the World Bank provider and new health sidebar aggregates

## Testing
- pytest tests/test_version_display.py tests/ui/test_health_sidebar.py controllers/test/test_opportunities_macro.py

------
https://chatgpt.com/codex/tasks/task_e_68de55450da08332aeeca1dcf23d571c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Updated guides and examples for release 0.3.24.
  - Expanded macro provider fallback to include World Bank with sequence-based flow and latency tracking.
  - Clarified telemetry and health metrics, including per-provider latency buckets and UI alignment with persisted health data.
  - Refined cache behavior explanations for presets/screenings, including indicators and invalidation.
  - Updated configuration references and UI copy related to health checks and macro summaries.
- Chores
  - Bumped version to 0.3.24.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->