### PR TITLE
Prepare release 0.3.26.1 documentation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+## [0.3.26.1] - 2025-10-26
+
+### Added
+- Notificaciones internas en la UI basadas en `st.toast` para confirmar refrescos y cierres de sesión,
+  consolidando feedback inmediato para los analistas que operan desde el dashboard.
+
+### Changed
+- Sincronización del número de versión 0.3.26.1 entre `pyproject.toml`, `shared.version` y las superficies
+  visibles (header, footer, sidebar y tests) para mantener la trazabilidad de la release.
+
+### Documentation
+- README, guías y quick-start alineados con la release 0.3.26.1, detallando el flujo de notificaciones
+  internas y los pasos para validar la numeración visible.
+
 ## [0.3.26] - 2025-10-19
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,14 +6,15 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.26)
+## Quick-start (release 0.3.26.1)
 
-La versión **0.3.26** refuerza la visibilidad del ciclo de release en todas las pantallas y deja documentado el recorrido completo de telemetría.
-## Quick-start (release 0.3.26 — 2025-10-19)
+La versión **0.3.26.1** refuerza la visibilidad del ciclo de release en todas las pantallas, habilita notificaciones internas guiadas por toasts y deja documentado el recorrido completo de telemetría.
+## Quick-start (release 0.3.26.1 — 2025-10-26)
 
-La versión **0.3.26** destaca tres ejes principales:
-- El **header del login y del dashboard** reutiliza el helper centralizado de versión para mostrar `Versión 0.3.26` junto con la hora de Argentina, evitando desfasajes entre superficies.
+La versión **0.3.26.1** destaca cuatro ejes principales:
+- El **header del login y del dashboard** reutiliza el helper centralizado de versión para mostrar `Versión 0.3.26.1` junto con la hora de Argentina, evitando desfasajes entre superficies.
 - El **health sidebar** condensa la cronología de screenings con badges de cache hit/miss, ratios de fallback y buckets de latencia sincronizados con los contadores globales.
+- El menú **⚙️ Acciones** del dashboard publica notificaciones internas (`st.toast`) que confirman actualizaciones de datos y cierres de sesión, dejando trazabilidad local para los analistas.
 - Las notas del screening y el resumen de riesgo comparten la numeración incremental de telemetría, manteniendo alineados los historiales guardados en `services.health` y los gráficos que se renderizan en la UI.
 
 Sigue estos pasos para reproducir el flujo completo y validar las novedades clave:
@@ -31,8 +32,10 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.26` junto con
-   el timestamp generado por `TimeProvider`, confirmando que la actualización quedó aplicada.
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.26.1` junto con
+   el timestamp generado por `TimeProvider`, confirmando que la actualización quedó aplicada. El menú
+   **⚙️ Acciones** mostrará un toast "Datos actualizados" cuando ejecutes **⟳ Refrescar**, dejando
+   registro inmediato de las notificaciones internas incorporadas en esta release.
    Abre la pestaña **Empresas con oportunidad**, activa la casilla **Mostrar resumen del
    screening** y ejecuta una búsqueda con los datos stub incluidos para ver las tarjetas de KPIs:
    universo analizado, candidatos finales y sectores activos (con deltas de descartes y tiempos de
@@ -58,10 +61,11 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
 
 - El mini-dashboard inicial resume valor de la cartera, variación diaria y cash disponible con formato de tarjetas, y se actualiza automáticamente después de cada screening.
 - El toast "Preset guardado" deja visible el preset recién creado dentro del selector para reutilizarlo en corridas posteriores.
+- Las notificaciones internas del menú **⚙️ Acciones** confirman tanto los refrescos como los cierres de sesión exitosos, evitando dudas al operar en entornos compartidos.
 - La comparación de presets presenta dos columnas paralelas con indicadores verdes/rojos que señalan qué filtros fueron ajustados antes de confirmar la ejecución definitiva.
 - El bloque de telemetría enriquecida marca explícitamente los *cache hits*, diferencia el tiempo invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa durante la sesión.
 
-**Comportamiento del caché (0.3.26).** Cuando guardas un preset, la aplicación persiste la
+**Comportamiento del caché (0.3.26.1).** Cuando guardas un preset, la aplicación persiste la
 combinación de filtros y el resultado del último screening asociado. Al relanzarlo, el panel de
 telemetría ahora etiqueta cada corrida con un identificador incremental y agrega una tabla de
 componentes (descarga, normalización, render) para comparar tiempos:
@@ -75,7 +79,7 @@ componentes (descarga, normalización, render) para comparar tiempos:
   que reutiliza inmediatamente los resultados previos, dispara el contador de *cache hits* y confirma
   la integridad del guardado.
 
-Estas novedades convierten a la release 0.3.26 en la referencia para validar onboarding, telemetría
+Estas novedades convierten a la release 0.3.26.1 en la referencia para validar onboarding, telemetría
 y caché cooperativa: toda la UI recuerda la versión activa, expone KPIs agregados de rendimiento en
 el health sidebar (incluyendo el resumen macro con World Bank) y los presets continúan recortando
 los tiempos de iteración al dejar a la vista el impacto de cada cambio.
@@ -183,7 +187,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.26)
+##### Escenarios de fallback macro (0.3.26.1)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El resumen macro del health sidebar incrementa los contadores de éxito y actualiza los buckets de latencia para el nuevo proveedor.
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente.
@@ -332,9 +336,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.26".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.26.1".
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.26)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia y reutilización, incluyendo el resumen macro con World Bank.
+El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
+
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.26.1)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia y reutilización, incluyendo el resumen macro con World Bank.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -41,6 +41,9 @@ consideraciones para extender o depurar estas pruebas:
   simular la interacción del usuario desde los tests sin depender de `streamlit.testing`.
 - Si se añade nuevo comportamiento en la UI que invoque APIs de Streamlit no cubiertas, amplia el
   stub agregando el método correspondiente y registrando su uso.
+- Para validar las notificaciones internas (`st.toast`), monkeypatchea la función como en
+  `application/test/test_login_flow.py` y aserta sobre las banderas de `session_state`
+  (`show_refresh_toast`, `logout_done`) o sobre el stub personalizado que definas.
 
 Gracias a esta infraestructura, las suites pueden ejecutarse en entornos mínimos (CI headless,
 containers livianos) sin requerir dependencias binarias de Streamlit.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -55,6 +55,14 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
        streamlit run app.py
        ```
 
+- **Las notificaciones internas no aparecen tras refrescar el dashboard.**
+  - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Datos actualizados" ni el mensaje de cierre de sesión.
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.26.1` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Resolución:**
+    1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
+    2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.
+    3. Si trabajas con el stub de pruebas, revisa `tests/conftest.py` y asegura que exponga un logger o impresión equivalente para simular la notificación.
+
 - **El contenedor Docker termina con error de configuración.**
   - **Síntomas:** Los logs muestran fallos de variables obligatorias (`IOL_TOKENS_KEY` ausente) o problemas de permisos con `tokens_iol.json`.
   - **Diagnóstico rápido:** Inspecciona el archivo `.env` que usas con `docker run --env-file` y confirma rutas montadas.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.26"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.26.1"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.26"
+DEFAULT_VERSION: str = "0.3.26.1"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project metadata to version 0.3.26.1 and keep the shared helper in sync
- refresh the quick-start and security documentation to highlight the new internal notification toasts
- record the 0.3.26.1 release notes and extend troubleshooting/testing guides for the notifications flow

## Testing
- pytest tests/test_version_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68df57e882d8833288f9ea14e7c14e06