### PR TITLE
Fix drawdown series handling and restore beta guardrails

### DIFF
--- a/application/risk_service.py
+++ b/application/risk_service.py
@@ -57,24 +57,7 @@ def beta(
     bench = pd.Series(benchmark_returns).dropna()
 
     if len(port) != len(bench) or len(port) == 0:
-def drawdown_series(returns: pd.Series) -> pd.Series:
-    """Compute drawdown series (in percentage terms) from returns."""
-    if returns is None or len(returns) == 0:
-        return pd.Series(dtype=float)
-    cumulative = (1 + returns.fillna(0.0)).cumprod()
-    peaks = cumulative.cummax()
-    drawdowns = cumulative / peaks - 1.0
-    return drawdowns
-
-
-def max_drawdown(returns: pd.Series) -> float:
-    """Maximum drawdown (minimum cumulative drop) for a return series."""
-    if returns is None or len(returns) == 0:
-        return 0.0
-    dd = drawdown_series(returns)
-    if dd.empty:
-        return 0.0
-    return float(dd.min())
+        return float("nan")
 
     if min_periods is not None and (
         len(port) < int(min_periods) or len(bench) < int(min_periods)
@@ -86,6 +69,33 @@ def max_drawdown(returns: pd.Series) -> float:
     if denom == 0:
         return float("nan")
     return float(cov[0, 1] / denom)
+
+
+def drawdown_series(returns: pd.Series) -> pd.Series:
+    """Compute drawdown series (in percentage terms) from returns."""
+
+    if returns is None:
+        return pd.Series(dtype=float)
+
+    series = pd.Series(returns)
+
+    if series.empty:
+        return pd.Series(dtype=float)
+
+    cumulative = (1.0 + series.fillna(0.0)).cumprod()
+    peaks = cumulative.cummax()
+    drawdowns = cumulative.subtract(peaks).divide(peaks)
+    return drawdowns
+
+
+def max_drawdown(returns: pd.Series) -> float:
+    """Maximum drawdown (minimum cumulative drop) for a return series."""
+    if returns is None or len(returns) == 0:
+        return 0.0
+    dd = drawdown_series(returns)
+    if dd.empty:
+        return 0.0
+    return float(dd.min())
 
 
 def drawdown(returns: pd.Series) -> pd.Series:


### PR DESCRIPTION
## Summary
- restore the missing guard clauses in `beta` for mismatched lengths, minimum periods, and zero benchmark variance
- update `drawdown_series` to return an empty series for empty inputs and compute drawdowns via cumulative equity peaks

## Testing
- pytest tests/application/test_risk_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68df4ad00318833287068024f3d2d36c