### PR TITLE
Add CVaR metrics and rolling correlation analysis

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -162,8 +162,11 @@ class _DummyStreamlitCore:
     def caption(self, text: object) -> None:
         self._record("caption", text=str(text))
 
-    def markdown(self, text: object) -> None:
-        self._record("markdown", text=str(text))
+    def markdown(self, text: object, *, unsafe_allow_html: bool = False) -> None:
+        self._record("markdown", text=str(text), unsafe=bool(unsafe_allow_html))
+
+    def plotly_chart(self, fig: object, **kwargs: Any) -> None:
+        self._record("plotly_chart", fig=fig, kwargs=kwargs)
 
     def write(self, text: object) -> None:
         self._record("write", text=text)
@@ -179,6 +182,10 @@ class _DummyStreamlitCore:
 
     def success(self, text: object) -> None:
         self._record("success", text=str(text))
+
+    def stop(self) -> None:
+        self._record("stop")
+        raise RuntimeError("streamlit.stop called")
 
     def spinner(self, text: object) -> _DummyContext:
         entry = self._record("spinner", text=str(text))


### PR DESCRIPTION
## Summary
- add expected shortfall and rolling correlation helpers to the risk service
- expose configurable VaR/CVaR metrics and rolling correlation visuals in the portfolio risk UI
- extend controller/UI/application/integration tests and streamlit stubs to cover the new analytics

## Testing
- pytest tests/application/test_risk_metrics.py
- PYTHONPATH=. pytest tests/ui/test_portfolio_ui.py
- PYTHONPATH=. pytest controllers/test/test_portfolio_helpers.py
- PYTHONPATH=. pytest tests/integration/test_portfolio_tabs.py

------
https://chatgpt.com/codex/tasks/task_e_68df52c58a9883328326c1415b36910b