### PR TITLE
feat(portfolio): add risk metrics overlay in advanced analysis

### DIFF
--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import plotly.express as px
 import streamlit as st
 
@@ -5,6 +6,7 @@ from shared.favorite_symbols import FavoriteSymbols, get_persistent_favorites
 from ui.favorites import render_favorite_badges, render_favorite_toggle
 from ui.tables import render_totals, render_table
 from ui.export import PLOTLY_CONFIG
+from services.portfolio_view import compute_symbol_risk_metrics
 from ui.charts import (
     plot_pl_topn,
     plot_donut_tipo,
@@ -139,14 +141,85 @@ def render_basic_section(
         st.info("Aún no hay datos de P/L diario.")
 
 
-def render_advanced_analysis(df_view):
+RISK_METRIC_OPTIONS = {
+    "Volatilidad anualizada": "volatilidad",
+    "Drawdown máximo": "drawdown",
+    "Beta vs benchmark": "beta",
+}
+
+
+def _format_risk_value(metric: str, value: float, *, with_sign: bool = False) -> str:
+    if value != value:
+        return "N/A"
+    if metric in {"volatilidad", "drawdown"}:
+        return f"{value:+.2%}" if with_sign else f"{value:.2%}"
+    return f"{value:+.2f}" if with_sign else f"{value:.2f}"
+
+
+def render_advanced_analysis(df_view, tasvc, *, benchmark_choices=None):
     """Render advanced analysis charts (bubble and heatmap)."""
     st.subheader("Bubble Chart Interactivo")
-    axis_options = [
+    benchmark_choices = benchmark_choices or {
+        "S&P 500 (^GSPC)": "^GSPC",
+    }
+
+    symbols = (
+        sorted({str(sym) for sym in df_view.get("simbolo", []) if str(sym).strip()})
+        if not df_view.empty
+        else []
+    )
+
+    cols_controls = st.columns(3)
+    with cols_controls[0]:
+        period = st.selectbox(
+            "Período de métricas",
+            options=["3mo", "6mo", "1y", "2y"],
+            index=2,
+            key="bubble_period",
+        )
+    with cols_controls[1]:
+        metric_label = st.selectbox(
+            "Métrica de riesgo",
+            options=list(RISK_METRIC_OPTIONS.keys()),
+            index=0,
+            key="bubble_risk_metric",
+        )
+    with cols_controls[2]:
+        bench_label = st.selectbox(
+            "Benchmark",
+            options=list(benchmark_choices.keys()),
+            index=0,
+            key="bubble_benchmark",
+        )
+    benchmark_symbol = benchmark_choices[bench_label]
+
+    metrics_df = compute_symbol_risk_metrics(
+        tasvc,
+        symbols,
+        benchmark=benchmark_symbol,
+        period=period,
+    )
+
+    assets_df = df_view.copy()
+    benchmark_row = pd.DataFrame()
+    if not metrics_df.empty:
+        asset_metrics = metrics_df.loc[~metrics_df["es_benchmark"]].drop(
+            columns=["es_benchmark"], errors="ignore"
+        )
+        assets_df = assets_df.merge(asset_metrics, on="simbolo", how="left")
+        benchmark_row = metrics_df.loc[metrics_df["es_benchmark"]]
+
+    axis_candidates = [
         c
         for c in ["costo", "pl", "pl_%", "valor_actual", "pl_d"]
-        if c in df_view.columns
+        if c in assets_df.columns
     ]
+    for c in RISK_METRIC_OPTIONS.values():
+        if c in assets_df.columns:
+            axis_candidates.append(c)
+
+    axis_options = list(dict.fromkeys(axis_candidates))
+
     if not axis_options:
         st.info("No hay columnas disponibles para el gráfico bubble.")
     else:
@@ -180,13 +253,42 @@ def render_advanced_analysis(df_view):
             "G10": px.colors.qualitative.G10,
         }
         color_seq = palette_map.get(palette_opt) if palette_opt != "Tema" else None
+        bubble_df = assets_df.copy()
+        if not benchmark_row.empty:
+            bench_data = benchmark_row.iloc[0].to_dict()
+            bench_entry = {col: None for col in bubble_df.columns}
+            bench_entry.update(bench_data)
+            bench_entry.setdefault("simbolo", benchmark_symbol)
+            if "valor_actual" in bubble_df.columns:
+                avg_val = bubble_df["valor_actual"].dropna()
+                bench_entry.setdefault(
+                    "valor_actual", float(avg_val.mean()) if not avg_val.empty else 0.0
+                )
+            bench_entry.setdefault("tipo", "Benchmark")
+            bubble_df = pd.concat(
+                [bubble_df, pd.DataFrame([bench_entry])], ignore_index=True
+            )
+
+        if "es_benchmark" not in bubble_df.columns:
+            if "simbolo" in bubble_df.columns:
+                bubble_df["es_benchmark"] = bubble_df["simbolo"].eq(benchmark_symbol)
+            else:
+                bubble_df["es_benchmark"] = False
+        else:
+            bubble_df["es_benchmark"] = bubble_df["es_benchmark"].fillna(False)
+        bubble_df["categoria"] = bubble_df["es_benchmark"].map(
+            {True: "Benchmark", False: "Activo"}
+        )
+
         fig = plot_bubble_pl_vs_costo(
-            df_view,
+            bubble_df,
             x_axis=x_axis,
             y_axis=y_axis,
             color_seq=color_seq,
             log_x=x_log,
             log_y=y_log,
+            category_col="categoria",
+            benchmark_col="es_benchmark",
         )
         if fig is not None:
             st.plotly_chart(
@@ -195,6 +297,26 @@ def render_advanced_analysis(df_view):
                 key="bubble_chart",
                 config=PLOTLY_CONFIG,
             )
+
+            metric_col = RISK_METRIC_OPTIONS[metric_label]
+            if metric_col in bubble_df.columns:
+                bench_value = bubble_df.loc[
+                    bubble_df["es_benchmark"], metric_col
+                ].dropna()
+                asset_values = bubble_df.loc[
+                    ~bubble_df["es_benchmark"], metric_col
+                ].dropna()
+                if not bench_value.empty and not asset_values.empty:
+                    bench_val = float(bench_value.iloc[0])
+                    avg_val = float(asset_values.mean())
+                    delta = avg_val - bench_val
+                    st.metric(
+                        f"Promedio {metric_label}",
+                        _format_risk_value(metric_col, avg_val),
+                        delta=_format_risk_value(metric_col, delta, with_sign=True),
+                        help=f"Benchmark: {bench_label} ({_format_risk_value(metric_col, bench_val)})",
+                    )
+
             with st.expander("Descripción"):
                 st.caption(
                     "Cada burbuja representa un símbolo; el tamaño refleja el valor actual. Cambia ejes, escalas y paleta para explorar distintos ángulos."

--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -74,7 +74,7 @@ def render_portfolio_section(container, cli, fx_rates):
                 totals=viewmodel.totals,
             )
         elif tab_idx == 1:
-            render_advanced_analysis(df_view)
+            render_advanced_analysis(df_view, tasvc)
         elif tab_idx == 2:
             render_risk_analysis(df_view, tasvc, favorites=favorites)
         elif tab_idx == 3:

--- a/controllers/test/test_portfolio_helpers.py
+++ b/controllers/test/test_portfolio_helpers.py
@@ -334,17 +334,48 @@ def test_render_advanced_analysis_no_columns(monkeypatch):
     monkeypatch.setattr(charts_mod.st, "subheader", lambda *a, **k: None)
     mock_info = MagicMock()
     monkeypatch.setattr(charts_mod.st, "info", mock_info)
-    pm.render_advanced_analysis(df)
+    monkeypatch.setattr(charts_mod, "compute_symbol_risk_metrics", lambda *a, **k: pd.DataFrame())
+
+    def _fake_columns(n):
+        return tuple(DummyCtx() for _ in range(n))
+
+    monkeypatch.setattr(charts_mod.st, "columns", _fake_columns)
+    monkeypatch.setattr(
+        charts_mod.st,
+        "selectbox",
+        lambda label, options, index=0, **_: options[index] if options else None,
+    )
+    monkeypatch.setattr(charts_mod.st, "checkbox", lambda *a, **k: False)
+    monkeypatch.setattr(charts_mod.st, "metric", lambda *a, **k: None)
+
+    pm.render_advanced_analysis(df, tasvc=None)
     mock_info.assert_called_once_with("No hay columnas disponibles para el gráfico bubble.")
 
 
 def test_render_advanced_analysis_missing_bubble_columns(monkeypatch):
     df = pd.DataFrame({"pl": [1, 2], "pl_%": [0.1, 0.2]})
     monkeypatch.setattr(charts_mod.st, "subheader", lambda *a, **k: None)
-    sel_vals = iter(["pl", "pl_%", "Tema", "RdBu"])
-    monkeypatch.setattr(charts_mod.st, "selectbox", lambda *a, **k: next(sel_vals))
+    monkeypatch.setattr(charts_mod, "compute_symbol_risk_metrics", lambda *a, **k: pd.DataFrame())
+
+    def _fake_selectbox(label, options, index=0, **_):
+        desired = {
+            "Período de métricas": options[index],
+            "Métrica de riesgo": options[index],
+            "Benchmark": options[index],
+            "Eje X": "pl",
+            "Eje Y": "pl_%",
+            "Paleta": "Tema",
+            "Escala de color": "RdBu",
+        }
+        return desired.get(label, options[index] if options else None)
+
+    monkeypatch.setattr(charts_mod.st, "selectbox", _fake_selectbox)
     monkeypatch.setattr(charts_mod.st, "checkbox", lambda *a, **k: False)
-    monkeypatch.setattr(charts_mod.st, "columns", lambda n: (DummyCtx(), DummyCtx()))
+    monkeypatch.setattr(
+        charts_mod.st,
+        "columns",
+        lambda n: tuple(DummyCtx() for _ in range(n)),
+    )
     info_mock = MagicMock()
     monkeypatch.setattr(charts_mod.st, "info", info_mock)
     monkeypatch.setattr(charts_mod.st, "plotly_chart", lambda *a, **k: None)
@@ -353,7 +384,7 @@ def test_render_advanced_analysis_missing_bubble_columns(monkeypatch):
     monkeypatch.setattr(charts_mod, "plot_bubble_pl_vs_costo", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "plot_heat_pl_pct", lambda *a, **k: None)
 
-    pm.render_advanced_analysis(df)
+    pm.render_advanced_analysis(df, tasvc=None)
 
     info_mock.assert_any_call("No hay datos suficientes para el gráfico bubble.")
 
@@ -371,31 +402,65 @@ def test_render_advanced_analysis_palette_and_log(monkeypatch):
         }
     )
     monkeypatch.setattr(charts_mod.st, "subheader", lambda *a, **k: None)
-    sel_vals = iter(["costo", "pl", "Plotly", "Viridis"])
-    monkeypatch.setattr(charts_mod.st, "selectbox", lambda *a, **k: next(sel_vals))
+    metrics = pd.DataFrame(
+        {
+            "simbolo": ["AL30", "GOOG", "^GSPC"],
+            "volatilidad": [0.1, 0.2, 0.15],
+            "drawdown": [-0.2, -0.3, -0.25],
+            "beta": [0.9, 1.1, 1.0],
+            "es_benchmark": [False, False, True],
+        }
+    )
+    monkeypatch.setattr(
+        charts_mod,
+        "compute_symbol_risk_metrics",
+        lambda *a, **k: metrics.copy(),
+    )
+
+    def _fake_selectbox(label, options, index=0, **_):
+        mapping = {
+            "Período de métricas": "1y",
+            "Métrica de riesgo": "Volatilidad anualizada",
+            "Benchmark": "S&P 500 (^GSPC)",
+            "Eje X": "costo",
+            "Eje Y": "pl",
+            "Paleta": "Plotly",
+            "Escala de color": "Viridis",
+        }
+        return mapping.get(label, options[index] if options else None)
+
+    monkeypatch.setattr(charts_mod.st, "selectbox", _fake_selectbox)
     chk_vals = iter([True, True])
     monkeypatch.setattr(charts_mod.st, "checkbox", lambda *a, **k: next(chk_vals))
-    monkeypatch.setattr(charts_mod.st, "columns", lambda n: (DummyCtx(), DummyCtx()))
+    monkeypatch.setattr(
+        charts_mod.st,
+        "columns",
+        lambda n: tuple(DummyCtx() for _ in range(n)),
+    )
     monkeypatch.setattr(charts_mod.st, "expander", lambda *a, **k: DummyCtx())
     monkeypatch.setattr(charts_mod.st, "caption", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod.st, "plotly_chart", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod.st, "metric", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod.st, "info", lambda *a, **k: None)
     bubble_mock = MagicMock(return_value="fig1")
     heat_mock = MagicMock(return_value="fig2")
     monkeypatch.setattr(charts_mod, "plot_bubble_pl_vs_costo", bubble_mock)
     monkeypatch.setattr(charts_mod, "plot_heat_pl_pct", heat_mock)
 
-    pm.render_advanced_analysis(df)
+    pm.render_advanced_analysis(df, tasvc=None)
 
-    bubble_mock.assert_called_once_with(
-        df,
-        x_axis="costo",
-        y_axis="pl",
-        color_seq=px.colors.qualitative.Plotly,
-        log_x=True,
-        log_y=True,
-    )
-    heat_mock.assert_called_once_with(df, color_scale="Viridis")
+    args, kwargs = bubble_mock.call_args
+    assert kwargs["x_axis"] == "costo"
+    assert kwargs["y_axis"] == "pl"
+    assert kwargs["color_seq"] == px.colors.qualitative.Plotly
+    assert kwargs["log_x"] is True
+    assert kwargs["log_y"] is True
+    assert kwargs["category_col"] == "categoria"
+    assert kwargs["benchmark_col"] == "es_benchmark"
+    result_df = args[0]
+    assert "categoria" in result_df.columns
+    assert result_df["categoria"].isin(["Activo", "Benchmark"]).all()
+    heat_mock.assert_called_once()
 
 
 def test_render_risk_analysis_insufficient_symbols(monkeypatch):

--- a/tests/test_portfolio_charts.py
+++ b/tests/test_portfolio_charts.py
@@ -13,6 +13,7 @@ if str(ROOT_DIR) not in sys.path:
 
 
 from controllers.portfolio.charts import generate_basic_charts
+from ui.charts import plot_bubble_pl_vs_costo
 
 
 def test_generate_basic_charts_produces_figures():
@@ -42,3 +43,31 @@ def test_generate_basic_charts_produces_figures():
     assert set(charts.keys()) == {"pl_topn", "donut_tipo", "dist_tipo", "pl_diario"}
     for name, fig in charts.items():
         assert isinstance(fig, go.Figure), f"Expected {name} to be a Plotly figure"
+
+
+def test_plot_bubble_with_benchmark_dataset():
+    df = pd.DataFrame(
+        {
+            "simbolo": ["AL30", "^GSPC"],
+            "valor_actual": [1500.0, 0.0],
+            "riesgo": [0.22, 0.18],
+            "pl": [120.0, 0.0],
+            "categoria": ["Activo", "Benchmark"],
+            "es_benchmark": [False, True],
+            "tipo": ["Accion", "Benchmark"],
+        }
+    )
+
+    fig = plot_bubble_pl_vs_costo(
+        df,
+        x_axis="riesgo",
+        y_axis="pl",
+        category_col="categoria",
+        benchmark_col="es_benchmark",
+    )
+
+    assert isinstance(fig, go.Figure)
+    names = {trace.name for trace in fig.data}
+    assert {"Activo", "Benchmark"}.issubset(names)
+    assert fig.layout.shapes
+    assert any(getattr(shape, "type", None) == "line" for shape in fig.layout.shapes)


### PR DESCRIPTION
## Summary
- add portfolio helper to compute per-symbol volatility, drawdown and beta for advanced analysis
- update the advanced analysis tab with risk metric controls, benchmark overlays and summary metric
- extend the bubble chart helper to support benchmark traces and cover with new UI tests

## Testing
- PYTHONPATH=. pytest controllers/test/test_portfolio_helpers.py -k advanced_analysis
- PYTHONPATH=. pytest tests/test_portfolio_charts.py -k benchmark
- PYTHONPATH=. pytest tests/ui/test_portfolio_ui.py -k advanced_analysis_controls_display

------
https://chatgpt.com/codex/tasks/task_e_68df0dfa5c988332917483e6070754c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Advanced analysis now includes risk metrics (volatility, drawdown, beta) with selectable period and metric.
  - Added benchmark selection and comparisons, including average deltas and benchmark annotations on charts.
  - Bubble chart supports category-based coloring and benchmark-aware aggregation; heatmap and new risk panel rendered together.

- Tests
  - Added tests for benchmark-aware bubble charts and presence of category/benchmark traces and lines.
  - Expanded UI tests to verify advanced analysis controls (period, risk metric, benchmark) are displayed.
  - Updated tests to cover new data paths and validations for risk metrics integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->