### PR TITLE
Document release 0.3.25.1 metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.25.1)
+## Quick-start (release 0.3.25.1 — 2025-10-03)
 
 La versión **0.3.25.1** refuerza la cobertura macro y la observabilidad de cada proveedor:
 - El **cliente World Bank** amplía el fallback multinivel (FRED → World Bank → fallback estático), manteniendo la columna `macro_outlook` cuando FRED queda inhabilitado o llega al límite de rate limiting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.25.1"
+version = "0.3.25.1"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -8,7 +8,8 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
     import tomli as _toml  # type: ignore[import-untyped]
 
 
-DEFAULT_VERSION = "0.3.25.1"
+# Keep in sync with ``pyproject.toml``'s ``project.version``.
+DEFAULT_VERSION: str = "0.3.25.1"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 

--- a/tests/test_version_sync.py
+++ b/tests/test_version_sync.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+try:  # pragma: no cover - Python < 3.11 fallback mirrors runtime module
+    import tomllib as _toml
+except ModuleNotFoundError:  # pragma: no cover
+    import tomli as _toml  # type: ignore[import-untyped]
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from shared import version
+
+
+def test_default_version_matches_pyproject() -> None:
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    project_version = _toml.loads(pyproject_path.read_text(encoding="utf-8"))["project"][
+        "version"
+    ]
+
+    assert version.DEFAULT_VERSION == project_version == version.__version__


### PR DESCRIPTION
## Summary
- document the release date in the Quick-start section for version 0.3.25.1
- add guard rails to keep the project version in sync with shared.version
- add a regression test that ensures DEFAULT_VERSION matches the package metadata

## Testing
- pytest tests/ui/test_health_sidebar.py
- pytest tests/test_version_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68df384d6a8c8332a21954f9843c8243