### PR TITLE
Enhance risk analytics with drawdown charts

### DIFF
--- a/controllers/test/test_portfolio_helpers.py
+++ b/controllers/test/test_portfolio_helpers.py
@@ -270,16 +270,30 @@ def test_compute_risk_metrics():
     expected_beta = risk_mod.beta(expected_port_ret, bench_ret)
     expected_var = risk_mod.historical_var(expected_port_ret)
     expected_opt_w = risk_mod.markowitz_optimize(returns_df)
-
-    vol, b, var_95, opt_w, port_ret = pm.compute_risk_metrics(
-        returns_df, bench_ret, weights
+    expected_asset_vols, expected_asset_drawdowns = risk_mod.asset_risk_breakdown(
+        returns_df
     )
+    expected_port_drawdown = risk_mod.max_drawdown(expected_port_ret)
+
+    (
+        vol,
+        b,
+        var_95,
+        opt_w,
+        port_ret,
+        asset_vols,
+        asset_drawdowns,
+        port_drawdown,
+    ) = pm.compute_risk_metrics(returns_df, bench_ret, weights)
 
     pd.testing.assert_series_equal(port_ret, expected_port_ret)
     assert vol == pytest.approx(expected_vol)
     assert b == pytest.approx(expected_beta)
     assert var_95 == pytest.approx(expected_var)
     pd.testing.assert_series_equal(opt_w, expected_opt_w)
+    pd.testing.assert_series_equal(asset_vols, expected_asset_vols)
+    pd.testing.assert_series_equal(asset_drawdowns, expected_asset_drawdowns)
+    assert port_drawdown == pytest.approx(expected_port_drawdown)
 
 
 def test_render_basic_section_handles_empty(monkeypatch):
@@ -453,10 +467,19 @@ def test_render_risk_analysis_valid_data(monkeypatch):
 
     monkeypatch.setattr(risk_mod.st, "expander", fake_expander)
 
-    col1 = SimpleNamespace(metric=MagicMock())
-    col2 = SimpleNamespace(metric=MagicMock())
-    col3 = SimpleNamespace(metric=MagicMock())
-    monkeypatch.setattr(risk_mod.st, "columns", lambda n: (col1, col2, col3))
+    col_metrics = [SimpleNamespace(metric=MagicMock()) for _ in range(4)]
+    vol_col = SimpleNamespace(plotly_chart=MagicMock(), info=MagicMock())
+    draw_col = SimpleNamespace(plotly_chart=MagicMock(), info=MagicMock())
+    scatter_col = SimpleNamespace(plotly_chart=MagicMock(), info=MagicMock())
+
+    columns_calls = iter(
+        [col_metrics, (vol_col, draw_col), (scatter_col,)]
+    )
+
+    def fake_columns(n):
+        return next(columns_calls)
+
+    monkeypatch.setattr(risk_mod.st, "columns", fake_columns)
 
     returns_df = pd.DataFrame({"A": [0.1, 0.2], "B": [0.05, 0.1]})
     bench_ret = pd.Series([0.03, 0.04])
@@ -470,18 +493,49 @@ def test_render_risk_analysis_valid_data(monkeypatch):
 
     fake_port_ret = pd.Series([0.01, -0.02])
     opt_w = pd.Series({"A": 0.6, "B": 0.4})
+    asset_vols = pd.Series({"A": 0.15, "B": 0.1})
+    asset_drawdowns = pd.Series({"A": -0.2, "B": -0.1})
+    port_drawdown = -0.25
     monkeypatch.setattr(
         risk_mod,
         "compute_risk_metrics",
-        lambda r, b, w: (0.2, 1.1, 0.03, opt_w, fake_port_ret),
+        lambda r, b, w: (
+            0.2,
+            1.1,
+            0.03,
+            opt_w,
+            fake_port_ret,
+            asset_vols,
+            asset_drawdowns,
+            port_drawdown,
+        ),
     )
 
-    monkeypatch.setattr(risk_mod.px, "line", lambda *a, **k: "fig")
+    class DummyFigure:
+        def update_layout(self, **kwargs):
+            return self
+
+        def update_xaxes(self, **kwargs):
+            return self
+
+        def update_yaxes(self, **kwargs):
+            return self
+
+        def update_traces(self, **kwargs):
+            return self
+
+        def add_vline(self, **kwargs):
+            return self
+
+    monkeypatch.setattr(risk_mod.px, "line", lambda *a, **k: DummyFigure())
     monkeypatch.setattr(
         risk_mod.px,
         "histogram",
-        lambda *a, **k: SimpleNamespace(add_vline=lambda *a, **k: None),
+        lambda *a, **k: DummyFigure(),
     )
+    monkeypatch.setattr(risk_mod.px, "bar", lambda *a, **k: DummyFigure())
+    monkeypatch.setattr(risk_mod.px, "scatter", lambda *a, **k: DummyFigure())
+    monkeypatch.setattr(risk_mod, "drawdown_series", lambda *_: pd.Series([-0.01, -0.05]))
 
     monkeypatch.setattr(
         risk_mod, "monte_carlo_simulation", lambda *a, **k: pd.Series([1, 2])
@@ -497,7 +551,7 @@ def test_render_risk_analysis_valid_data(monkeypatch):
 
     tasvc = SimpleNamespace(portfolio_history=fake_history)
 
-    select_values = iter([["A", "B"], "1y"])
+    select_values = iter([["A", "B"], "1y", "S&P 500 (^GSPC)", "Leve"])
 
     def fake_selectbox(label, options, index=0, **kwargs):
         try:
@@ -512,19 +566,95 @@ def test_render_risk_analysis_valid_data(monkeypatch):
 
     pm.render_risk_analysis(df, tasvc, favorites=FavoriteSymbols({}))
 
-    assert col1.metric.call_args[0] == (
+    assert col_metrics[0].metric.call_args[0] == (
         "Volatilidad anualizada",
         "20.00%",
     )
-    assert col2.metric.call_args[0] == (
-        "Beta vs S&P 500",
+    assert col_metrics[1].metric.call_args[0] == (
+        "Beta vs S&P 500 (^GSPC)",
         "1.10",
     )
-    assert col3.metric.call_args[0] == (
+    assert col_metrics[2].metric.call_args[0] == (
         "VaR 5%",
         "3.00%",
     )
-    assert len(expander_calls) == 5
+    assert col_metrics[3].metric.call_args[0] == (
+        "Drawdown máximo",
+        "-25.00%",
+    )
+    vol_col.plotly_chart.assert_called_once()
+    draw_col.plotly_chart.assert_called_once()
+    scatter_col.plotly_chart.assert_called_once()
+    assert len(expander_calls) == 6
+
+
+def test_render_risk_analysis_insufficient_per_asset_data(monkeypatch):
+    df = pd.DataFrame({"simbolo": ["A"], "valor_actual": [100]})
+    monkeypatch.setattr(risk_mod.st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod.st, "spinner", lambda *a, **k: DummyCtx())
+    info_messages = []
+
+    def fake_info(message):
+        info_messages.append(message)
+
+    monkeypatch.setattr(risk_mod.st, "info", fake_info)
+    monkeypatch.setattr(risk_mod.st, "warning", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod.st, "bar_chart", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod.st, "line_chart", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod.st, "write", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod.st, "plotly_chart", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod.st, "caption", lambda *a, **k: None)
+
+    dummy_col = SimpleNamespace(plotly_chart=MagicMock(), info=fake_info)
+    monkeypatch.setattr(
+        risk_mod.st,
+        "columns",
+        lambda n: ([SimpleNamespace(metric=MagicMock()) for _ in range(n)]
+        if n == 4
+        else (dummy_col, dummy_col) if n == 2 else (dummy_col,)),
+    )
+
+    returns_df = pd.DataFrame({"A": [0.01, -0.02]})
+    bench_ret = pd.Series([0.0, 0.0])
+
+    def fake_history(simbolos=None, period=None):
+        if simbolos and simbolos[0] == "^GSPC":
+            return pd.DataFrame({"^GSPC": [1.0, 1.01, 1.02]})
+        return pd.DataFrame({"A": [1.0, 1.02, 1.01]})
+
+    tasvc = SimpleNamespace(portfolio_history=fake_history)
+
+    monkeypatch.setattr(risk_mod, "compute_returns", lambda df: returns_df)
+    monkeypatch.setattr(
+        risk_mod,
+        "compute_risk_metrics",
+        lambda *a, **k: (
+            0.1,
+            1.0,
+            0.02,
+            pd.Series({"A": 1.0}),
+            pd.Series([0.01, -0.02]),
+            pd.Series(dtype=float),
+            pd.Series(dtype=float),
+            -0.05,
+        ),
+    )
+    monkeypatch.setattr(risk_mod, "drawdown_series", lambda *_: pd.Series(dtype=float))
+    monkeypatch.setattr(risk_mod.px, "bar", lambda *a, **k: None)
+
+    select_values = iter([["A"], "1y", "S&P 500 (^GSPC)", "Leve"])
+    monkeypatch.setattr(
+        risk_mod.st,
+        "selectbox",
+        lambda *a, **k: next(select_values),
+    )
+
+    pm.render_risk_analysis(df, tasvc, favorites=FavoriteSymbols({}))
+
+    assert any(
+        "volatilidad por activo" in msg.lower()
+        for msg in info_messages
+    )
 
 
 def test_render_fundamental_analysis_no_symbols(monkeypatch):

--- a/tests/ui/test_portfolio_ui.py
+++ b/tests/ui/test_portfolio_ui.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 from typing import Any, Iterable, Iterator, Sequence
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -15,6 +16,7 @@ if str(_PROJECT_ROOT) not in sys.path:
 
 from controllers.portfolio.portfolio import render_portfolio_section
 from domain.models import Controls
+from shared.favorite_symbols import FavoriteSymbols
 
 
 class _DummyContainer:
@@ -41,6 +43,21 @@ class _ContextManager:
     def selectbox(self, *args: Any, **kwargs: Any) -> Any:
         return self._owner.selectbox(*args, **kwargs)
 
+    def plotly_chart(self, *args: Any, **kwargs: Any) -> Any:
+        return self._owner.plotly_chart(*args, **kwargs)
+
+    def info(self, *args: Any, **kwargs: Any) -> Any:
+        return self._owner.info(*args, **kwargs)
+
+    def metric(self, *args: Any, **kwargs: Any) -> Any:
+        return self._owner.metric(*args, **kwargs)
+
+    def line_chart(self, *args: Any, **kwargs: Any) -> Any:
+        return self._owner.line_chart(*args, **kwargs)
+
+    def bar_chart(self, *args: Any, **kwargs: Any) -> Any:
+        return self._owner.bar_chart(*args, **kwargs)
+
 
 class FakeStreamlit:
     """Minimal Streamlit stub capturing the interactions we care about."""
@@ -58,6 +75,7 @@ class FakeStreamlit:
         self.successes: list[str] = []
         self.plot_calls: list[dict[str, Any]] = []
         self.line_charts: list[pd.DataFrame] = []
+        self.bar_charts: list[dict[str, Any]] = []
         self.metrics: list[tuple[Any, Any, Any]] = []
 
     # ---- Core widgets -------------------------------------------------
@@ -92,6 +110,9 @@ class FakeStreamlit:
     def expander(self, label: str):  # noqa: ANN001 - mimics streamlit signature
         return _ContextManager(self)
 
+    def spinner(self, *_: Any, **__: Any) -> _ContextManager:
+        return _ContextManager(self)
+
     # ---- Feedback widgets ---------------------------------------------
     def subheader(self, text: str) -> None:
         self.subheaders.append(text)
@@ -116,6 +137,12 @@ class FakeStreamlit:
 
     def line_chart(self, data: pd.DataFrame) -> None:
         self.line_charts.append(data)
+
+    def bar_chart(self, data: pd.DataFrame, **kwargs: Any) -> None:
+        self.bar_charts.append({"data": data, "kwargs": kwargs})
+
+    def write(self, *_: Any, **__: Any) -> None:
+        return None
 
     def metric(self, label: str, value: Any, delta: Any | None = None) -> None:
         self.metrics.append((label, value, delta))
@@ -263,3 +290,162 @@ def test_render_portfolio_section_renders_symbol_selector_for_favorites(_portfol
     # Ensure advanced analysis helpers were not triggered in this branch
     advanced.assert_not_called()
     basic.assert_not_called()
+
+
+def test_risk_analysis_ui_renders_new_charts(monkeypatch: pytest.MonkeyPatch) -> None:
+    import controllers.portfolio.risk as risk_mod
+
+    fake_st = FakeStreamlit(radio_sequence=[], selectbox_defaults={
+        "Benchmark para beta y drawdown": "S&P 500 (^GSPC)",
+        "Escenario": "Leve",
+    })
+    risk_mod.st = fake_st
+
+    monkeypatch.setattr(risk_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod, "render_favorite_toggle", lambda *a, **k: None)
+
+    df_view = pd.DataFrame({"simbolo": ["A", "B"], "valor_actual": [100.0, 200.0]})
+
+    def fake_history(simbolos=None, period="1y"):
+        if simbolos == ["S&P 500 (^GSPC)"] or simbolos == ["^GSPC"]:
+            return pd.DataFrame({"^GSPC": [100.0, 102.0, 101.0, 103.0]})
+        return pd.DataFrame({"A": [10.0, 10.5, 10.2, 10.8], "B": [20.0, 19.5, 20.5, 21.0]})
+
+    tasvc = SimpleNamespace(portfolio_history=fake_history)
+
+    fake_port_ret = pd.Series([0.01, -0.02, 0.03])
+    asset_vols = pd.Series({"A": 0.12, "B": 0.09})
+    asset_drawdowns = pd.Series({"A": -0.2, "B": -0.1})
+    port_drawdown = -0.25
+
+    monkeypatch.setattr(
+        risk_mod,
+        "compute_returns",
+        lambda prices: prices.pct_change().dropna(),
+    )
+    monkeypatch.setattr(
+        risk_mod,
+        "compute_risk_metrics",
+        lambda *a, **k: (
+            0.2,
+            1.1,
+            0.05,
+            pd.Series({"A": 0.6, "B": 0.4}),
+            fake_port_ret,
+            asset_vols,
+            asset_drawdowns,
+            port_drawdown,
+        ),
+    )
+
+    drawdown_series_output = pd.Series([-0.01, -0.05], name="drawdown")
+    monkeypatch.setattr(risk_mod, "drawdown_series", lambda *_: drawdown_series_output)
+
+    class DummyFigure:
+        def __init__(self, tag: str) -> None:
+            self.tag = tag
+
+        def update_layout(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def update_traces(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def update_xaxes(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def update_yaxes(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def add_vline(self, **_: Any) -> "DummyFigure":
+            return self
+
+    monkeypatch.setattr(risk_mod.px, "bar", lambda *a, **k: DummyFigure("volatility_dist"))
+
+    def dummy_line(data, **kwargs):
+        tag = "portfolio_drawdown" if data is drawdown_series_output else "rolling_vol"
+        return DummyFigure(tag)
+
+    monkeypatch.setattr(risk_mod.px, "line", dummy_line)
+
+    class DummyScatter(DummyFigure):
+        pass
+
+    monkeypatch.setattr(risk_mod.px, "scatter", lambda *a, **k: DummyScatter("beta_scatter"))
+    monkeypatch.setattr(
+        risk_mod.px,
+        "histogram",
+        lambda *a, **k: DummyFigure("returns_hist"),
+    )
+
+    pm = risk_mod
+    pm.render_risk_analysis(df_view, tasvc, favorites=FavoriteSymbols({}))
+
+    tags = [call["fig"].tag for call in fake_st.plot_calls if hasattr(call["fig"], "tag")]
+    assert {"volatility_dist", "portfolio_drawdown", "beta_scatter"}.issubset(tags)
+
+
+def test_risk_analysis_ui_handles_missing_series(monkeypatch: pytest.MonkeyPatch) -> None:
+    import controllers.portfolio.risk as risk_mod
+
+    fake_st = FakeStreamlit(radio_sequence=[], selectbox_defaults={
+        "Benchmark para beta y drawdown": "S&P 500 (^GSPC)",
+        "Escenario": "Leve",
+    })
+    risk_mod.st = fake_st
+
+    monkeypatch.setattr(risk_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod, "render_favorite_toggle", lambda *a, **k: None)
+
+    df_view = pd.DataFrame({"simbolo": ["A"], "valor_actual": [100.0]})
+    tasvc = SimpleNamespace(
+        portfolio_history=lambda simbolos=None, period="1y": pd.DataFrame(
+            {"A": [10.0, 10.0, 10.0], "^GSPC": [100.0, 101.0, 102.0]}
+        )
+    )
+
+    monkeypatch.setattr(
+        risk_mod,
+        "compute_returns",
+        lambda prices: prices.pct_change().dropna(),
+    )
+    monkeypatch.setattr(
+        risk_mod,
+        "compute_risk_metrics",
+        lambda *a, **k: (
+            0.0,
+            float("nan"),
+            0.0,
+            pd.Series({"A": 1.0}),
+            pd.Series([0.0, 0.0]),
+            pd.Series(dtype=float),
+            pd.Series(dtype=float),
+            0.0,
+        ),
+    )
+    monkeypatch.setattr(risk_mod, "drawdown_series", lambda *_: pd.Series(dtype=float))
+    class DummyFigure:
+        def __init__(self, tag: str) -> None:
+            self.tag = tag
+
+        def update_layout(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def update_traces(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def update_xaxes(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def update_yaxes(self, **_: Any) -> "DummyFigure":
+            return self
+
+        def add_vline(self, **_: Any) -> "DummyFigure":
+            return self
+
+    monkeypatch.setattr(risk_mod.px, "bar", lambda *a, **k: DummyFigure("volatility_dist"))
+
+    pm = risk_mod
+    pm.render_risk_analysis(df_view, tasvc, favorites=FavoriteSymbols({}))
+
+    assert any("volatilidad" in msg.lower() for msg in fake_st.warnings)


### PR DESCRIPTION
## Summary
- extend the risk service with helpers to compute per-asset volatility and drawdown along with portfolio drawdown series
- enrich the risk analysis UI with benchmark selection, volatility distribution, portfolio drawdown and beta vs. return charts that highlight favorites
- expand controller and UI tests to cover the new analytics, including insufficient data scenarios

## Testing
- PYTHONPATH=$PWD pytest controllers/test/test_portfolio_helpers.py -k risk_analysis
- PYTHONPATH=$PWD pytest tests/ui/test_portfolio_ui.py -k risk_analysis

------
https://chatgpt.com/codex/tasks/task_e_68df0dfb86c083328ae9f63750c494c0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Added benchmark selection in risk analysis with dynamic calculations.
  - Introduced per-asset volatility and max drawdown metrics.
  - Added portfolio drawdown metric and drawdown evolution chart.
  - New visualizations: volatility distribution and “Beta vs annualized return” scatter, with favorites highlighting and responsive layout.
  - Expanded metrics display with “Drawdown máximo” and new expander sections.

* Bug Fixes
  - Improved handling of missing/insufficient data with clearer messages and safer fallbacks during benchmark retrieval and chart rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->