### PR TITLE
docs: add changelog entry for 0.3.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+## [0.3.24.1] - 2025-10-09
+
+### Tests
+- La suite de CI recuperó su estabilidad tras ajustar los timeouts intermitentes y sincronizar los entornos de ejecución.
+
+### Changed
+- Los mocks de proveedores externos fueron alineados con los contratos vigentes para evitar desfasajes durante las pruebas integradas.
+
+### Fixed
+- La persistencia de favoritos ahora conserva los emisores marcados entre sesiones, incluso al alternar entre vistas y filtros derivados.
+
+### Documentation
+- Guías actualizadas describiendo la estabilidad recuperada, los mocks vigentes y el flujo persistente de favoritos para el release 0.3.24.1.
+
 ## [0.3.24] - 2025-10-08
 
 ### Changed


### PR DESCRIPTION
## Summary
- add the 0.3.24.1 section to the changelog with notes on test stability, external mocks, favorites persistence, and documentation
- leave the Unreleased section ready for future additions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dea4bd56308332ae30c5597a5d6ae9