### PR TITLE
Document CI/CD pytest workflows and coverage review

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ los tiempos de iteración al dejar a la vista el impacto de cada cambio.
 
 - [Guía de troubleshooting](docs/troubleshooting.md)
 - [Guía de pruebas](docs/testing.md)
+- [Integración en CI/CD](docs/testing.md#integración-en-cicd): ejemplos de pipelines para instalar dependencias,
+  forzar los mocks (`RUN_LIVE_YF=0`) y ejecutar `pytest --maxfail=1 --disable-warnings -q`. Los jobs adjuntan
+  el directorio `htmlcov`; descárgalo desde los artefactos del pipeline y abre `index.html` para revisar la
+  cobertura en detalle.
 
 ## Uso del proveedor de tiempo
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,3 +55,84 @@ recomienda ejecutarlos sólo en entornos controlados.
 
 El proyecto utiliza fixtures que escriben artefactos temporales bajo `tmp_path`. Asegúrate de contar
 con permisos de escritura en el directorio temporal del sistema.
+
+## Integración en CI/CD
+
+Para mantener las ejecuciones reproducibles en pipelines, establece las variables de entorno que
+desactivan integraciones externas y ejecuta la suite en modo compacto. Los siguientes ejemplos
+ilustran cómo instalar dependencias, inyectar los mocks por defecto y lanzar `pytest` en los sistemas
+de CI más comunes.
+
+### GitHub Actions
+
+```yaml
+name: qa
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    env:
+      RUN_LIVE_YF: "0"           # Fuerza el uso de stubs para Yahoo Finance
+      FRED_API_KEY: ""          # Variables vacías para evitar llamadas reales
+      WORLD_BANK_API_KEY: ""
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+      - name: Instalar dependencias
+        run: |
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Ejecutar pruebas
+        run: pytest --maxfail=1 --disable-warnings -q
+      - name: Generar coverage
+        run: pytest --cov=application --cov=controllers --cov-report=term --cov-report=html
+      - name: Publicar artefacto coverage
+        uses: actions/upload-artifact@v4
+        with:
+          name: htmlcov
+          path: htmlcov
+```
+
+El artefacto `htmlcov/index.html` queda disponible en la sección "Artifacts" del job. Descárgalo y
+abre el archivo en tu navegador para revisar los módulos con menor cobertura.
+
+### GitLab CI
+
+```yaml
+stages:
+  - test
+
+pytest:
+  stage: test
+  image: python:3.10-slim
+  variables:
+    RUN_LIVE_YF: "0"
+    FRED_API_KEY: ""
+    WORLD_BANK_API_KEY: ""
+    PIP_CACHE_DIR: "$CI_PROJECT_DIR/.cache/pip"
+  cache:
+    paths:
+      - .cache/pip
+  script:
+    - pip install -r requirements.txt -r requirements-dev.txt
+    - pytest --maxfail=1 --disable-warnings -q
+    - pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=xml
+  artifacts:
+    when: always
+    paths:
+      - coverage.xml
+      - htmlcov/
+    reports:
+      cobertura: coverage.xml
+```
+
+En GitLab, el reporte Cobertura queda adjunto al job y puede visualizarse en la pestaña **CI/CD →
+Pipelines → Jobs → Artifacts**. Para el detalle HTML, descarga el directorio `htmlcov` y abre
+`index.html` localmente.


### PR DESCRIPTION
## Summary
- add a CI/CD integration section to the testing guide with GitHub Actions and GitLab CI examples
- document environment variables to force mocks and how to publish coverage artifacts for review
- link the new guidance from the README, highlighting how to download and inspect the htmlcov report

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68dea4bf2bcc83328dc6390ff78b9660