### PR TITLE
Move legacy controller tests into excluded suite

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -29,6 +29,14 @@ pytest
 El proyecto incorpora `pytest.ini` con marcadores y configuración de logging. La ejecución completa
 usa los stubs deterministas para mantener resultados reproducibles.
 
+### Suites legacy
+
+La carpeta `tests/legacy/` contiene casos heredados que duplican escenarios ya cubiertos en la suite principal. Se excluye de la recolección estándar para mantener los tiempos de CI. Si necesitas auditarlos manualmente, ejecútalos de forma explícita:
+
+```bash
+pytest tests/legacy
+```
+
 ### Stubs de Streamlit y control de fixtures
 
 Las suites de UI y sidebar utilizan un stub definido en `tests/conftest.py` que emula las

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,3 +6,6 @@ version = "0.3.27"  # Keep shared.version.DEFAULT_VERSION aligned with this valu
 markers = [
     "live_yahoo: Tests that call the live Yahoo Finance API (enable with RUN_LIVE_YF=1)",
 ]
+norecursedirs = [
+    "tests/legacy",
+]

--- a/tests/legacy/controllers/test_fx_controller.py
+++ b/tests/legacy/controllers/test_fx_controller.py
@@ -4,6 +4,9 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 
+# NOTE: Suite legacy mantenida sólo para auditorías puntuales del flujo antiguo
+# de FX. La cobertura activa se encuentra en `tests/controllers/` y estos casos
+# se eliminarán una vez que confirmemos la paridad de escenarios.
 from controllers.fx import render_fx_section
 
 

--- a/tests/legacy/controllers/test_opportunities_macro.py
+++ b/tests/legacy/controllers/test_opportunities_macro.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import pandas as pd
 import pytest
 
+# NOTE: Estas pruebas viven en la suite legacy mientras migramos sus escenarios
+# a `tests/controllers/test_opportunities_controller.py`. Mantenerlas permite
+# auditar la lógica previa hasta que consolidemos los duplicados y quitemos el
+# uso del helper `_enrich_with_macro_context` en tests nuevos.
 from controllers import opportunities
 from services.macro_adapter import MacroFetchResult
 

--- a/tests/legacy/controllers/test_portfolio_controller.py
+++ b/tests/legacy/controllers/test_portfolio_controller.py
@@ -5,6 +5,9 @@ from unittest.mock import MagicMock, patch, ANY
 import pandas as pd
 import pytest
 
+# NOTE: Casos heredados previos a la refactorización de `tests/controllers/`.
+# Se conservan aquí para comparaciones manuales hasta completar la migración
+# definitiva del controlador de portafolio.
 from controllers.portfolio import (
     PortfolioMetrics,
     PortfolioViewModel,

--- a/tests/legacy/controllers/test_portfolio_helpers.py
+++ b/tests/legacy/controllers/test_portfolio_helpers.py
@@ -4,6 +4,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock
 import plotly.express as px
 
+# NOTE: Helpers legacy mantenidos temporalmente para comparar con la suite
+# moderna de portfolio. Una vez validada la cobertura en `tests/controllers/`
+# estos escenarios se eliminarán.
 from controllers import portfolio as pm
 import controllers.portfolio.load_data as load_mod
 import controllers.portfolio.filters as filters_mod


### PR DESCRIPTION
## Summary
- move the legacy controller tests into `tests/legacy/` with explanatory notes for future migration
- configure pytest to skip the legacy folder during normal collection
- document how to execute the legacy suite manually when needed

## Testing
- pytest *(fails: existing repository issue — import mismatch in tests/application/test_portfolio_viewmodel.py and missing streamlit dependency)*

------
https://chatgpt.com/codex/tasks/task_e_68dfb21af148833293edb8db6175b595

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a “Legacy Suites” section explaining the legacy test set, its exclusion from standard CI runs, and how to execute it manually.
* **Tests**
  * Segregated legacy tests for auditing during migration and clarified intent with added explanatory comments across legacy cases.
* **Chores**
  * Updated test runner configuration to exclude the legacy tests directory from default discovery to streamline CI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->