### PR TITLE
Add notification badge thresholds and service

### DIFF
--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,5 @@
+"""Public services exposed by the application layer."""
+
+from .notifications import build_notification_badges
+
+__all__ = ["build_notification_badges"]

--- a/services/notifications.py
+++ b/services/notifications.py
@@ -1,0 +1,251 @@
+"""Helpers to compute notification badges across the application.
+
+The :func:`build_notification_badges` helper centralises the heuristics
+used by controllers to highlight risk, technical and earnings alerts.  It
+keeps the UI decoupled from the configuration format by working with simple
+Python primitives and returning a dictionary of flags ready for rendering.
+
+The returned payload has the following structure::
+
+    {
+        "risk": {
+            "active": bool,                # Whether the risk badge should be shown.
+            "value": Optional[float],      # Normalised risk metric used for the comparison.
+            "threshold": float,            # Threshold applied.
+        },
+        "technical": {
+            "active": bool,
+            "direction": Optional[str],    # "bullish" | "bearish" when active.
+            "counts": {                    # Aggregated signal counts.
+                "bullish": int,
+                "bearish": int,
+            },
+            "threshold": float,
+        },
+        "earnings": {
+            "active": bool,
+            "next_event": Optional[dict],  # Shallow copy of the closest event with ``days_until`` normalised.
+            "threshold_days": int,
+        },
+    }
+
+Controllers can rely on the keys above without caring about the shape of the
+raw data provided by the analytics layer.  Each badge becomes active when the
+normalised value crosses the configured thresholds exposed by
+``shared.settings``.
+"""
+from __future__ import annotations
+
+from copy import deepcopy
+from datetime import date, datetime
+from typing import Any, Iterable, Mapping, MutableMapping
+
+from shared.settings import (
+    earnings_upcoming_days as _default_earnings_threshold,
+    risk_badge_threshold as _default_risk_threshold,
+    technical_signal_threshold as _default_technical_threshold,
+)
+from shared.time_provider import TimeProvider
+
+
+def build_notification_badges(
+    *,
+    risk_metrics: Mapping[str, Any] | float | int | None,
+    technical_indicators: Mapping[str, Any] | None,
+    earnings_calendar: Iterable[Mapping[str, Any]] | None,
+    risk_threshold: float | None = None,
+    technical_threshold: float | None = None,
+    earnings_days_threshold: int | None = None,
+) -> dict[str, Any]:
+    """Return badge flags derived from analytics data.
+
+    Parameters
+    ----------
+    risk_metrics:
+        Either a numeric score or a mapping containing keys such as ``"score"``
+        or ``"value"``.  The first numeric value found is compared against the
+        configured threshold.
+    technical_indicators:
+        Mapping containing counts or iterables of signals under ``"bullish"``
+        and ``"bearish"`` keys (optionally nested under ``"signals"``).  The
+        badge becomes active when either side meets the threshold.
+    earnings_calendar:
+        Iterable of mappings that may include a ``"days_until"`` precomputed
+        value or an ``"date"`` entry (``datetime``/``date``/ISO string).  The
+        closest upcoming event is compared against the threshold.
+    risk_threshold, technical_threshold, earnings_days_threshold:
+        Optional overrides, useful for tests.  When omitted the values defined
+        in ``config.json``/environment (via :mod:`shared.settings`) are used.
+    """
+
+    risk_threshold = float(
+        risk_threshold if risk_threshold is not None else _default_risk_threshold
+    )
+    technical_threshold = float(
+        technical_threshold
+        if technical_threshold is not None
+        else _default_technical_threshold
+    )
+    earnings_days_threshold = int(
+        earnings_days_threshold
+        if earnings_days_threshold is not None
+        else _default_earnings_threshold
+    )
+
+    risk_value = _extract_risk_value(risk_metrics)
+    risk_active = bool(
+        risk_value is not None and _is_greater_or_equal(risk_value, risk_threshold)
+    )
+
+    bullish_count, bearish_count = _extract_signal_counts(technical_indicators)
+    technical_active = bool(
+        max(bullish_count, bearish_count) >= technical_threshold
+    )
+    if technical_active:
+        if bullish_count >= bearish_count and bullish_count >= technical_threshold:
+            technical_direction: str | None = "bullish"
+        elif bearish_count >= technical_threshold:
+            technical_direction = "bearish"
+        else:  # pragma: no cover - defensive guard, should not be hit
+            technical_direction = None
+            technical_active = False
+    else:
+        technical_direction = None
+
+    next_event = _find_next_earnings_event(earnings_calendar)
+    earnings_active = bool(
+        next_event is not None
+        and next_event.get("days_until") is not None
+        and next_event["days_until"] <= earnings_days_threshold
+    )
+
+    return {
+        "risk": {
+            "active": risk_active,
+            "value": risk_value,
+            "threshold": risk_threshold,
+        },
+        "technical": {
+            "active": technical_active,
+            "direction": technical_direction,
+            "counts": {"bullish": bullish_count, "bearish": bearish_count},
+            "threshold": technical_threshold,
+        },
+        "earnings": {
+            "active": earnings_active,
+            "next_event": next_event,
+            "threshold_days": earnings_days_threshold,
+        },
+    }
+
+
+def _extract_risk_value(data: Mapping[str, Any] | float | int | None) -> float | None:
+    if data is None:
+        return None
+    if isinstance(data, Mapping):
+        for key in ("score", "value", "volatility", "risk", "beta"):
+            raw = data.get(key)
+            numeric = _to_float(raw)
+            if numeric is not None:
+                return numeric
+        return None
+    return _to_float(data)
+
+
+def _extract_signal_counts(data: Mapping[str, Any] | None) -> tuple[int, int]:
+    if not isinstance(data, Mapping):
+        return 0, 0
+
+    signals: Mapping[str, Any]
+    if "signals" in data and isinstance(data["signals"], Mapping):
+        signals = data["signals"]
+    else:
+        signals = data
+
+    bullish = _to_int(signals.get("bullish"))
+    bearish = _to_int(signals.get("bearish"))
+    return bullish, bearish
+
+
+def _find_next_earnings_event(
+    calendar: Iterable[Mapping[str, Any]] | None,
+) -> MutableMapping[str, Any] | None:
+    if not calendar:
+        return None
+
+    closest: MutableMapping[str, Any] | None = None
+    min_days: float | None = None
+    for entry in calendar:
+        if not isinstance(entry, Mapping):
+            continue
+        days = _coerce_days_until(entry)
+        if days is None:
+            continue
+        if days < 0:
+            continue
+        if min_days is None or days < min_days:
+            closest = deepcopy(dict(entry))
+            closest["days_until"] = int(days)
+            min_days = days
+    return closest
+
+
+def _coerce_days_until(entry: Mapping[str, Any]) -> float | None:
+    raw = entry.get("days_until")
+    numeric = _to_float(raw)
+    if numeric is not None:
+        return numeric
+
+    raw_date = entry.get("date")
+    event_date = _parse_date(raw_date)
+    if event_date is None:
+        return None
+    now = TimeProvider.now_datetime().date()
+    delta = event_date - now
+    return float(delta.days)
+
+
+def _parse_date(value: Any) -> date | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date()
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value)
+        except ValueError:
+            return None
+        return parsed.date()
+    return None
+
+
+def _to_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_int(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, (list, tuple, set)):
+        return len(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _is_greater_or_equal(value: float, threshold: float) -> bool:
+    try:
+        return float(value) >= float(threshold)
+    except (TypeError, ValueError):  # pragma: no cover - defensive guard
+        return False
+
+
+__all__ = ["build_notification_badges"]

--- a/services/test/test_notifications.py
+++ b/services/test/test_notifications.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import pytest
+
+from services.notifications import build_notification_badges
+
+
+@pytest.mark.parametrize(
+    "risk_value,threshold,expected",
+    [
+        (0.85, 0.75, True),
+        (0.60, 0.75, False),
+    ],
+)
+def test_risk_badge_activation(risk_value: float, threshold: float, expected: bool) -> None:
+    badges = build_notification_badges(
+        risk_metrics={"score": risk_value},
+        technical_indicators=None,
+        earnings_calendar=None,
+        risk_threshold=threshold,
+    )
+    assert badges["risk"]["active"] is expected
+    assert badges["risk"]["value"] == pytest.approx(risk_value)
+    assert badges["risk"]["threshold"] == pytest.approx(threshold)
+
+
+def test_technical_badge_prefers_bullish_direction() -> None:
+    badges = build_notification_badges(
+        risk_metrics=None,
+        technical_indicators={"bullish": 3, "bearish": 1},
+        earnings_calendar=None,
+        technical_threshold=2,
+    )
+    tech = badges["technical"]
+    assert tech["active"] is True
+    assert tech["direction"] == "bullish"
+    assert tech["counts"] == {"bullish": 3, "bearish": 1}
+
+
+def test_technical_badge_handles_bearish_signals() -> None:
+    badges = build_notification_badges(
+        risk_metrics=None,
+        technical_indicators={"signals": {"bullish": ["rsi"], "bearish": ["macd", "sma"]}},
+        earnings_calendar=None,
+        technical_threshold=2,
+    )
+    tech = badges["technical"]
+    assert tech["active"] is True
+    assert tech["direction"] == "bearish"
+    assert tech["counts"] == {"bullish": 1, "bearish": 2}
+
+
+def test_earnings_badge_activates_for_upcoming_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Freeze "today" by overriding TimeProvider.now_datetime so the delta is deterministic.
+    from shared import time_provider
+
+    fixed_now = time_provider.datetime(2024, 1, 1, tzinfo=time_provider.ZoneInfo(time_provider.TIMEZONE))
+
+    monkeypatch.setattr(time_provider.TimeProvider, "now_datetime", classmethod(lambda cls: fixed_now))
+
+    badges = build_notification_badges(
+        risk_metrics=None,
+        technical_indicators=None,
+        earnings_calendar=[{"symbol": "AAPL", "date": "2024-01-03"}, {"symbol": "MSFT", "days_until": 10}],
+        earnings_days_threshold=5,
+    )
+    earnings = badges["earnings"]
+    assert earnings["active"] is True
+    assert earnings["next_event"]["symbol"] == "AAPL"
+    assert earnings["next_event"]["days_until"] == 2
+
+
+def test_earnings_badge_ignores_distant_events() -> None:
+    badges = build_notification_badges(
+        risk_metrics=None,
+        technical_indicators=None,
+        earnings_calendar=[{"symbol": "AAPL", "days_until": 12}],
+        earnings_days_threshold=5,
+    )
+    earnings = badges["earnings"]
+    assert earnings["active"] is False
+    assert earnings["next_event"]["symbol"] == "AAPL"
+    assert earnings["next_event"]["days_until"] == 12

--- a/shared/config.py
+++ b/shared/config.py
@@ -135,6 +135,18 @@ class Settings:
             os.getenv("MIN_SCORE_THRESHOLD", cfg.get("MIN_SCORE_THRESHOLD", 80))
         )
         self.max_results: int = int(os.getenv("MAX_RESULTS", cfg.get("MAX_RESULTS", 20)))
+        self.RISK_BADGE_THRESHOLD: float = float(
+            os.getenv("RISK_BADGE_THRESHOLD", cfg.get("RISK_BADGE_THRESHOLD", 0.75))
+        )
+        self.TECHNICAL_SIGNAL_THRESHOLD: float = float(
+            os.getenv(
+                "TECHNICAL_SIGNAL_THRESHOLD",
+                cfg.get("TECHNICAL_SIGNAL_THRESHOLD", 2),
+            )
+        )
+        self.EARNINGS_UPCOMING_DAYS: int = int(
+            os.getenv("EARNINGS_UPCOMING_DAYS", cfg.get("EARNINGS_UPCOMING_DAYS", 7))
+        )
 
         self.STUB_MAX_RUNTIME_WARN: float = float(
             os.getenv("STUB_MAX_RUNTIME_WARN", cfg.get("STUB_MAX_RUNTIME_WARN", 0.25))

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -32,6 +32,11 @@ max_results: int = settings.max_results
 stub_max_runtime_warn: float = getattr(settings, "STUB_MAX_RUNTIME_WARN", 0.25)
 STUB_MAX_RUNTIME_WARN: float = stub_max_runtime_warn
 
+# Notification thresholds
+risk_badge_threshold: float = getattr(settings, "RISK_BADGE_THRESHOLD", 0.75)
+technical_signal_threshold: float = getattr(settings, "TECHNICAL_SIGNAL_THRESHOLD", 2)
+earnings_upcoming_days: int = getattr(settings, "EARNINGS_UPCOMING_DAYS", 7)
+
 # Backwards compatibility for legacy imports
 YAHOO_FUNDAMENTALS_TTL: int = yahoo_fundamentals_ttl
 YAHOO_QUOTES_TTL: int = yahoo_quotes_ttl
@@ -89,6 +94,9 @@ __all__ = [
     "YAHOO_QUOTES_TTL",
     "MIN_SCORE_THRESHOLD",
     "MAX_RESULTS",
+    "risk_badge_threshold",
+    "technical_signal_threshold",
+    "earnings_upcoming_days",
     "FEATURE_OPPORTUNITIES_TAB",
     "macro_api_provider",
     "fred_api_key",


### PR DESCRIPTION
## Summary
- expose configurable thresholds for risk, technical signals and upcoming earnings in the shared settings
- add a notifications helper that derives UI badge flags from analytics data and re-export it in the services package
- cover the new badge logic with focused unit tests across multiple scenarios

## Testing
- pytest services/test/test_notifications.py

------
https://chatgpt.com/codex/tasks/task_e_68df57eb20bc83328f67ccc716dd08f7