### PR TITLE
Add matplotlib pin for dashboard asset generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,8 @@ bash scripts/update_dependencies.sh
 
 El script actualiza los paquetes a sus últimas versiones, ejecuta las pruebas y, si todo pasa, escribe las nuevas versiones en `requirements.txt`. Este proceso también se ejecuta mensualmente mediante [GitHub Actions](.github/workflows/dependency-update.yml).
 
+La guía interna que detalla cómo recrear los assets del dashboard se apoya en el script generador correspondiente; a partir de ahora `matplotlib` queda instalada automáticamente al ejecutar `pip install -r requirements.txt`, por lo que no hace falta agregarla manualmente antes de correr ese flujo.
+
 ## Políticas de sesión y manejo de tokens
 
 Cada sesión de usuario genera un identificador aleatorio almacenado en `st.session_state["session_id"]`, que debe mantenerse constante para aislar los recursos cacheados.

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ requests==2.31.0
 python-dotenv==1.1.1
 iolConn==0.4.2
 plotly==6.3.0
+matplotlib==3.10.6
 kaleido==1.1.0
 tomli==2.0.1
 # Utilidades varias

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -13,6 +13,7 @@ PACKAGES=(
   python-dotenv
   iolConn
   plotly
+  matplotlib
   kaleido
   cryptography
   yfinance
@@ -26,4 +27,4 @@ python -m pip install --upgrade "${PACKAGES[@]}"
 pytest
 
 # Freeze the exact versions back into requirements.txt
-python -m pip freeze | grep -i -E '^(streamlit|pandas|numpy|requests|python-dotenv|iolConn|plotly|kaleido|cryptography|yfinance|ta)==' > requirements.txt
+python -m pip freeze | grep -i -E '^(streamlit|pandas|numpy|requests|python-dotenv|iolConn|plotly|matplotlib|kaleido|cryptography|yfinance|ta)==' > requirements.txt


### PR DESCRIPTION
## Summary
- add a matplotlib pin to the main requirements so the dashboard asset generator installs cleanly
- include the package in the dependency update script and document that the generator now works without manual installs

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df1d7552bc8332912c7fd569589c3d