### PR TITLE
Refactor portfolio section view-model handling

### DIFF
--- a/application/test/test_portfolio_viewmodel.py
+++ b/application/test/test_portfolio_viewmodel.py
@@ -1,0 +1,61 @@
+import pandas as pd
+import pandas.testing as pdt
+import pytest
+
+from application.portfolio_viewmodel import (
+    build_portfolio_viewmodel,
+    get_portfolio_tabs,
+)
+from domain.models import Controls
+
+
+def test_build_portfolio_viewmodel_computes_totals_and_metrics():
+    df_pos = pd.DataFrame({'simbolo': ['AAA']})
+    controls = Controls(refresh_secs=60)
+    filtered = pd.DataFrame({
+        'simbolo': ['AAA'],
+        'valor_actual': [120.0],
+        'costo': [100.0],
+    })
+
+    vm = build_portfolio_viewmodel(
+        df_pos=df_pos,
+        controls=controls,
+        cli=object(),
+        portfolio_service=object(),
+        fx_rates={'ccl': 900.0},
+        all_symbols=['AAA'],
+        apply_filters_fn=lambda *a, **k: filtered,
+    )
+
+    pdt.assert_frame_equal(vm.positions, filtered)
+    assert vm.controls is controls
+    assert vm.totals.total_value == pytest.approx(120.0)
+    assert vm.totals.total_cost == pytest.approx(100.0)
+    assert vm.totals.total_pl == pytest.approx(20.0)
+    assert vm.metrics.refresh_secs == 60
+    assert vm.metrics.ccl_rate == 900.0
+    assert vm.metrics.all_symbols == ('AAA',)
+    assert vm.metrics.has_positions is True
+    assert vm.tab_options == get_portfolio_tabs()
+
+
+def test_build_portfolio_viewmodel_handles_missing_data():
+    controls = Controls()
+
+    vm = build_portfolio_viewmodel(
+        df_pos=pd.DataFrame(),
+        controls=controls,
+        cli=None,
+        portfolio_service=None,
+        fx_rates=None,
+        all_symbols=None,
+        apply_filters_fn=lambda *a, **k: None,
+    )
+
+    assert isinstance(vm.positions, pd.DataFrame)
+    assert vm.positions.empty
+    assert vm.metrics.has_positions is False
+    assert vm.metrics.ccl_rate is None
+    assert vm.metrics.all_symbols == ()
+    assert vm.controls is controls

--- a/controllers/portfolio/__init__.py
+++ b/controllers/portfolio/__init__.py
@@ -1,4 +1,10 @@
 from .portfolio import render_portfolio_section
+from application.portfolio_viewmodel import (
+    build_portfolio_viewmodel,
+    get_portfolio_tabs,
+    PortfolioMetrics,
+    PortfolioViewModel,
+)
 from .load_data import load_portfolio_data
 from .filters import apply_filters
 from .charts import (
@@ -11,6 +17,10 @@ from .fundamentals import render_fundamental_analysis
 
 __all__ = [
     "render_portfolio_section",
+    "build_portfolio_viewmodel",
+    "get_portfolio_tabs",
+    "PortfolioMetrics",
+    "PortfolioViewModel",
     "load_portfolio_data",
     "apply_filters",
     "generate_basic_charts",

--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -1,4 +1,5 @@
 import logging
+
 import streamlit as st
 
 from domain.models import Controls
@@ -9,6 +10,7 @@ from ui.export import PLOTLY_CONFIG
 from ui.charts import plot_technical_analysis_chart
 from application.portfolio_service import PortfolioService, map_to_us_ticker
 from application.ta_service import TAService
+from application.portfolio_viewmodel import build_portfolio_viewmodel
 from shared.errors import AppError
 
 from .load_data import load_portfolio_data
@@ -34,29 +36,28 @@ def render_portfolio_section(container, cli, fx_rates):
 
         refresh_secs = controls.refresh_secs
 
-        df_view = apply_filters(df_pos, controls, cli, psvc)
+        viewmodel = build_portfolio_viewmodel(
+            df_pos=df_pos,
+            controls=controls,
+            cli=cli,
+            portfolio_service=psvc,
+            fx_rates=fx_rates,
+            all_symbols=all_symbols,
+            apply_filters_fn=apply_filters,
+        )
 
-        ccl_rate = fx_rates.get("ccl")
-
-        tab_labels = [
-            "📂 Portafolio",
-            "📊 Análisis avanzado",
-            "🎲 Análisis de Riesgo",
-            "📑 Análisis fundamental",
-            "🔎 Análisis de activos",
-        ]
-
-        if "portfolio_tab" not in st.session_state:
-            st.session_state["portfolio_tab"] = 0
+        tab_labels = list(viewmodel.tab_options)
 
         tab_idx = st.radio(
             "Secciones",
             options=range(len(tab_labels)),
             format_func=lambda i: tab_labels[i],
-            index=st.session_state["portfolio_tab"],
             horizontal=True,
+            key="portfolio_tab",
         )
-        st.session_state["portfolio_tab"] = tab_idx
+        controls = viewmodel.controls
+        ccl_rate = viewmodel.metrics.ccl_rate
+        df_view = viewmodel.positions
 
         if tab_idx == 0:
             render_basic_section(df_view, controls, ccl_rate)
@@ -68,12 +69,13 @@ def render_portfolio_section(container, cli, fx_rates):
             render_fundamental_analysis(df_view, tasvc)
         else:
             st.subheader("Indicadores técnicos por activo")
-            if not all_symbols:
+            all_symbols_vm = list(viewmodel.metrics.all_symbols)
+            if not all_symbols_vm:
                 st.info("No hay símbolos en el portafolio para analizar.")
             else:
                 sym = st.selectbox(
                     "Seleccioná un símbolo (CEDEAR / ETF)",
-                    options=all_symbols,
+                    options=all_symbols_vm,
                     index=0,
                     key="ta_symbol",
                 )

--- a/controllers/test/test_portfolio_controller.py
+++ b/controllers/test/test_portfolio_controller.py
@@ -4,8 +4,31 @@ from unittest.mock import MagicMock, patch, ANY
 import pandas as pd
 import pytest
 
-from controllers.portfolio import render_portfolio_section
+from controllers.portfolio import (
+    PortfolioMetrics,
+    PortfolioViewModel,
+    get_portfolio_tabs,
+    render_portfolio_section,
+)
+from application.portfolio_service import calculate_totals
 from domain.models import Controls
+
+
+def _make_viewmodel(df: pd.DataFrame, controls: Controls, all_symbols=None, ccl_rate=None):
+    totals = calculate_totals(df)
+    metrics = PortfolioMetrics(
+        refresh_secs=controls.refresh_secs,
+        ccl_rate=ccl_rate,
+        all_symbols=tuple(all_symbols or ()),
+        has_positions=not df.empty,
+    )
+    return PortfolioViewModel(
+        positions=df,
+        totals=totals,
+        controls=controls,
+        metrics=metrics,
+        tab_options=get_portfolio_tabs(),
+    )
 
 
 def test_render_portfolio_section_returns_refresh_secs_and_handles_empty():
@@ -16,15 +39,17 @@ def test_render_portfolio_section_returns_refresh_secs_and_handles_empty():
     mock_st.radio.return_value = 0
 
     empty_df = pd.DataFrame(columns=['simbolo'])
+    controls = Controls(refresh_secs=55)
+    vm = _make_viewmodel(empty_df, controls, all_symbols=[])
 
     with patch('controllers.portfolio.portfolio.st', mock_st), \
          patch('controllers.portfolio.charts.st', mock_st), \
          patch('controllers.portfolio.portfolio.PortfolioService'), \
          patch('controllers.portfolio.portfolio.TAService'), \
          patch('controllers.portfolio.portfolio.load_portfolio_data', return_value=(pd.DataFrame(), [], [])), \
-         patch('controllers.portfolio.portfolio.render_sidebar', return_value=Controls(refresh_secs=55)), \
+         patch('controllers.portfolio.portfolio.render_sidebar', return_value=controls), \
          patch('controllers.portfolio.portfolio.render_ui_controls'), \
-         patch('controllers.portfolio.portfolio.apply_filters', return_value=empty_df), \
+         patch('controllers.portfolio.portfolio.build_portfolio_viewmodel', return_value=vm), \
          patch('controllers.portfolio.portfolio.render_advanced_analysis'), \
          patch('controllers.portfolio.portfolio.render_risk_analysis'), \
          patch('controllers.portfolio.portfolio.render_fundamental_analysis'):
@@ -41,13 +66,16 @@ def test_ta_section_without_symbols_shows_message():
     mock_st.session_state = {}
     mock_st.radio.return_value = 4
 
+    controls = Controls(refresh_secs=0)
+    vm = _make_viewmodel(pd.DataFrame(), controls, all_symbols=[])
+
     with patch('controllers.portfolio.portfolio.st', mock_st), \
          patch('controllers.portfolio.portfolio.PortfolioService'), \
          patch('controllers.portfolio.portfolio.TAService'), \
          patch('controllers.portfolio.portfolio.load_portfolio_data', return_value=(pd.DataFrame(), [], [])), \
-         patch('controllers.portfolio.portfolio.render_sidebar', return_value=Controls(refresh_secs=0)), \
+         patch('controllers.portfolio.portfolio.render_sidebar', return_value=controls), \
          patch('controllers.portfolio.portfolio.render_ui_controls'), \
-         patch('controllers.portfolio.portfolio.apply_filters', return_value=pd.DataFrame()), \
+         patch('controllers.portfolio.portfolio.build_portfolio_viewmodel', return_value=vm), \
          patch('controllers.portfolio.portfolio.render_basic_section'), \
          patch('controllers.portfolio.portfolio.render_advanced_analysis'), \
          patch('controllers.portfolio.portfolio.render_risk_analysis'), \
@@ -74,14 +102,16 @@ def test_tabs_render_expected_sections(tab_idx, func_name):
     mock_st.radio.return_value = tab_idx
 
     df = pd.DataFrame({'simbolo': ['AAA']})
+    controls = Controls(refresh_secs=0)
+    vm = _make_viewmodel(df, controls, all_symbols=['AAA'])
 
     with patch('controllers.portfolio.portfolio.st', mock_st), \
          patch('controllers.portfolio.portfolio.PortfolioService'), \
          patch('controllers.portfolio.portfolio.TAService'), \
          patch('controllers.portfolio.portfolio.load_portfolio_data', return_value=(df, ['AAA'], [])), \
-         patch('controllers.portfolio.portfolio.render_sidebar', return_value=Controls(refresh_secs=0)), \
+         patch('controllers.portfolio.portfolio.render_sidebar', return_value=controls), \
          patch('controllers.portfolio.portfolio.render_ui_controls'), \
-         patch('controllers.portfolio.portfolio.apply_filters', return_value=df), \
+         patch('controllers.portfolio.portfolio.build_portfolio_viewmodel', return_value=vm), \
          patch('controllers.portfolio.portfolio.render_basic_section') as basic, \
          patch('controllers.portfolio.portfolio.render_advanced_analysis') as adv, \
          patch('controllers.portfolio.portfolio.render_risk_analysis') as risk, \
@@ -111,14 +141,16 @@ def test_ta_section_symbol_without_us_ticker():
     mock_st.columns.return_value = [MagicMock(), MagicMock(), MagicMock()]
 
     df = pd.DataFrame({'simbolo': ['AAA']})
+    controls = Controls(refresh_secs=0)
+    vm = _make_viewmodel(df, controls, all_symbols=['AAA'])
 
     with patch('controllers.portfolio.portfolio.st', mock_st), \
          patch('controllers.portfolio.portfolio.PortfolioService'), \
          patch('controllers.portfolio.portfolio.TAService'), \
          patch('controllers.portfolio.portfolio.load_portfolio_data', return_value=(df, ['AAA'], [])), \
-         patch('controllers.portfolio.portfolio.render_sidebar', return_value=Controls(refresh_secs=0)), \
+         patch('controllers.portfolio.portfolio.render_sidebar', return_value=controls), \
          patch('controllers.portfolio.portfolio.render_ui_controls'), \
-         patch('controllers.portfolio.portfolio.apply_filters', return_value=df), \
+         patch('controllers.portfolio.portfolio.build_portfolio_viewmodel', return_value=vm), \
          patch('controllers.portfolio.portfolio.map_to_us_ticker', side_effect=ValueError('invalid')), \
          patch('controllers.portfolio.portfolio.render_basic_section'), \
          patch('controllers.portfolio.portfolio.render_advanced_analysis'), \
@@ -160,13 +192,16 @@ def test_ta_section_symbol_with_empty_df():
     mock_tasvc.fundamentals.return_value = {}
     mock_tasvc.indicators_for.return_value = pd.DataFrame()
 
+    controls = Controls(refresh_secs=0)
+    vm = _make_viewmodel(df, controls, all_symbols=['AAA'])
+
     with patch('controllers.portfolio.portfolio.st', mock_st), \
          patch('controllers.portfolio.portfolio.PortfolioService'), \
          patch('controllers.portfolio.portfolio.TAService', return_value=mock_tasvc), \
          patch('controllers.portfolio.portfolio.load_portfolio_data', return_value=(df, ['AAA'], [])), \
-         patch('controllers.portfolio.portfolio.render_sidebar', return_value=Controls(refresh_secs=0)), \
+         patch('controllers.portfolio.portfolio.render_sidebar', return_value=controls), \
          patch('controllers.portfolio.portfolio.render_ui_controls'), \
-         patch('controllers.portfolio.portfolio.apply_filters', return_value=df), \
+         patch('controllers.portfolio.portfolio.build_portfolio_viewmodel', return_value=vm), \
          patch('controllers.portfolio.portfolio.map_to_us_ticker', return_value='AA'), \
          patch('controllers.portfolio.portfolio.render_basic_section'), \
          patch('controllers.portfolio.portfolio.render_advanced_analysis'), \
@@ -205,13 +240,16 @@ def test_ta_section_symbol_with_data():
     mock_tasvc.alerts_for.return_value = []
     mock_tasvc.backtest.return_value = pd.DataFrame({'equity': [1.0, 1.1]})
 
+    controls = Controls(refresh_secs=0)
+    vm = _make_viewmodel(df, controls, all_symbols=['AAA'])
+
     with patch('controllers.portfolio.portfolio.st', mock_st), \
          patch('controllers.portfolio.portfolio.PortfolioService'), \
          patch('controllers.portfolio.portfolio.TAService', return_value=mock_tasvc), \
          patch('controllers.portfolio.portfolio.load_portfolio_data', return_value=(df, ['AAA'], [])), \
-         patch('controllers.portfolio.portfolio.render_sidebar', return_value=Controls(refresh_secs=0)), \
+         patch('controllers.portfolio.portfolio.render_sidebar', return_value=controls), \
          patch('controllers.portfolio.portfolio.render_ui_controls'), \
-         patch('controllers.portfolio.portfolio.apply_filters', return_value=df), \
+         patch('controllers.portfolio.portfolio.build_portfolio_viewmodel', return_value=vm), \
          patch('controllers.portfolio.portfolio.map_to_us_ticker', return_value='AA'), \
          patch('controllers.portfolio.portfolio.render_basic_section'), \
          patch('controllers.portfolio.portfolio.render_advanced_analysis'), \


### PR DESCRIPTION
## Summary
- add a portfolio view-model builder with tab metadata, totals, and metrics
- refactor the portfolio controller to consume the new view-model service and re-export helpers
- extend the test suite to cover the pure builder and update controller tests to use it

## Testing
- pytest controllers/test/test_portfolio_controller.py application/test/test_portfolio_viewmodel.py

------
https://chatgpt.com/codex/tasks/task_e_68de5545c9f0833298b4f7792894f2f9