### PR TITLE
Add portfolio timeline and contribution analytics

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -1,4 +1,6 @@
+import pandas as pd
 import plotly.express as px
+import plotly.graph_objects as go
 import streamlit as st
 
 from shared.favorite_symbols import FavoriteSymbols, get_persistent_favorites
@@ -6,12 +8,15 @@ from ui.favorites import render_favorite_badges, render_favorite_toggle
 from ui.tables import render_totals, render_table
 from ui.export import PLOTLY_CONFIG
 from ui.charts import (
+    _apply_layout,
     plot_pl_topn,
     plot_donut_tipo,
     plot_dist_por_tipo,
     plot_pl_daily_topn,
     plot_bubble_pl_vs_costo,
     plot_heat_pl_pct,
+    plot_portfolio_timeline,
+    plot_contribution_heatmap,
 )
 
 
@@ -31,6 +36,8 @@ def render_basic_section(
     ccl_rate,
     totals=None,
     favorites: FavoriteSymbols | None = None,
+    historical_total=None,
+    contribution_metrics=None,
 ):
     """Render totals, table and basic charts for the portfolio."""
     favorites = favorites or get_persistent_favorites()
@@ -137,6 +144,82 @@ def render_basic_section(
         )
     else:
         st.info("Aún no hay datos de P/L diario.")
+
+    st.subheader("Evolución histórica del portafolio")
+    timeline_fig = plot_portfolio_timeline(historical_total)
+    if timeline_fig is not None:
+        st.plotly_chart(
+            timeline_fig,
+            width="stretch",
+            key="portfolio_timeline",
+            config=PLOTLY_CONFIG,
+        )
+        st.caption(
+            "Sigue cómo varían tus totales (valor, costo y P/L) con el tiempo para detectar tendencias y cambios relevantes."
+        )
+    else:
+        st.info("Aún no hay suficientes datos históricos del portafolio.")
+
+    st.subheader("Contribución por símbolo y tipo")
+    by_symbol = getattr(contribution_metrics, "by_symbol", None)
+    heatmap_fig = plot_contribution_heatmap(by_symbol)
+    if heatmap_fig is not None:
+        st.plotly_chart(
+            heatmap_fig,
+            width="stretch",
+            key="portfolio_contribution_heatmap",
+            config=PLOTLY_CONFIG,
+        )
+        st.caption(
+            "Visualiza qué combinaciones de tipo y símbolo concentran mayor peso en tu cartera."
+        )
+    else:
+        st.info("Sin datos de contribución por símbolo para mostrar el mapa de calor.")
+
+    by_type = getattr(contribution_metrics, "by_type", None)
+    if isinstance(by_type, pd.DataFrame) and not by_type.empty:
+        display_cols = [
+            col
+            for col in ["tipo", "valor_actual", "valor_actual_pct", "pl", "pl_pct"]
+            if col in by_type.columns
+        ]
+        df_table = by_type[display_cols].copy()
+        for col in df_table.columns:
+            if col == "tipo":
+                df_table[col] = df_table[col].astype(str)
+            elif col.endswith("_pct"):
+                df_table[col] = df_table[col].apply(
+                    lambda v: f"{float(v):.2f}%" if pd.notna(v) else "—"
+                )
+            else:
+                df_table[col] = df_table[col].apply(
+                    lambda v: f"{float(v):,.0f}" if pd.notna(v) else "—"
+                )
+
+        table_fig = go.Figure(
+            data=[
+                go.Table(
+                    header=dict(
+                        values=[col.replace("_", " ").title() for col in df_table.columns],
+                        fill_color="rgba(0,0,0,0)",
+                        align="left",
+                    ),
+                    cells=dict(
+                        values=[df_table[col].tolist() for col in df_table.columns],
+                        align="left",
+                    ),
+                )
+            ]
+        )
+        table_fig = _apply_layout(table_fig, show_legend=False)
+        st.plotly_chart(
+            table_fig,
+            width="stretch",
+            key="portfolio_contribution_table",
+            config=PLOTLY_CONFIG,
+        )
+    else:
+        st.info("No hay datos agregados por tipo para mostrar en tabla.")
 
 
 def render_advanced_analysis(df_view):

--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -72,6 +72,8 @@ def render_portfolio_section(container, cli, fx_rates):
                 ccl_rate,
                 favorites=favorites,
                 totals=viewmodel.totals,
+                historical_total=viewmodel.historical_total,
+                contribution_metrics=viewmodel.contributions,
             )
         elif tab_idx == 1:
             render_advanced_analysis(df_view)

--- a/tests/test_portfolio_charts.py
+++ b/tests/test_portfolio_charts.py
@@ -13,6 +13,8 @@ if str(ROOT_DIR) not in sys.path:
 
 
 from controllers.portfolio.charts import generate_basic_charts
+from services.portfolio_view import PortfolioContributionMetrics
+from ui.charts import plot_portfolio_timeline, plot_contribution_heatmap
 
 
 def test_generate_basic_charts_produces_figures():
@@ -42,3 +44,58 @@ def test_generate_basic_charts_produces_figures():
     assert set(charts.keys()) == {"pl_topn", "donut_tipo", "dist_tipo", "pl_diario"}
     for name, fig in charts.items():
         assert isinstance(fig, go.Figure), f"Expected {name} to be a Plotly figure"
+
+
+def test_plot_portfolio_timeline_handles_history():
+    history = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=4, freq="D"),
+            "total_value": [1000.0, 1050.0, 990.0, 1100.0],
+            "total_cost": [900.0, 900.0, 900.0, 900.0],
+        }
+    )
+
+    fig = plot_portfolio_timeline(history)
+
+    assert isinstance(fig, go.Figure)
+    assert fig.data, "Expected timeline figure to contain traces"
+
+
+def test_plot_contribution_heatmap_from_contribution_metrics():
+    metrics = PortfolioContributionMetrics(
+        by_symbol=pd.DataFrame(
+            {
+                "tipo": ["ACCION", "ACCION", "BONO"],
+                "simbolo": ["GGAL", "YPFD", "AL30"],
+                "valor_actual": [1000.0, 500.0, 300.0],
+                "costo": [800.0, 600.0, 250.0],
+                "pl": [200.0, -100.0, 50.0],
+                "pl_d": [10.0, -5.0, 1.0],
+                "valor_actual_pct": [50.0, 25.0, 25.0],
+                "pl_pct": [57.14, -28.57, 14.29],
+            }
+        ),
+        by_type=pd.DataFrame(
+            {
+                "tipo": ["ACCION", "BONO"],
+                "valor_actual": [1500.0, 300.0],
+                "costo": [1400.0, 250.0],
+                "pl": [100.0, 50.0],
+                "pl_d": [5.0, 1.0],
+                "valor_actual_pct": [83.33, 16.67],
+                "pl_pct": [66.67, 33.33],
+            }
+        ),
+    )
+
+    fig = plot_contribution_heatmap(metrics.by_symbol)
+
+    assert isinstance(fig, go.Figure)
+    assert fig.data, "Heatmap should include data traces"
+
+
+def test_plot_contribution_heatmap_handles_empty_df():
+    empty_metrics = PortfolioContributionMetrics.empty()
+
+    assert plot_portfolio_timeline(pd.DataFrame()) is None
+    assert plot_contribution_heatmap(empty_metrics.by_symbol) is None

--- a/tests/ui/test_portfolio_ui.py
+++ b/tests/ui/test_portfolio_ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Sequence
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -13,8 +14,14 @@ _PROJECT_ROOT = Path(__file__).resolve().parents[2]
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+from controllers.portfolio.charts import render_basic_section
 from controllers.portfolio.portfolio import render_portfolio_section
+from application.portfolio_service import PortfolioTotals
 from domain.models import Controls
+from services.portfolio_view import (
+    PortfolioContributionMetrics,
+    PortfolioViewSnapshot,
+)
 
 
 class _DummyContainer:
@@ -59,11 +66,26 @@ class FakeStreamlit:
         self.plot_calls: list[dict[str, Any]] = []
         self.line_charts: list[pd.DataFrame] = []
         self.metrics: list[tuple[Any, Any, Any]] = []
+        self.markdowns: list[dict[str, Any]] = []
 
     # ---- Core widgets -------------------------------------------------
-    def radio(self, label: str, *, options: Sequence[int], format_func, index: int, horizontal: bool) -> int:
+    def radio(
+        self,
+        label: str,
+        *,
+        options: Sequence[int],
+        format_func,
+        index: int = 0,
+        horizontal: bool,
+        **kwargs: Any,
+    ) -> int:
         value = next(self._radio_iter)
-        self.radio_calls.append({"label": label, "options": list(options), "index": index})
+        record = {"label": label, "options": list(options), "index": index}
+        key = kwargs.get("key")
+        if key is not None:
+            record["key"] = key
+            self.session_state[key] = value
+        self.radio_calls.append(record)
         return value
 
     def selectbox(self, label: str, options: Sequence[Any], index: int = 0, key: str | None = None, **_: Any) -> Any:
@@ -120,6 +142,9 @@ class FakeStreamlit:
     def metric(self, label: str, value: Any, delta: Any | None = None) -> None:
         self.metrics.append((label, value, delta))
 
+    def markdown(self, body: str, *, unsafe_allow_html: bool = False) -> None:
+        self.markdowns.append({"body": body, "unsafe": unsafe_allow_html})
+
     def columns_context(self, layout: Sequence[Any]) -> None:  # pragma: no cover - helper for compatibility
         return None
 
@@ -140,6 +165,20 @@ def _portfolio_setup(monkeypatch: pytest.MonkeyPatch):
 
     def _configure(fake_st: FakeStreamlit, *, df_view: pd.DataFrame | None = None, all_symbols: list[str] | None = None):
         portfolio_mod.st = fake_st
+        monkeypatch.setattr(portfolio_mod, "render_favorite_badges", lambda *a, **k: None)
+        monkeypatch.setattr(portfolio_mod, "render_favorite_toggle", lambda *a, **k: None)
+
+        class _FavoritesStub:
+            def sort_options(self, options):
+                return list(options)
+
+            def default_index(self, options):
+                return 0 if options else 0
+
+            def format_symbol(self, sym):
+                return sym
+
+        monkeypatch.setattr(portfolio_mod, "get_persistent_favorites", lambda: _FavoritesStub())
         monkeypatch.setattr(portfolio_mod, "PortfolioService", lambda: MagicMock())
         monkeypatch.setattr(portfolio_mod, "TAService", lambda: MagicMock())
 
@@ -168,7 +207,19 @@ def _portfolio_setup(monkeypatch: pytest.MonkeyPatch):
         monkeypatch.setattr(portfolio_mod, "render_ui_controls", lambda: None)
 
         df_view = df_view or pd.DataFrame({"simbolo": ["GGAL"], "valor_actual": [1200.0]})
-        monkeypatch.setattr(portfolio_mod, "apply_filters", lambda *a, **k: df_view)
+
+        def _fake_snapshot(*_args, **_kwargs):
+            return PortfolioViewSnapshot(
+                df_view=df_view,
+                totals=PortfolioTotals(0.0, 0.0, 0.0, float("nan"), 0.0),
+                apply_elapsed=0.0,
+                totals_elapsed=0.0,
+                generated_at=0.0,
+                historical_total=pd.DataFrame(),
+                contribution_metrics=PortfolioContributionMetrics.empty(),
+            )
+
+        monkeypatch.setattr(portfolio_mod.view_model_service, "get_portfolio_view", _fake_snapshot)
 
         basic = MagicMock()
         advanced = MagicMock()
@@ -263,3 +314,137 @@ def test_render_portfolio_section_renders_symbol_selector_for_favorites(_portfol
     # Ensure advanced analysis helpers were not triggered in this branch
     advanced.assert_not_called()
     basic.assert_not_called()
+
+
+def test_render_basic_section_renders_timeline_and_heatmap(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_st = FakeStreamlit(radio_sequence=[])
+
+    import controllers.portfolio.charts as charts_mod
+
+    class DummyFavorites:
+        def sort_options(self, options):
+            return list(options)
+
+        def default_index(self, options):
+            return 0 if options else 0
+
+        def format_symbol(self, sym):
+            return sym
+
+    favorites_stub = DummyFavorites()
+
+    monkeypatch.setattr(charts_mod, "st", fake_st)
+    monkeypatch.setattr(charts_mod, "render_totals", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_table", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "get_persistent_favorites", lambda: favorites_stub)
+
+    df_view = pd.DataFrame(
+        {
+            "simbolo": ["GGAL", "AL30"],
+            "tipo": ["ACCION", "BONO"],
+            "valor_actual": [1200.0, 800.0],
+            "pl": [200.0, 50.0],
+            "pl_d": [10.0, 5.0],
+        }
+    )
+    controls = SimpleNamespace(order_by="valor_actual", desc=True, top_n=5, show_usd=False)
+    history = pd.DataFrame(
+        {
+            "timestamp": pd.date_range("2024-01-01", periods=3, freq="D"),
+            "total_value": [1500.0, 1600.0, 1700.0],
+            "total_cost": [1400.0, 1400.0, 1400.0],
+        }
+    )
+    contributions = PortfolioContributionMetrics(
+        by_symbol=pd.DataFrame(
+            {
+                "tipo": ["ACCION", "BONO"],
+                "simbolo": ["GGAL", "AL30"],
+                "valor_actual": [1200.0, 800.0],
+                "costo": [1000.0, 750.0],
+                "pl": [200.0, 50.0],
+                "pl_d": [10.0, 5.0],
+                "valor_actual_pct": [60.0, 40.0],
+                "pl_pct": [80.0, 20.0],
+            }
+        ),
+        by_type=pd.DataFrame(
+            {
+                "tipo": ["ACCION", "BONO"],
+                "valor_actual": [1200.0, 800.0],
+                "costo": [1000.0, 750.0],
+                "pl": [200.0, 50.0],
+                "pl_d": [10.0, 5.0],
+                "valor_actual_pct": [60.0, 40.0],
+                "pl_pct": [80.0, 20.0],
+            }
+        ),
+    )
+
+    render_basic_section(
+        df_view,
+        controls,
+        ccl_rate=1000.0,
+        totals=None,
+        favorites=None,
+        historical_total=history,
+        contribution_metrics=contributions,
+    )
+
+    plotted_keys = {call["kwargs"].get("key") for call in fake_st.plot_calls}
+    assert {"portfolio_timeline", "portfolio_contribution_heatmap", "portfolio_contribution_table"}.issubset(
+        plotted_keys
+    )
+    assert not any("históricos" in msg for msg in fake_st.warnings)
+
+
+def test_render_basic_section_handles_missing_analytics(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_st = FakeStreamlit(radio_sequence=[])
+
+    import controllers.portfolio.charts as charts_mod
+
+    class DummyFavorites:
+        def sort_options(self, options):
+            return list(options)
+
+        def default_index(self, options):
+            return 0 if options else 0
+
+        def format_symbol(self, sym):
+            return sym
+
+    favorites_stub = DummyFavorites()
+
+    monkeypatch.setattr(charts_mod, "st", fake_st)
+    monkeypatch.setattr(charts_mod, "render_totals", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_table", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "get_persistent_favorites", lambda: favorites_stub)
+
+    df_view = pd.DataFrame(
+        {
+            "simbolo": ["GGAL"],
+            "tipo": ["ACCION"],
+            "valor_actual": [1200.0],
+            "pl": [200.0],
+            "pl_d": [10.0],
+        }
+    )
+    controls = SimpleNamespace(order_by="valor_actual", desc=True, top_n=5, show_usd=False)
+
+    render_basic_section(
+        df_view,
+        controls,
+        ccl_rate=1000.0,
+        totals=None,
+        favorites=None,
+        historical_total=pd.DataFrame(),
+        contribution_metrics=PortfolioContributionMetrics.empty(),
+    )
+
+    info_messages = " ".join(fake_st.warnings)
+    assert "históricos" in info_messages
+    assert "contribución" in info_messages

--- a/ui/charts.py
+++ b/ui/charts.py
@@ -132,6 +132,134 @@ def plot_dist_por_tipo(df: pd.DataFrame):
         fig.update_yaxes(title=None, tickformat=",")
     return _apply_layout(fig, show_legend=False)
 
+
+def plot_portfolio_timeline(history_df: pd.DataFrame | None):
+    """Plot the historical evolution of the portfolio totals."""
+
+    if history_df is None or history_df.empty:
+        return None
+
+    df = history_df.copy()
+    time_col = "timestamp"
+    if time_col not in df.columns:
+        return None
+
+    if not pd.api.types.is_datetime64_any_dtype(df[time_col]):
+        df[time_col] = pd.to_datetime(df[time_col], unit="s", errors="coerce")
+
+    df = df.dropna(subset=[time_col])
+    if df.empty:
+        return None
+
+    value_cols = [
+        col
+        for col in ["total_value", "total_cost", "total_pl"]
+        if col in df.columns
+    ]
+    if not value_cols:
+        return None
+
+    df = df.sort_values(time_col)
+    melted = df.melt(
+        id_vars=[time_col],
+        value_vars=value_cols,
+        var_name="metric",
+        value_name="value",
+    )
+    melted = melted.dropna(subset=["value"])
+    if melted.empty:
+        return None
+
+    metrics = melted["metric"].astype(str).unique().tolist()
+    color_map = _symbol_color_map(metrics)
+
+    fig = px.line(
+        melted,
+        x=time_col,
+        y="value",
+        color="metric",
+        color_discrete_map=color_map,
+        markers=True,
+    )
+
+    if SHOW_AXIS_TITLES:
+        fig.update_xaxes(title="Fecha")
+        fig.update_yaxes(title="Valor", tickformat=",")
+    else:
+        fig.update_xaxes(title=None)
+        fig.update_yaxes(title=None, tickformat=",")
+
+    fig.update_traces(mode="lines+markers")
+    return _apply_layout(fig, show_legend=True)
+
+
+def plot_contribution_heatmap(by_symbol: pd.DataFrame | None, *, value_col: str = "valor_actual_pct"):
+    """Render a heatmap of contributions grouped by type and symbol."""
+
+    if by_symbol is None or by_symbol.empty:
+        return None
+
+    required = {"tipo", "simbolo", value_col}
+    if not required.issubset(by_symbol.columns):
+        return None
+
+    df = by_symbol.copy()
+    df["tipo"] = df["tipo"].astype(str).replace({"": "Sin tipo"})
+    df["simbolo"] = df["simbolo"].astype(str).replace({"": "Sin símbolo"})
+    df[value_col] = pd.to_numeric(df[value_col], errors="coerce").fillna(0.0)
+
+    pivot = (
+        df.pivot_table(
+            index="tipo",
+            columns="simbolo",
+            values=value_col,
+            aggfunc="sum",
+            fill_value=0.0,
+        )
+        .sort_index()
+    )
+
+    if pivot.empty:
+        return None
+
+    tipos = pivot.index.tolist()
+    symbols = pivot.columns.tolist()
+
+    if pivot.values.size == 0:
+        return None
+
+    type_color_map = _color_discrete_map(pd.DataFrame({"tipo": tipos}))
+    palette = list(dict.fromkeys(type_color_map.get(t, "#636EFA") for t in tipos))
+    if len(palette) < 2:
+        palette = palette * 2
+    colorscale = [
+        (i / (len(palette) - 1), color)
+        for i, color in enumerate(palette)
+    ]
+
+    fig = go.Figure(
+        data=[
+            go.Heatmap(
+                z=pivot.values,
+                x=symbols,
+                y=tipos,
+                colorscale=colorscale,
+                colorbar=dict(title="% valorizado" if value_col.endswith("pct") else value_col),
+                hovertemplate="Tipo: %{y}<br>Símbolo: %{x}<br>Valor: %{z:.2f}%<extra></extra>",
+            )
+        ]
+    )
+
+    if SHOW_AXIS_TITLES:
+        fig.update_xaxes(title="Símbolo")
+        fig.update_yaxes(title="Tipo")
+    else:
+        fig.update_xaxes(title=None)
+        fig.update_yaxes(title=None)
+
+    return _apply_layout(fig, show_legend=False)
+
+
 # =================
 # Gráficos avanzados
 # =================


### PR DESCRIPTION
## Summary
- extend the cached portfolio snapshot with historical totals and contribution aggregates
- surface the new data in the view model and basic portfolio UI, including a timeline and contribution heatmap/table
- add chart helpers plus expanded unit tests covering the new figures and empty-data handling

## Testing
- pytest tests/test_portfolio_charts.py tests/ui/test_portfolio_ui.py

------
https://chatgpt.com/codex/tasks/task_e_68df0dfa41a08332bf3ecd4a59e8dcbd