### PR TITLE
Add favorite symbol management across portfolio views

### DIFF
--- a/controllers/portfolio/fundamentals.py
+++ b/controllers/portfolio/fundamentals.py
@@ -1,6 +1,8 @@
 import logging
 import streamlit as st
 
+from shared.favorite_symbols import FavoriteSymbols
+from ui.favorites import render_favorite_badges, render_favorite_toggle
 from ui.fundamentals import (
     render_fundamental_ranking,
     render_sector_comparison,
@@ -11,9 +13,36 @@ from shared.errors import AppError
 logger = logging.getLogger(__name__)
 
 
-def render_fundamental_analysis(df_view, tasvc):
+def render_fundamental_analysis(df_view, tasvc, favorites: FavoriteSymbols | None = None):
     """Render fundamental analysis section."""
+    favorites = favorites or FavoriteSymbols(st.session_state)
     st.subheader("Análisis fundamental del portafolio")
+    symbols = (
+        sorted({str(sym) for sym in df_view.get("simbolo", []) if str(sym).strip()})
+        if not df_view.empty
+        else []
+    )
+
+    render_favorite_badges(
+        favorites,
+        empty_message="⭐ Marcá favoritos para enfocarte en los activos clave al analizar fundamentos.",
+    )
+    if symbols:
+        options = favorites.sort_options(symbols)
+        selected_symbol = st.selectbox(
+            "Gestionar favoritos",
+            options=options,
+            index=favorites.default_index(options),
+            key="fundamental_favorite_select",
+            format_func=favorites.format_symbol,
+        )
+        render_favorite_toggle(
+            selected_symbol,
+            favorites,
+            key_prefix="fundamental",
+            help_text="Los favoritos se comparten entre todas las pestañas y exportaciones.",
+        )
+
     portfolio_symbols = df_view["simbolo"].tolist()
     if portfolio_symbols:
         with st.spinner("Descargando datos fundamentales…"):

--- a/shared/favorite_symbols.py
+++ b/shared/favorite_symbols.py
@@ -1,0 +1,127 @@
+"""Utilities to manage favorite symbols persisted in Streamlit session state."""
+from __future__ import annotations
+
+from typing import Iterable, MutableMapping, Sequence
+
+import streamlit as st
+
+
+class FavoriteSymbols:
+    """Manage a shared list of favorite symbols stored in ``st.session_state``."""
+
+    STATE_KEY = "favorite_symbols"
+
+    def __init__(self, state: MutableMapping[str, object] | None = None) -> None:
+        self._state = state if state is not None else st.session_state
+        if self.STATE_KEY not in self._state:
+            self._state[self.STATE_KEY] = []
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    def _normalize(self, symbol: str | None) -> str:
+        if symbol is None:
+            return ""
+        sym = str(symbol).strip().upper()
+        return sym
+
+    def normalize(self, symbol: str | None) -> str:
+        """Public wrapper returning the canonical representation for ``symbol``."""
+        return self._normalize(symbol)
+
+    # ------------------------------------------------------------------
+    # CRUD operations
+    def list(self) -> list[str]:
+        """Return the current list of favorite symbols."""
+        return list(self._state.get(self.STATE_KEY, []))
+
+    def is_favorite(self, symbol: str | None) -> bool:
+        """Check whether the provided symbol is currently marked as favorite."""
+        sym = self._normalize(symbol)
+        if not sym:
+            return False
+        return sym in self._state[self.STATE_KEY]
+
+    def add(self, symbol: str | None) -> None:
+        """Add a symbol to the favorites list."""
+        sym = self._normalize(symbol)
+        if not sym:
+            return
+        favorites = self._state[self.STATE_KEY]
+        if sym not in favorites:
+            favorites.append(sym)
+
+    def remove(self, symbol: str | None) -> None:
+        """Remove a symbol from the favorites list."""
+        sym = self._normalize(symbol)
+        if not sym:
+            return
+        favorites = self._state[self.STATE_KEY]
+        if sym in favorites:
+            favorites.remove(sym)
+
+    def replace(self, symbols: Iterable[str]) -> list[str]:
+        """Replace the favorites list with the given iterable of symbols."""
+        normalized: list[str] = []
+        for symbol in symbols:
+            sym = self._normalize(symbol)
+            if sym and sym not in normalized:
+                normalized.append(sym)
+        self._state[self.STATE_KEY] = normalized
+        return normalized
+
+    def toggle(self, symbol: str | None, *, value: bool | None = None) -> bool:
+        """Toggle the favorite state for ``symbol``.
+
+        Args:
+            symbol: Symbol to toggle.
+            value: Optional explicit state. When ``None`` the value will
+                be flipped.
+
+        Returns:
+            bool: The resulting favorite state.
+        """
+        sym = self._normalize(symbol)
+        if not sym:
+            return False
+        current = self.is_favorite(sym)
+        target = not current if value is None else bool(value)
+        if target and not current:
+            self.add(sym)
+        elif not target and current:
+            self.remove(sym)
+        return target
+
+    # ------------------------------------------------------------------
+    # Helpers for UI integration
+    def format_symbol(self, symbol: str | None) -> str:
+        """Format a symbol for display, highlighting favorites."""
+        sym = self._normalize(symbol)
+        if not sym:
+            return ""
+        return f"⭐ {sym}" if self.is_favorite(sym) else sym
+
+    def sort_options(self, options: Sequence[str]) -> list[str]:
+        """Return options sorted with favorites first and alphabetical inside each group."""
+        unique = []
+        seen: set[str] = set()
+        for opt in options:
+            sym = self._normalize(opt)
+            if sym and sym not in seen:
+                seen.add(sym)
+                unique.append(sym)
+        favorites = set(self.list())
+        fav_items = sorted([s for s in unique if s in favorites])
+        rest = sorted([s for s in unique if s not in favorites])
+        return fav_items + rest
+
+    def default_index(self, options: Sequence[str]) -> int:
+        """Return the default index prioritising the first favorite in ``options``."""
+        favorites = self.list()
+        normalized_options = [self._normalize(opt) for opt in options]
+        for favorite in favorites:
+            if favorite in normalized_options:
+                return normalized_options.index(favorite)
+        return 0 if options else 0
+
+
+__all__ = ["FavoriteSymbols"]

--- a/shared/test/test_favorite_symbols.py
+++ b/shared/test/test_favorite_symbols.py
@@ -1,0 +1,48 @@
+from shared.favorite_symbols import FavoriteSymbols
+
+
+def test_initializes_state_when_missing():
+    state: dict[str, object] = {}
+    fav = FavoriteSymbols(state)
+    assert state[FavoriteSymbols.STATE_KEY] == []
+    assert fav.list() == []
+
+
+def test_add_remove_and_toggle_symbols():
+    state: dict[str, object] = {}
+    fav = FavoriteSymbols(state)
+    fav.add("ggal")
+    fav.add(" GGAL ")
+    fav.add("APBR")
+    assert fav.list() == ["GGAL", "APBR"]
+
+    fav.remove("GGAL")
+    assert fav.list() == ["APBR"]
+
+    fav.toggle("apbr")
+    assert fav.list() == []
+    fav.toggle("PAMP")
+    assert fav.list() == ["PAMP"]
+
+
+def test_replace_and_helpers():
+    state: dict[str, object] = {}
+    fav = FavoriteSymbols(state)
+    fav.replace(["apbr", "GGAL", "ggal"])
+    assert fav.list() == ["APBR", "GGAL"]
+    assert fav.format_symbol("apbr") == "⭐ APBR"
+    assert fav.format_symbol("pamp") == "PAMP"
+
+    options = ["PAMP", "APBR", "GGAL"]
+    sorted_opts = fav.sort_options(options)
+    assert sorted_opts[:2] == ["APBR", "GGAL"]
+    assert fav.default_index(sorted_opts) == 0
+
+    fav.toggle("pamp")
+    assert fav.default_index(sorted_opts) == 0
+
+
+def test_is_favorite_handles_none():
+    fav = FavoriteSymbols({})
+    assert not fav.is_favorite(None)
+    assert fav.toggle(None) is False

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -13,6 +13,7 @@ from controllers.portfolio import risk as risk_mod
 from ui.fx_panels import render_spreads
 import ui.fx_panels as fx_panels
 import ui.tables as tables_mod
+from shared.favorite_symbols import FavoriteSymbols
 
 
 class DummyCtx:
@@ -38,7 +39,9 @@ def test_render_basic_section_captions(monkeypatch):
     monkeypatch.setattr(charts_mod.st, "columns", lambda n: (DummyCtx(), DummyCtx()))
     mock_caption = MagicMock()
     monkeypatch.setattr(charts_mod.st, "caption", mock_caption)
-    charts_mod.render_basic_section(df, controls, None)
+    monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
+    charts_mod.render_basic_section(df, controls, None, favorites=FavoriteSymbols({}))
     captions = [c.args[0] for c in mock_caption.call_args_list]
     expected = [
         "Barras que muestran qué activos ganan o pierden más. Las más altas son las que más afectan tu resultado.",
@@ -65,7 +68,9 @@ def test_render_risk_analysis_caption(monkeypatch):
     monkeypatch.setattr(risk_mod.st, "caption", mock_caption)
     monkeypatch.setattr(risk_mod, "plot_correlation_heatmap", lambda df: object())
     monkeypatch.setattr(risk_mod, "compute_returns", lambda df: pd.DataFrame())
-    risk_mod.render_risk_analysis(df, tasvc)
+    monkeypatch.setattr(risk_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod, "render_favorite_toggle", lambda *a, **k: None)
+    risk_mod.render_risk_analysis(df, tasvc, favorites=FavoriteSymbols({}))
     assert any("heatmap de correlación" in str(c.args[0]) for c in mock_caption.call_args_list)
 
 

--- a/ui/favorites.py
+++ b/ui/favorites.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import streamlit as st
+
+from shared.favorite_symbols import FavoriteSymbols
+
+_BADGE_STYLE_KEY = "_favorite_badge_css"
+
+
+def _ensure_badge_styles() -> None:
+    if st.session_state.get(_BADGE_STYLE_KEY):
+        return
+    st.markdown(
+        """
+        <style>
+        .favorite-badges { margin-bottom: 0.5rem; }
+        .favorite-badge {
+            display: inline-block;
+            background-color: rgba(255, 215, 0, 0.15);
+            color: #b8860b;
+            border: 1px solid rgba(184, 134, 11, 0.4);
+            border-radius: 999px;
+            padding: 0.1rem 0.6rem;
+            margin-right: 0.3rem;
+            font-size: 0.85rem;
+        }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+    st.session_state[_BADGE_STYLE_KEY] = True
+
+
+def render_favorite_badges(
+    favorites: FavoriteSymbols,
+    *,
+    title: str = "⭐ Favoritos",
+    empty_message: str = "⭐ Aún no marcaste favoritos.",
+) -> None:
+    """Render a badge list with the current favorites."""
+    _ensure_badge_styles()
+    favs = favorites.list()
+    if not favs:
+        st.caption(empty_message)
+        return
+    badges = " ".join(f"<span class='favorite-badge'>⭐ {sym}</span>" for sym in favs)
+    st.markdown(
+        f"<div class='favorite-badges'><strong>{title}:</strong> {badges}</div>",
+        unsafe_allow_html=True,
+    )
+
+
+def render_favorite_toggle(
+    symbol: str | None,
+    favorites: FavoriteSymbols,
+    *,
+    key_prefix: str,
+    help_text: str | None = None,
+) -> bool:
+    """Render a toggle to mark/unmark the provided symbol as favorite."""
+    if not symbol:
+        st.caption("Seleccioná un símbolo para poder marcarlo como favorito.")
+        return False
+
+    toggle_key = f"favorite_toggle_{key_prefix}"
+    last_symbol_key = f"favorite_toggle_last_{key_prefix}"
+
+    current_symbol = favorites.normalize(symbol)
+    last_symbol = st.session_state.get(last_symbol_key)
+    current_state = favorites.is_favorite(current_symbol)
+
+    if last_symbol != current_symbol:
+        st.session_state[last_symbol_key] = current_symbol
+        st.session_state[toggle_key] = current_state
+
+    toggled = st.toggle(
+        "⭐ Marcar como favorito",
+        key=toggle_key,
+        help=help_text,
+    )
+
+    if toggled and not current_state:
+        favorites.add(current_symbol)
+    elif not toggled and current_state:
+        favorites.remove(current_symbol)
+
+    return toggled
+
+
+__all__ = [
+    "render_favorite_badges",
+    "render_favorite_toggle",
+]


### PR DESCRIPTION
## Summary
- add a shared FavoriteSymbols helper with Streamlit session persistence
- expose reusable badge/toggle UI helpers and wire favorites into the portfolio, risk and fundamental tabs
- surface favorite status in the positions table export and cover the helper with unit tests

## Testing
- PYTHONPATH=. pytest shared/test/test_favorite_symbols.py -q
- PYTHONPATH=. pytest controllers/test/test_portfolio_helpers.py::test_render_basic_section_with_data -q
- PYTHONPATH=. pytest tests/test_captions.py::test_render_basic_section_captions -q
- PYTHONPATH=. pytest tests/test_captions.py::test_render_risk_analysis_caption -q
- PYTHONPATH=. pytest ui/test/test_tables.py -q

------
https://chatgpt.com/codex/tasks/task_e_68de55498c888332b48d6a43f9825ad0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced Favorites: mark/unmark symbols with a toggle and persistent session storage.
  - Display favorite badges and a star “Favorito” column in tables; favorites included in exports.
  - Option lists now prioritize favorites and default to a favorite when available.
  - Integrated across Portfolio, Basic, Risk, and Fundamentals views with helpful empty-state messages.

- Tests
  - Added comprehensive tests for favorites behavior and updated existing tests to use favorites, stubbing related UI where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->