### PR TITLE
Fix apply_filters NameError in portfolio controller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+## [0.3.24.2] - 2025-10-10
+
+### Fixed
+- Se corrigió el `NameError` en `render_portfolio_section` al eliminar la referencia
+  obsoleta a `apply_filters` y delegar la construcción del view-model al servicio
+  cacheado de portafolio.
+
+### Changed
+- `build_portfolio_viewmodel` ahora recibe un `PortfolioViewSnapshot` en lugar de
+  ejecutar filtros manualmente, alineando la nueva capa de cache con los
+  controladores.
+
+### Tests
+- Se actualizaron las suites de portafolio para simular el servicio de view-model
+  cacheado y validar el flujo completo tras el refactor.
+
 ## [0.3.24.1] - 2025-10-09
 
 ### Tests

--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -13,7 +13,7 @@ from application.portfolio_service import PortfolioService, map_to_us_ticker
 from application.ta_service import TAService
 from application.portfolio_viewmodel import build_portfolio_viewmodel
 from shared.errors import AppError
-from shared.favorite_symbols import FavoriteSymbols, get_persistent_favorites
+from shared.favorite_symbols import get_persistent_favorites
 from services.portfolio_view import PortfolioViewModelService
 
 from .load_data import load_portfolio_data
@@ -38,14 +38,18 @@ def render_portfolio_section(container, cli, fx_rates):
         render_ui_controls()
 
         refresh_secs = controls.refresh_secs
-        viewmodel = build_portfolio_viewmodel(
+        snapshot = view_model_service.get_portfolio_view(
             df_pos=df_pos,
             controls=controls,
             cli=cli,
-            portfolio_service=psvc,
+            psvc=psvc,
+        )
+
+        viewmodel = build_portfolio_viewmodel(
+            snapshot=snapshot,
+            controls=controls,
             fx_rates=fx_rates,
             all_symbols=all_symbols,
-            apply_filters_fn=apply_filters,
         )
 
         tab_labels = list(viewmodel.tab_options)
@@ -62,7 +66,13 @@ def render_portfolio_section(container, cli, fx_rates):
         df_view = viewmodel.positions
 
         if tab_idx == 0:
-            render_basic_section(df_view, controls, ccl_rate, favorites=favorites, totals=snapshot.totals)
+            render_basic_section(
+                df_view,
+                controls,
+                ccl_rate,
+                favorites=favorites,
+                totals=viewmodel.totals,
+            )
         elif tab_idx == 1:
             render_advanced_analysis(df_view)
         elif tab_idx == 2:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,6 +4,18 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Portafolio y datos de mercado
 
+- **La app falla con `NameError: name 'apply_filters' is not defined`.**
+  - **Síntomas:** Al iniciar sesión, Streamlit detiene la ejecución y
+    muestra el error anterior en `controllers/portfolio/portfolio.py`.
+  - **Diagnóstico rápido:** Confirmá que estés ejecutando la versión
+    `0.3.24.2` o superior, donde el controlador delega la construcción
+    del view-model al servicio cacheado.
+  - **Resolución:**
+    1. Actualizá el repo a la release más reciente.
+    2. Si mantenés un fork, reemplazá llamadas directas a
+       `apply_filters` por `PortfolioViewModelService.get_portfolio_view`
+       y reutilizá `build_portfolio_viewmodel` con el snapshot devuelto.
+
 - **No se puede guardar el token de IOL y la aplicación se cierra.**
   - **Síntomas:** Streamlit termina inmediatamente con un mensaje que indica que falta la clave Fernet o que no se permiten tokens sin cifrar.
   - **Diagnóstico rápido:** Revisa las variables `IOL_TOKENS_KEY` y `IOL_ALLOW_PLAIN_TOKENS` definidas en el `.env` o en `secrets.toml`.


### PR DESCRIPTION
## Summary
- wire render_portfolio_section through PortfolioViewModelService so the controller no longer calls the removed apply_filters helper
- adjust build_portfolio_viewmodel and portfolio unit tests to consume cached snapshots from the new service
- document the regression in troubleshooting and log the fix in the 0.3.24.2 changelog entry

## Testing
- pytest controllers/test/test_portfolio_controller.py application/test/test_portfolio_viewmodel.py -q

------
https://chatgpt.com/codex/tasks/task_e_68dda6cb9cbc8332a3fce264c47f0642