### PR TITLE
Add portfolio analytics export tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,38 @@ El muestreo superior refleja la combinación live + fallback que hoy ve la UI: l
 
 El botón **"Descargar resultados (.csv)"** replica esta grilla y genera un archivo con las mismas columnas visibles en la UI (incluidos `score_compuesto`, el filtro aplicado y el enlace a Yahoo). Así se asegura paridad total entre lo que se analiza en pantalla y lo que se comparte para backtesting o QA, sin importar si la sesión proviene del origen `yahoo` o `stub`.
 
+## Exportación de análisis enriquecido
+
+La aplicación permite llevarte un paquete completo de métricas, rankings y visualizaciones del portafolio sin salir del dashboard o desde la línea de comandos si trabajás con snapshots persistidos.
+
+### Desde el dashboard
+
+1. Abrí la pestaña **📂 Portafolio** y desplegá el acordeón **📦 Exportar análisis enriquecido**.
+2. Seleccioná las métricas que querés incluir en el reporte (valor total, P/L, cantidad de posiciones, etc.). Cada opción muestra una breve descripción para que identifiques rápidamente qué KPI estás incorporando.
+3. Elegí los gráficos que se van a embeber en el Excel (por defecto se incluyen P/L Top N, composición por tipo, distribución valorizada, la evolución histórica y el mapa de calor por símbolo/tipo). Si Kaleido no está disponible la UI te lo indicará para que habilites la dependencia.
+4. Activá o desactivá la exportación de rankings e historial y definí el límite de filas para cada ranking.
+5. Descargá el ZIP con los CSV (`kpis.csv`, `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.) o el Excel enriquecido (`*_analisis.xlsx`) que incluye todas las tablas en hojas dedicadas y los gráficos renderizados como imágenes.
+
+### Desde la línea de comandos
+
+El script `scripts/export_analysis.py` procesa snapshots serializados en JSON (por ejemplo los generados por jobs batch o instrumentación de QA) y genera los mismos artefactos enriquecidos que la UI.
+
+```bash
+python scripts/export_analysis.py \
+  --input .cache/portfolio_snapshots \
+  --output ./exports/nocturno \
+  --metrics total_value total_pl total_pl_pct positions symbols \
+  --charts pl_top composition timeline heatmap \
+  --limit 15
+```
+
+- El argumento `--metrics help` lista todos los KPIs disponibles; `--charts help` hace lo propio con los gráficos.
+- Con `--formats csv` o `--formats excel` podés limitar la salida a un solo formato.
+- Cada snapshot genera un subdirectorio dentro de `--output` con todos los CSV y, si corresponde, el Excel `analysis.xlsx`.
+- Se adjunta además `summary.csv` en la raíz con los KPIs crudos (`raw_value`) de cada snapshot para facilitar comparaciones rápidas o integraciones en pipelines.
+
+> Dependencias: asegurate de instalar `kaleido` y `XlsxWriter` (ambos incluidos en `requirements.txt`) para que el script pueda renderizar los gráficos y escribir el Excel correctamente.
+
 Cada registro respeta los principios de la estrategia Andy: payout y P/E saludables, rachas y CAGR positivos, EPS forward por encima del trailing, buybacks y crecimiento de ingresos cuando corresponde. En la release actual, ese set determinista permite verificar que `score_compuesto` se mantenga estable tanto en modo `yahoo` como `stub`, sosteniendo la comparabilidad del ranking.
 
 Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas contextuales del caption principal. Los tests automatizados siguen apoyándose en este dataset extendido para validar diversidad sectorial, completitud de fundamentals y la presencia de la nueva columna `Score`.

--- a/controllers/portfolio/charts.py
+++ b/controllers/portfolio/charts.py
@@ -6,7 +6,7 @@ import streamlit as st
 from shared.favorite_symbols import FavoriteSymbols, get_persistent_favorites
 from ui.favorites import render_favorite_badges, render_favorite_toggle
 from ui.tables import render_totals, render_table
-from ui.export import PLOTLY_CONFIG
+from ui.export import PLOTLY_CONFIG, render_portfolio_exports
 from services.portfolio_view import compute_symbol_risk_metrics
 from ui.charts import (
     _apply_layout,
@@ -39,6 +39,7 @@ def render_basic_section(
     favorites: FavoriteSymbols | None = None,
     historical_total=None,
     contribution_metrics=None,
+    snapshot=None,
 ):
     """Render totals, table and basic charts for the portfolio."""
     favorites = favorites or get_persistent_favorites()
@@ -74,6 +75,15 @@ def render_basic_section(
         return
 
     render_totals(df_view, ccl_rate=ccl_rate, totals=totals)
+    render_portfolio_exports(
+        snapshot=snapshot,
+        df_view=df_view,
+        totals=totals,
+        historical_total=historical_total,
+        contribution_metrics=contribution_metrics,
+        filename_prefix="portafolio",
+        ranking_limit=max(5, getattr(controls, "top_n", 10)),
+    )
     render_table(
         df_view,
         controls.order_by,

--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -97,6 +97,7 @@ def render_portfolio_section(container, cli, fx_rates):
                 totals=viewmodel.totals,
                 historical_total=viewmodel.historical_total,
                 contribution_metrics=viewmodel.contributions,
+                snapshot=snapshot,
             )
         elif tab_idx == 1:
             render_advanced_analysis(df_view, tasvc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ iolConn==0.4.2
 plotly==6.3.0
 matplotlib==3.10.6
 kaleido==1.1.0
+XlsxWriter==3.2.0
 tomli==2.0.1
 # Utilidades varias
 cryptography==41.0.3

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,23 @@
+# Scripts
+
+## `export_analysis.py`
+
+Genera reportes enriquecidos (CSV + Excel) a partir de snapshots persistidos en formato JSON.
+
+### Uso rápido
+
+```bash
+python scripts/export_analysis.py \
+  --input .cache/portfolio_snapshots \
+  --output ./exports/informe_diario \
+  --metrics total_value total_pl total_pl_pct positions \
+  --charts pl_top composition timeline heatmap \
+  --limit 20
+```
+
+- `--metrics help` y `--charts help` muestran todas las opciones disponibles.
+- `--formats csv|excel|both` permite limitar los formatos generados.
+- Cada snapshot produce un subdirectorio con los CSV (`kpis.csv`, `positions.csv`, `history.csv`, etc.) y, si corresponde, el Excel `analysis.xlsx`.
+- Se crea además `summary.csv` en la carpeta raíz con los valores crudos de los KPIs seleccionados para todas las corridas.
+
+> Requisitos: tener instalados `kaleido` y `XlsxWriter` (ambos incluidos en `requirements.txt`).

--- a/scripts/export_analysis.py
+++ b/scripts/export_analysis.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Generador de reportes enriquecidos a partir de snapshots persistidos."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import pandas as pd
+
+from shared.portfolio_export import (
+    CHART_SPECS,
+    METRIC_SPECS,
+    PortfolioSnapshotExport,
+    compute_kpis,
+    create_excel_workbook,
+    write_tables_to_directory,
+)
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Exporta KPIs, rankings y gráficos del portafolio en CSV/Excel a partir "
+            "de snapshots serializados (JSON)."
+        )
+    )
+    parser.add_argument(
+        "--input",
+        "-i",
+        type=Path,
+        required=True,
+        help="Directorio o archivo JSON con snapshots persistidos.",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        default=Path("exports"),
+        help="Directorio raíz donde se almacenarán los reportes (por defecto ./exports).",
+    )
+    parser.add_argument(
+        "--metrics",
+        nargs="+",
+        help="Lista de KPIs a incluir (usar --metrics help para ver opciones).",
+    )
+    parser.add_argument(
+        "--charts",
+        nargs="+",
+        help="Lista de gráficos a embeber en el Excel (usar --charts help para ver opciones).",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=10,
+        help="Cantidad máxima de filas por ranking (default: 10).",
+    )
+    parser.add_argument(
+        "--formats",
+        choices=["csv", "excel", "both"],
+        default="both",
+        help="Formartos a generar (default: both).",
+    )
+    parser.add_argument(
+        "--no-history",
+        dest="include_history",
+        action="store_false",
+        help="Omitir la hoja/tables de historial de totales.",
+    )
+    parser.add_argument(
+        "--no-rankings",
+        dest="include_rankings",
+        action="store_false",
+        help="Omitir rankings en CSV/Excel.",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Habilita logs informativos durante la ejecución.",
+    )
+    return parser.parse_args()
+
+
+def _available(options: Sequence) -> dict[str, str]:
+    return {spec.key: getattr(spec, "label", getattr(spec, "title", spec.key)) for spec in options}
+
+
+def _resolve_metric_keys(raw: Iterable[str] | None) -> list[str]:
+    lookup = _available(METRIC_SPECS)
+    if raw is None:
+        return [spec.key for spec in METRIC_SPECS[:5]]
+    if len(raw) == 1 and raw[0].lower() == "help":
+        msg = "\n".join(f"- {key}: {label}" for key, label in lookup.items())
+        raise SystemExit(f"Métricas disponibles:\n{msg}")
+    unknown = [key for key in raw if key not in lookup]
+    if unknown:
+        LOGGER.warning("Ignorando métricas desconocidas: %s", ", ".join(unknown))
+    resolved = [key for key in raw if key in lookup]
+    return resolved or [spec.key for spec in METRIC_SPECS[:5]]
+
+
+def _resolve_chart_keys(raw: Iterable[str] | None) -> list[str]:
+    lookup = _available(CHART_SPECS)
+    if raw is None:
+        return [spec.key for spec in CHART_SPECS]
+    if len(raw) == 1 and raw[0].lower() == "help":
+        msg = "\n".join(f"- {key}: {label}" for key, label in lookup.items())
+        raise SystemExit(f"Gráficos disponibles:\n{msg}")
+    unknown = [key for key in raw if key not in lookup]
+    if unknown:
+        LOGGER.warning("Ignorando gráficos desconocidos: %s", ", ".join(unknown))
+    return [key for key in raw if key in lookup]
+
+
+def _iter_snapshot_paths(path: Path) -> list[Path]:
+    if path.is_dir():
+        return sorted(p for p in path.glob("*.json") if p.is_file())
+    if path.is_file():
+        return [path]
+    raise FileNotFoundError(f"No se encontró {path}")
+
+
+def _load_snapshot(path: Path) -> PortfolioSnapshotExport | None:
+    try:
+        snapshot = PortfolioSnapshotExport.from_path(path)
+    except Exception as exc:  # pragma: no cover - robust frente a datos malformados
+        LOGGER.error("No se pudo leer %s: %s", path, exc)
+        return None
+    return snapshot
+
+
+def main() -> int:
+    args = _parse_args()
+    logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING, format="%(levelname)s %(message)s")
+
+    metric_keys = _resolve_metric_keys(args.metrics)
+    chart_keys = _resolve_chart_keys(args.charts)
+    include_history = getattr(args, "include_history", True)
+    include_rankings = getattr(args, "include_rankings", True)
+    limit = max(1, args.limit)
+
+    csv_enabled = args.formats in {"csv", "both"}
+    excel_enabled = args.formats in {"excel", "both"}
+
+    paths = _iter_snapshot_paths(args.input)
+    if not paths:
+        LOGGER.error("No se encontraron snapshots en %s", args.input)
+        return 1
+
+    args.output.mkdir(parents=True, exist_ok=True)
+
+    summary_rows: list[dict[str, object]] = []
+
+    for path in paths:
+        snapshot = _load_snapshot(path)
+        if snapshot is None:
+            continue
+        name = snapshot.name or path.stem
+        LOGGER.info("Procesando snapshot %s", name)
+        target_dir = args.output / name
+        target_dir.mkdir(parents=True, exist_ok=True)
+
+        if csv_enabled:
+            write_tables_to_directory(
+                snapshot,
+                target_dir,
+                metric_keys=metric_keys,
+                include_rankings=include_rankings,
+                include_history=include_history,
+                limit=limit,
+            )
+        if excel_enabled:
+            excel_bytes = create_excel_workbook(
+                snapshot,
+                metric_keys=metric_keys,
+                chart_keys=chart_keys,
+                include_rankings=include_rankings,
+                include_history=include_history,
+                limit=limit,
+            )
+            (target_dir / "analysis.xlsx").write_bytes(excel_bytes)
+
+        kpis = compute_kpis(snapshot, metric_keys=metric_keys)
+        if not kpis.empty:
+            row = {
+                "snapshot": name,
+                "generated_at": snapshot.generated_at.isoformat() if snapshot.generated_at else "",
+            }
+            for _, metric in kpis.iterrows():
+                row[metric["metric"]] = metric.get("raw_value")
+            summary_rows.append(row)
+
+    if summary_rows:
+        summary_df = pd.DataFrame(summary_rows)
+        summary_path = args.output / "summary.csv"
+        summary_df.to_csv(summary_path, index=False)
+        LOGGER.info("Resumen guardado en %s", summary_path)
+
+    LOGGER.info("Exportación completada (%d snapshots)", len(summary_rows))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/shared/portfolio_export.py
+++ b/shared/portfolio_export.py
@@ -1,0 +1,896 @@
+"""Helpers to transform portfolio snapshots into enriched exports."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from datetime import datetime
+import json
+import logging
+from io import BytesIO
+from pathlib import Path
+from typing import Callable, Iterable, Sequence
+
+import numpy as np
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+
+from shared.export import fig_to_png_bytes
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Data containers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MetricSpec:
+    """Metadata describing a KPI available for export."""
+
+    key: str
+    label: str
+    description: str
+    compute: Callable[["PortfolioSnapshotExport"], float | int | None]
+    formatter: Callable[[float | int | None], str]
+
+
+@dataclass(frozen=True)
+class ChartSpec:
+    """Metadata describing an available chart for enriched exports."""
+
+    key: str
+    title: str
+    description: str
+    builder: Callable[["PortfolioSnapshotExport", int], go.Figure | None]
+
+
+@dataclass(frozen=True)
+class RankingTable:
+    """Structured ranking used by CSV/Excel generators."""
+
+    key: str
+    title: str
+    value_label: str
+    share_label: str | None
+    description: str
+    dataframe: pd.DataFrame
+
+
+@dataclass(frozen=True)
+class PortfolioSnapshotExport:
+    """Normalized payload with portfolio analytics for export routines."""
+
+    name: str
+    generated_at: datetime | None
+    positions: pd.DataFrame
+    totals: dict[str, float | None]
+    history: pd.DataFrame
+    contributions_by_symbol: pd.DataFrame
+    contributions_by_type: pd.DataFrame
+
+    @classmethod
+    def from_snapshot(cls, snapshot, name: str = "snapshot") -> "PortfolioSnapshotExport":
+        """Create a normalized payload from :class:`PortfolioViewSnapshot`."""
+
+        try:
+            from application.portfolio_service import PortfolioTotals
+            from services.portfolio_view import PortfolioContributionMetrics
+        except ImportError:  # pragma: no cover - defensive, tests patch modules
+            PortfolioTotals = object  # type: ignore[assignment]
+            PortfolioContributionMetrics = object  # type: ignore[assignment]
+
+        df_view = _ensure_dataframe(getattr(snapshot, "df_view", None))
+        totals = getattr(snapshot, "totals", None)
+        totals_dict: dict[str, float | None]
+        if totals is None:
+            totals_dict = {}
+        elif isinstance(totals, dict):
+            totals_dict = {k: _safe_float(v) for k, v in totals.items()}
+        elif "PortfolioTotals" in str(type(totals)):
+            totals_dict = {k: _safe_float(v) for k, v in asdict(totals).items()}
+        else:
+            totals_dict = {
+                key: _safe_float(getattr(totals, key, None))
+                for key in ("total_value", "total_cost", "total_pl", "total_pl_pct", "total_cash")
+            }
+
+        generated_at_ts = getattr(snapshot, "generated_at", None)
+        generated_at_dt = _parse_timestamp(generated_at_ts)
+
+        history_df = _ensure_dataframe(getattr(snapshot, "historical_total", None))
+        contrib = getattr(snapshot, "contribution_metrics", None)
+        if contrib is not None and "PortfolioContributionMetrics" in str(type(contrib)):
+            by_symbol = _ensure_dataframe(getattr(contrib, "by_symbol", None))
+            by_type = _ensure_dataframe(getattr(contrib, "by_type", None))
+        else:
+            by_symbol = _ensure_dataframe(getattr(contrib, "by_symbol", None))
+            by_type = _ensure_dataframe(getattr(contrib, "by_type", None))
+
+        return cls(
+            name=name,
+            generated_at=generated_at_dt,
+            positions=df_view.reset_index(drop=True),
+            totals=totals_dict,
+            history=history_df.reset_index(drop=True),
+            contributions_by_symbol=by_symbol.reset_index(drop=True),
+            contributions_by_type=by_type.reset_index(drop=True),
+        )
+
+    @classmethod
+    def from_payload(
+        cls,
+        payload: dict,
+        name: str | None = None,
+    ) -> "PortfolioSnapshotExport":
+        """Create a payload from a JSON-compatible snapshot representation."""
+
+        name = name or str(payload.get("name") or payload.get("snapshot") or "snapshot")
+        positions = payload.get("positions")
+        if positions is None:
+            positions = payload.get("df_view")
+        positions_df = _ensure_dataframe(positions)
+
+        totals_raw = payload.get("totals") or {}
+        if isinstance(totals_raw, str):
+            try:
+                totals_raw = json.loads(totals_raw)
+            except json.JSONDecodeError:
+                totals_raw = {}
+        totals = {k: _safe_float(v) for k, v in dict(totals_raw).items()} if totals_raw else {}
+
+        generated_at = payload.get("generated_at") or payload.get("timestamp")
+        generated_at_dt = _parse_timestamp(generated_at)
+
+        history_raw = payload.get("history") or payload.get("historical_total") or []
+        history_df = _ensure_dataframe(history_raw)
+
+        contributions = payload.get("contributions") or {}
+        by_symbol = contributions.get("by_symbol") or payload.get("contribution_by_symbol") or []
+        by_type = contributions.get("by_type") or payload.get("contribution_by_type") or []
+
+        return cls(
+            name=name,
+            generated_at=generated_at_dt,
+            positions=positions_df.reset_index(drop=True),
+            totals=totals,
+            history=history_df.reset_index(drop=True),
+            contributions_by_symbol=_ensure_dataframe(by_symbol).reset_index(drop=True),
+            contributions_by_type=_ensure_dataframe(by_type).reset_index(drop=True),
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> "PortfolioSnapshotExport":
+        """Load a snapshot payload from disk."""
+
+        suffix = path.suffix.lower()
+        if suffix == ".json":
+            payload = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(payload, dict):
+                raise ValueError(f"Snapshot {path} is not a JSON object")
+            return cls.from_payload(payload, name=path.stem)
+        raise ValueError(f"Unsupported snapshot format: {path.suffix}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _ensure_dataframe(data) -> pd.DataFrame:
+    if isinstance(data, pd.DataFrame):
+        return data.copy()
+    if data is None:
+        return pd.DataFrame()
+    try:
+        return pd.DataFrame(data)
+    except ValueError:
+        return pd.DataFrame()
+
+
+def _safe_float(value) -> float | None:
+    if value is None:
+        return None
+    try:
+        fval = float(value)
+    except (TypeError, ValueError):
+        return None
+    if np.isnan(fval):  # type: ignore[arg-type]
+        return None
+    return fval
+
+
+def _parse_timestamp(value) -> datetime | None:
+    if value in (None, ""):
+        return None
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, (int, float)):
+        try:
+            return datetime.fromtimestamp(float(value))
+        except (OverflowError, OSError, ValueError):
+            return None
+    if isinstance(value, str):
+        try:
+            return datetime.fromisoformat(value)
+        except ValueError:
+            try:
+                return datetime.fromtimestamp(float(value))
+            except (ValueError, OverflowError, OSError):
+                return None
+    return None
+
+
+def _format_currency(value: float | int | None) -> str:
+    if value is None or not np.isfinite(value):
+        return "—"
+    return f"${value:,.2f}".replace(",", "_").replace(".", ",").replace("_", ".")
+
+
+def _format_integer(value: float | int | None) -> str:
+    if value is None or not np.isfinite(value):
+        return "—"
+    return f"{int(value):,}".replace(",", ".")
+
+
+def _format_percentage(value: float | int | None) -> str:
+    if value is None or not np.isfinite(value):
+        return "—"
+    return f"{float(value):.2f}%"
+
+
+def _format_ratio(value: float | int | None) -> str:
+    if value is None or not np.isfinite(value):
+        return "—"
+    return f"{float(value):.2f}"
+
+
+def _compute_ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or denominator is None:
+        return None
+    if np.isclose(denominator, 0.0):
+        return None
+    return float(numerator) / float(denominator)
+
+
+def _unique_symbols(df: pd.DataFrame) -> int:
+    if df is None or df.empty or "simbolo" not in df.columns:
+        return 0
+    return int(df["simbolo"].astype(str).nunique())
+
+
+def _normalize_history(history: pd.DataFrame) -> pd.DataFrame:
+    if history is None or history.empty:
+        return pd.DataFrame(columns=["timestamp", "total_value", "total_cost", "total_pl"])
+    df = history.copy()
+    if "timestamp" in df.columns:
+        if not pd.api.types.is_datetime64_any_dtype(df["timestamp"]):
+            df["timestamp"] = pd.to_numeric(df["timestamp"], errors="coerce")
+            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s", errors="coerce")
+        df = df.dropna(subset=["timestamp"]).sort_values("timestamp")
+    return df.reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Metric and chart configuration
+# ---------------------------------------------------------------------------
+
+
+def _total_value(snapshot: PortfolioSnapshotExport) -> float | None:
+    return snapshot.totals.get("total_value")
+
+
+def _total_cost(snapshot: PortfolioSnapshotExport) -> float | None:
+    return snapshot.totals.get("total_cost")
+
+
+def _total_pl(snapshot: PortfolioSnapshotExport) -> float | None:
+    return snapshot.totals.get("total_pl")
+
+
+def _total_pl_pct(snapshot: PortfolioSnapshotExport) -> float | None:
+    return snapshot.totals.get("total_pl_pct")
+
+
+def _total_cash(snapshot: PortfolioSnapshotExport) -> float | None:
+    return snapshot.totals.get("total_cash")
+
+
+def _num_positions(snapshot: PortfolioSnapshotExport) -> int:
+    return len(snapshot.positions.index)
+
+
+def _num_symbols(snapshot: PortfolioSnapshotExport) -> int:
+    return _unique_symbols(snapshot.positions)
+
+
+def _avg_position(snapshot: PortfolioSnapshotExport) -> float | None:
+    total_val = _total_value(snapshot)
+    if total_val is None:
+        return None
+    count = _num_positions(snapshot)
+    if count <= 0:
+        return None
+    return total_val / count
+
+
+def _cash_ratio(snapshot: PortfolioSnapshotExport) -> float | None:
+    total_val = _total_value(snapshot)
+    cash = _total_cash(snapshot)
+    ratio = _compute_ratio(cash, total_val)
+    if ratio is None:
+        return None
+    return ratio * 100.0
+
+
+METRIC_SPECS: list[MetricSpec] = [
+    MetricSpec(
+        key="total_value",
+        label="Valor total (ARS)",
+        description="Valorizado actual del portafolio.",
+        compute=_total_value,
+        formatter=_format_currency,
+    ),
+    MetricSpec(
+        key="total_cost",
+        label="Costo total (ARS)",
+        description="Inversión histórica realizada.",
+        compute=_total_cost,
+        formatter=_format_currency,
+    ),
+    MetricSpec(
+        key="total_pl",
+        label="P/L acumulado (ARS)",
+        description="Ganancia o pérdida acumulada en moneda local.",
+        compute=_total_pl,
+        formatter=_format_currency,
+    ),
+    MetricSpec(
+        key="total_pl_pct",
+        label="P/L acumulado (%)",
+        description="Rentabilidad acumulada respecto del costo.",
+        compute=_total_pl_pct,
+        formatter=_format_percentage,
+    ),
+    MetricSpec(
+        key="total_cash",
+        label="Cash disponible (ARS)",
+        description="Liquidez identificada en cuentas o parking.",
+        compute=_total_cash,
+        formatter=_format_currency,
+    ),
+    MetricSpec(
+        key="positions",
+        label="Cantidad de posiciones",
+        description="Total de filas en el snapshot exportado.",
+        compute=lambda snap: float(_num_positions(snap)),
+        formatter=_format_integer,
+    ),
+    MetricSpec(
+        key="symbols",
+        label="Símbolos únicos",
+        description="Cantidad de tickers diferentes presentes.",
+        compute=lambda snap: float(_num_symbols(snap)),
+        formatter=_format_integer,
+    ),
+    MetricSpec(
+        key="avg_position",
+        label="Valorizado promedio",
+        description="Promedio de valuación por posición.",
+        compute=_avg_position,
+        formatter=_format_currency,
+    ),
+    MetricSpec(
+        key="cash_ratio",
+        label="Cash sobre total (%)",
+        description="Porcentaje del portafolio asignado a liquidez.",
+        compute=_cash_ratio,
+        formatter=_format_percentage,
+    ),
+]
+
+METRIC_LOOKUP = {spec.key: spec for spec in METRIC_SPECS}
+
+
+def _chart_pl_top(snapshot: PortfolioSnapshotExport, limit: int) -> go.Figure | None:
+    df = snapshot.positions
+    if df is None or df.empty or "pl" not in df.columns:
+        return None
+    data = df.copy()
+    data["pl"] = pd.to_numeric(data["pl"], errors="coerce")
+    data = data.dropna(subset=["pl"]).sort_values("pl", ascending=False).head(limit)
+    if data.empty:
+        return None
+    fig = px.bar(
+        data,
+        x="simbolo",
+        y="pl",
+        hover_data={"tipo": True, "pl": ":,.0f"},
+        color="simbolo",
+        title="Top P/L acumulado",
+    )
+    fig.update_traces(texttemplate="%{y:,.0f}", textposition="outside", cliponaxis=False)
+    fig.update_layout(template="plotly_white", showlegend=False)
+    return fig
+
+
+def _chart_composition(snapshot: PortfolioSnapshotExport, limit: int) -> go.Figure | None:
+    df = snapshot.positions
+    if df is None or df.empty:
+        return None
+    if "valor_actual" not in df.columns or "tipo" not in df.columns:
+        return None
+    data = df.copy()
+    data["valor_actual"] = pd.to_numeric(data["valor_actual"], errors="coerce")
+    data = data.dropna(subset=["valor_actual"]).groupby("tipo", dropna=False)["valor_actual"].sum().reset_index()
+    data = data.sort_values("valor_actual", ascending=False)
+    if data.empty:
+        return None
+    fig = px.pie(
+        data,
+        values="valor_actual",
+        names="tipo",
+        hole=0.5,
+        title="Composición por tipo",
+    )
+    fig.update_traces(textinfo="percent+label")
+    fig.update_layout(template="plotly_white")
+    return fig
+
+
+def _chart_distribution(snapshot: PortfolioSnapshotExport, limit: int) -> go.Figure | None:
+    df = snapshot.positions
+    if df is None or df.empty:
+        return None
+    if "valor_actual" not in df.columns or "tipo" not in df.columns:
+        return None
+    data = df.copy()
+    data["valor_actual"] = pd.to_numeric(data["valor_actual"], errors="coerce")
+    data = data.dropna(subset=["valor_actual"]).groupby("tipo", dropna=False)["valor_actual"].sum().reset_index()
+    data = data.sort_values("valor_actual", ascending=False)
+    if data.empty:
+        return None
+    fig = px.bar(
+        data,
+        x="tipo",
+        y="valor_actual",
+        color="tipo",
+        hover_data={"valor_actual": ":,.0f"},
+        title="Distribución por tipo",
+    )
+    fig.update_traces(texttemplate="%{y:,.0f}", textposition="outside", cliponaxis=False)
+    fig.update_layout(template="plotly_white", showlegend=False)
+    return fig
+
+
+def _chart_timeline(snapshot: PortfolioSnapshotExport, limit: int) -> go.Figure | None:
+    history = _normalize_history(snapshot.history)
+    if history.empty:
+        return None
+    value_cols = [
+        col
+        for col in ("total_value", "total_cost", "total_pl")
+        if col in history.columns
+    ]
+    if not value_cols:
+        return None
+    melted = history.melt(
+        id_vars=["timestamp"],
+        value_vars=value_cols,
+        var_name="metric",
+        value_name="value",
+    )
+    melted = melted.dropna(subset=["value"])
+    if melted.empty:
+        return None
+    fig = px.line(
+        melted,
+        x="timestamp",
+        y="value",
+        color="metric",
+        markers=True,
+        title="Evolución histórica",
+    )
+    fig.update_layout(template="plotly_white")
+    return fig
+
+
+def _chart_heatmap(snapshot: PortfolioSnapshotExport, limit: int) -> go.Figure | None:
+    df = snapshot.contributions_by_symbol
+    if df is None or df.empty:
+        return None
+    if "tipo" not in df.columns or "simbolo" not in df.columns:
+        return None
+    value_col = "valor_actual_pct" if "valor_actual_pct" in df.columns else None
+    if value_col is None and "pl_pct" in df.columns:
+        value_col = "pl_pct"
+    if value_col is None:
+        return None
+    data = df.copy()
+    data[value_col] = pd.to_numeric(data[value_col], errors="coerce")
+    pivot = data.pivot_table(index="tipo", columns="simbolo", values=value_col, aggfunc="sum")
+    pivot = pivot.sort_index().fillna(0.0)
+    if pivot.empty:
+        return None
+    fig = go.Figure(data=go.Heatmap(z=pivot.values, x=list(pivot.columns), y=list(pivot.index), colorscale="Blues"))
+    fig.update_layout(template="plotly_white", title="Mapa de calor por símbolo y tipo")
+    return fig
+
+
+CHART_SPECS: list[ChartSpec] = [
+    ChartSpec(
+        key="pl_top",
+        title="Top P/L acumulado",
+        description="Ranking de ganancias acumuladas por símbolo.",
+        builder=_chart_pl_top,
+    ),
+    ChartSpec(
+        key="composition",
+        title="Composición por tipo",
+        description="Participación porcentual de cada tipo de activo.",
+        builder=_chart_composition,
+    ),
+    ChartSpec(
+        key="distribution",
+        title="Distribución valorizada",
+        description="Valorizado total por tipo de instrumento.",
+        builder=_chart_distribution,
+    ),
+    ChartSpec(
+        key="timeline",
+        title="Evolución histórica",
+        description="Serie temporal con valor, costo y P/L.",
+        builder=_chart_timeline,
+    ),
+    ChartSpec(
+        key="heatmap",
+        title="Mapa de calor por símbolo/tipo",
+        description="Matriz de contribución porcentual por símbolo.",
+        builder=_chart_heatmap,
+    ),
+]
+
+CHART_LOOKUP = {spec.key: spec for spec in CHART_SPECS}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def compute_kpis(
+    snapshot: PortfolioSnapshotExport,
+    metric_keys: Sequence[str] | None = None,
+) -> pd.DataFrame:
+    """Return a table with the selected metrics for the provided snapshot."""
+
+    keys = list(metric_keys or [spec.key for spec in METRIC_SPECS[:5]])
+    rows = []
+    for key in keys:
+        spec = METRIC_LOOKUP.get(key)
+        if spec is None:
+            continue
+        raw = spec.compute(snapshot)
+        if raw is not None and not np.isfinite(raw):
+            raw = None
+        rows.append(
+            {
+                "metric": spec.key,
+                "label": spec.label,
+                "value": spec.formatter(raw),
+                "raw_value": raw,
+                "description": spec.description,
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def build_rankings(
+    snapshot: PortfolioSnapshotExport,
+    *,
+    limit: int = 10,
+) -> list[RankingTable]:
+    """Return ranking tables for cumulative P/L and valorizado metrics."""
+
+    df = snapshot.positions
+    if df is None or df.empty:
+        return []
+
+    rankings: list[RankingTable] = []
+
+    def _prepare(column: str, ascending: bool) -> pd.DataFrame:
+        data = df.copy()
+        data[column] = pd.to_numeric(data[column], errors="coerce")
+        data = data.dropna(subset=[column]).sort_values(column, ascending=ascending).head(limit)
+        if data.empty:
+            return pd.DataFrame()
+        total = data[column].sum(min_count=1)
+        total_ref = df[column].sum(min_count=1)
+        share = None
+        if np.isfinite(total_ref) and not np.isclose(total_ref, 0.0):
+            share = (data[column] / total_ref) * 100.0
+        data = data.assign(
+            Rank=range(1, len(data) + 1),
+            Símbolo=data.get("simbolo", pd.Series(dtype=str)).astype(str),
+            Tipo=data.get("tipo", pd.Series(dtype=str)).astype(str),
+            Valor=data[column],
+        )
+        if share is not None:
+            data = data.assign(Participación=share)
+        cols = ["Rank", "Símbolo", "Tipo", "Valor"]
+        if "Participación" in data.columns:
+            cols.append("Participación")
+        return data[cols]
+
+    if "pl" in df.columns:
+        top_df = _prepare("pl", ascending=False)
+        if not top_df.empty:
+            rankings.append(
+                RankingTable(
+                    key="pl_top",
+                    title="Ranking P/L (Top)",
+                    value_label="Valor P/L",
+                    share_label="Participación (%)" if "Participación" in top_df.columns else None,
+                    description="Símbolos con mayor ganancia acumulada.",
+                    dataframe=top_df,
+                )
+            )
+        bottom_df = _prepare("pl", ascending=True)
+        if not bottom_df.empty:
+            rankings.append(
+                RankingTable(
+                    key="pl_bottom",
+                    title="Ranking P/L (Bottom)",
+                    value_label="Valor P/L",
+                    share_label="Participación (%)" if "Participación" in bottom_df.columns else None,
+                    description="Símbolos con mayor pérdida acumulada.",
+                    dataframe=bottom_df,
+                )
+            )
+
+    if "valor_actual" in df.columns:
+        val_df = _prepare("valor_actual", ascending=False)
+        if not val_df.empty:
+            rankings.append(
+                RankingTable(
+                    key="valor_actual",
+                    title="Ranking valorizado",
+                    value_label="Valor actual",
+                    share_label="Participación (%)" if "Participación" in val_df.columns else None,
+                    description="Posiciones con mayor peso en el portafolio.",
+                    dataframe=val_df,
+                )
+            )
+
+    return rankings
+
+
+def assemble_tables(
+    snapshot: PortfolioSnapshotExport,
+    *,
+    metric_keys: Sequence[str] | None = None,
+    include_rankings: bool = True,
+    include_history: bool = True,
+    limit: int = 10,
+) -> dict[str, pd.DataFrame]:
+    """Return a mapping of table name → DataFrame for CSV/Excel exports."""
+
+    tables: dict[str, pd.DataFrame] = {}
+
+    kpis = compute_kpis(snapshot, metric_keys)
+    if not kpis.empty:
+        kpis.insert(0, "snapshot", snapshot.name)
+        if snapshot.generated_at is not None:
+            kpis.insert(1, "generated_at", snapshot.generated_at.isoformat())
+    tables["kpis"] = kpis
+
+    positions = snapshot.positions.copy()
+    if not positions.empty:
+        positions.insert(0, "snapshot", snapshot.name)
+    tables["positions"] = positions
+
+    by_symbol = snapshot.contributions_by_symbol.copy()
+    if not by_symbol.empty:
+        by_symbol.insert(0, "snapshot", snapshot.name)
+    tables["contribution_by_symbol"] = by_symbol
+
+    by_type = snapshot.contributions_by_type.copy()
+    if not by_type.empty:
+        by_type.insert(0, "snapshot", snapshot.name)
+    tables["contribution_by_type"] = by_type
+
+    if include_history:
+        history = _normalize_history(snapshot.history)
+        if not history.empty:
+            history.insert(0, "snapshot", snapshot.name)
+            tables["history"] = history
+
+    if include_rankings:
+        rankings = build_rankings(snapshot, limit=limit)
+        for ranking in rankings:
+            df = ranking.dataframe.copy()
+            df.insert(0, "snapshot", snapshot.name)
+            tables[f"ranking_{ranking.key}"] = df
+
+    return tables
+
+
+def create_csv_bundle(
+    snapshot: PortfolioSnapshotExport,
+    *,
+    metric_keys: Sequence[str] | None = None,
+    include_rankings: bool = True,
+    include_history: bool = True,
+    limit: int = 10,
+) -> bytes:
+    """Return a ZIP with CSV exports for the snapshot."""
+
+    from zipfile import ZIP_DEFLATED, ZipFile
+
+    tables = assemble_tables(
+        snapshot,
+        metric_keys=metric_keys,
+        include_rankings=include_rankings,
+        include_history=include_history,
+        limit=limit,
+    )
+
+    buffer = BytesIO()
+    with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as zf:
+        for name, df in tables.items():
+            csv_bytes = df.to_csv(index=False).encode("utf-8")
+            zf.writestr(f"{name}.csv", csv_bytes)
+    return buffer.getvalue()
+
+
+def write_tables_to_directory(
+    snapshot: PortfolioSnapshotExport,
+    directory: Path,
+    *,
+    metric_keys: Sequence[str] | None = None,
+    include_rankings: bool = True,
+    include_history: bool = True,
+    limit: int = 10,
+) -> dict[str, Path]:
+    """Persist CSV tables to ``directory`` and return mapping name → path."""
+
+    directory.mkdir(parents=True, exist_ok=True)
+    tables = assemble_tables(
+        snapshot,
+        metric_keys=metric_keys,
+        include_rankings=include_rankings,
+        include_history=include_history,
+        limit=limit,
+    )
+    written: dict[str, Path] = {}
+    for name, df in tables.items():
+        path = directory / f"{name}.csv"
+        df.to_csv(path, index=False)
+        written[name] = path
+    return written
+
+
+def build_chart_figures(
+    snapshot: PortfolioSnapshotExport,
+    chart_keys: Iterable[str],
+    *,
+    limit: int = 10,
+) -> dict[str, go.Figure]:
+    """Generate Plotly figures for the requested chart keys."""
+
+    figures: dict[str, go.Figure] = {}
+    for key in chart_keys:
+        spec = CHART_LOOKUP.get(key)
+        if spec is None:
+            continue
+        try:
+            fig = spec.builder(snapshot, limit)
+        except Exception:  # pragma: no cover - safeguard for plotly edge-cases
+            logger.exception("No se pudo generar el gráfico %s", key)
+            continue
+        if fig is not None:
+            figures[key] = fig
+    return figures
+
+
+def create_excel_workbook(
+    snapshot: PortfolioSnapshotExport,
+    *,
+    metric_keys: Sequence[str] | None = None,
+    chart_keys: Sequence[str] | None = None,
+    include_rankings: bool = True,
+    include_history: bool = True,
+    limit: int = 10,
+) -> bytes:
+    """Create an Excel workbook containing KPIs, tables and embedded charts."""
+
+    tables = assemble_tables(
+        snapshot,
+        metric_keys=metric_keys,
+        include_rankings=include_rankings,
+        include_history=include_history,
+        limit=limit,
+    )
+
+    buffer = BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+        workbook = writer.book
+
+        sheet_order: list[tuple[str, pd.DataFrame]] = []
+
+        for name in ["kpis", "positions", "contribution_by_symbol", "contribution_by_type", "history"]:
+            if name in tables and not tables[name].empty:
+                sheet_order.append((name, tables[name]))
+
+        ranking_names = [name for name in tables if name.startswith("ranking_")]
+        for name in ranking_names:
+            sheet_order.append((name, tables[name]))
+
+        # Persist tables to individual sheets
+        for name, df in sheet_order:
+            sheet_name = _sheet_title(name)
+            df.to_excel(writer, sheet_name=sheet_name, index=False)
+            worksheet = writer.sheets[sheet_name]
+            for idx, col in enumerate(df.columns):
+                lengths = df[col].astype(str).map(len).tolist()
+                max_len = max([14] + lengths) if lengths else 14
+                width = max(14, min(60, max_len + 4))
+                worksheet.set_column(idx, idx, width)
+
+        # Add charts if available
+        chart_keys = list(chart_keys or [])
+        if chart_keys:
+            charts_sheet = workbook.add_worksheet("Gráficos")
+            charts_sheet.set_column(0, 4, 48)
+            row = 0
+            figures = build_chart_figures(snapshot, chart_keys, limit=limit)
+            for key in chart_keys:
+                if key not in figures:
+                    continue
+                spec = CHART_LOOKUP[key]
+                charts_sheet.write(row, 0, spec.title)
+                row += 1
+                try:
+                    img_bytes = fig_to_png_bytes(figures[key])
+                except ValueError:
+                    logger.warning("No se pudo convertir el gráfico %s a PNG", key)
+                    charts_sheet.write(row, 0, "No se pudo exportar el gráfico (kaleido ausente)")
+                    row += 18
+                    continue
+                charts_sheet.insert_image(row, 0, f"{key}.png", {"image_data": BytesIO(img_bytes), "x_scale": 0.9, "y_scale": 0.9})
+                row += 20
+
+    return buffer.getvalue()
+
+
+def _sheet_title(name: str) -> str:
+    mapping = {
+        "kpis": "KPIs",
+        "positions": "Posiciones",
+        "contribution_by_symbol": "Contribución símbolo",
+        "contribution_by_type": "Contribución tipo",
+        "history": "Histórico",
+    }
+    if name.startswith("ranking_"):
+        return name.replace("ranking_", "Ranking ").title()[:31]
+    return mapping.get(name, name.replace("_", " ").title())[:31]
+
+
+__all__ = [
+    "MetricSpec",
+    "ChartSpec",
+    "RankingTable",
+    "PortfolioSnapshotExport",
+    "METRIC_SPECS",
+    "METRIC_LOOKUP",
+    "CHART_SPECS",
+    "CHART_LOOKUP",
+    "compute_kpis",
+    "build_rankings",
+    "assemble_tables",
+    "build_chart_figures",
+    "create_csv_bundle",
+    "create_excel_workbook",
+    "write_tables_to_directory",
+]

--- a/shared/test/test_portfolio_export.py
+++ b/shared/test/test_portfolio_export.py
@@ -1,0 +1,141 @@
+import base64
+from datetime import datetime
+from io import BytesIO
+from pathlib import Path
+import sys
+
+import pandas as pd
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from shared.portfolio_export import (
+    PortfolioSnapshotExport,
+    build_rankings,
+    compute_kpis,
+    create_csv_bundle,
+    create_excel_workbook,
+    write_tables_to_directory,
+)
+
+
+def _snapshot() -> PortfolioSnapshotExport:
+    positions = pd.DataFrame(
+        [
+            {"simbolo": "GGAL", "tipo": "ACCION", "valor_actual": 1200.0, "pl": 200.0},
+            {"simbolo": "AL30", "tipo": "BONO", "valor_actual": 800.0, "pl": -50.0},
+        ]
+    )
+    totals = {
+        "total_value": 2000.0,
+        "total_cost": 1700.0,
+        "total_pl": 300.0,
+        "total_pl_pct": (300.0 / 1700.0) * 100.0,
+        "total_cash": 250.0,
+    }
+    history = pd.DataFrame(
+        {
+            "timestamp": [datetime(2024, 1, 1), datetime(2024, 1, 2)],
+            "total_value": [1800.0, 2000.0],
+            "total_cost": [1700.0, 1700.0],
+            "total_pl": [100.0, 300.0],
+        }
+    )
+    contrib_symbol = pd.DataFrame(
+        {
+            "tipo": ["ACCION", "BONO"],
+            "simbolo": ["GGAL", "AL30"],
+            "valor_actual": [1200.0, 800.0],
+            "valor_actual_pct": [60.0, 40.0],
+            "pl": [200.0, -50.0],
+            "pl_pct": [80.0, -20.0],
+        }
+    )
+    contrib_type = pd.DataFrame(
+        {
+            "tipo": ["ACCION", "BONO"],
+            "valor_actual": [1200.0, 800.0],
+            "valor_actual_pct": [60.0, 40.0],
+            "pl": [200.0, -50.0],
+            "pl_pct": [80.0, -20.0],
+        }
+    )
+    return PortfolioSnapshotExport(
+        name="demo",
+        generated_at=datetime(2024, 1, 2, 15, 30),
+        positions=positions,
+        totals=totals,
+        history=history,
+        contributions_by_symbol=contrib_symbol,
+        contributions_by_type=contrib_type,
+    )
+
+
+def test_compute_kpis_returns_metrics() -> None:
+    snap = _snapshot()
+    df = compute_kpis(snap, metric_keys=["total_value", "positions", "cash_ratio"])
+    assert set(df["metric"]) == {"total_value", "positions", "cash_ratio"}
+    positions_row = df[df["metric"] == "positions"].iloc[0]
+    assert positions_row["raw_value"] == 2.0
+    assert positions_row["value"].isdigit()
+
+
+def test_build_rankings_includes_expected_tables() -> None:
+    snap = _snapshot()
+    rankings = build_rankings(snap, limit=5)
+    keys = {r.key for r in rankings}
+    assert {"pl_top", "pl_bottom", "valor_actual"}.issubset(keys)
+    top = next(r for r in rankings if r.key == "pl_top")
+    assert "Valor" in top.dataframe.columns
+
+
+def test_create_csv_bundle_contains_expected_members() -> None:
+    snap = _snapshot()
+    bundle = create_csv_bundle(snap, metric_keys=["total_value"], limit=3)
+    from zipfile import ZipFile
+
+    with ZipFile(BytesIO(bundle)) as zf:
+        names = set(zf.namelist())
+    assert "kpis.csv" in names
+    assert "positions.csv" in names
+    assert any(name.startswith("ranking_") for name in names)
+
+
+def test_create_excel_workbook_generates_sheets(monkeypatch: pytest.MonkeyPatch) -> None:
+    snap = _snapshot()
+
+    png_bytes = base64.b64decode(
+        b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+    )
+
+    monkeypatch.setattr("shared.portfolio_export.fig_to_png_bytes", lambda fig: png_bytes)
+
+    workbook = create_excel_workbook(
+        snap,
+        metric_keys=["total_value", "positions"],
+        chart_keys=["pl_top"],
+        limit=3,
+    )
+
+    from zipfile import ZipFile
+
+    with ZipFile(BytesIO(workbook)) as zf:
+        workbook_xml = zf.read("xl/workbook.xml")
+    assert b"KPIs" in workbook_xml
+    assert b"Posiciones" in workbook_xml
+    assert b"Gr\xc3\xa1ficos" in workbook_xml or "Gr\xc3\xa1ficos".encode("latin1") in workbook_xml
+
+
+def test_write_tables_to_directory(tmp_path: Path) -> None:
+    snap = _snapshot()
+    output = write_tables_to_directory(
+        snap,
+        tmp_path,
+        metric_keys=["total_value"],
+        include_rankings=False,
+        include_history=False,
+    )
+    assert "kpis" in output and output["kpis"].exists()
+    assert output["kpis"].read_text(encoding="utf-8").startswith("snapshot")

--- a/tests/integration/test_portfolio_tabs.py
+++ b/tests/integration/test_portfolio_tabs.py
@@ -374,6 +374,7 @@ def _run_for_tab(tab_index: int, monkeypatch: pytest.MonkeyPatch) -> _FakeStream
     monkeypatch.setattr(favorites_mod, "st", fake_st)
     monkeypatch.setattr(charts_mod, "render_table", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_totals", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_portfolio_exports", lambda *a, **k: None)
     monkeypatch.setattr(portfolio_mod, "PortfolioService", lambda: object())
     monkeypatch.setattr(portfolio_mod, "TAService", lambda: ta_stub)
     monkeypatch.setattr(portfolio_mod, "load_portfolio_data", lambda cli, svc: (df, ["GGAL", "AAPL"], ["ACCION", "CEDEAR"]))

--- a/tests/legacy/controllers/test_portfolio_helpers.py
+++ b/tests/legacy/controllers/test_portfolio_helpers.py
@@ -325,6 +325,7 @@ def test_render_basic_section_with_data(monkeypatch):
     monkeypatch.setattr(charts_mod, "render_table", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_portfolio_exports", lambda *a, **k: None)
     fig = object()
     monkeypatch.setattr(
         charts_mod,

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -41,6 +41,7 @@ def test_render_basic_section_captions(monkeypatch):
     monkeypatch.setattr(charts_mod.st, "caption", mock_caption)
     monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_portfolio_exports", lambda *a, **k: None)
     charts_mod.render_basic_section(df, controls, None, favorites=FavoriteSymbols({}))
     captions = [c.args[0] for c in mock_caption.call_args_list]
     expected = [

--- a/tests/ui/test_portfolio_charts_rendering.py
+++ b/tests/ui/test_portfolio_charts_rendering.py
@@ -113,6 +113,7 @@ def _patch_favorite_helpers(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_table", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_totals", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_portfolio_exports", lambda *a, **k: None)
 
 
 def _portfolio_frame() -> pd.DataFrame:

--- a/tests/ui/test_portfolio_ui.py
+++ b/tests/ui/test_portfolio_ui.py
@@ -639,6 +639,7 @@ def test_render_basic_section_renders_timeline_and_heatmap(monkeypatch: pytest.M
     monkeypatch.setattr(charts_mod, "render_table", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod, "render_portfolio_exports", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "get_persistent_favorites", lambda: favorites_stub)
 
     df_view = pd.DataFrame(
@@ -724,6 +725,7 @@ def test_render_basic_section_handles_missing_analytics(monkeypatch: pytest.Monk
     monkeypatch.setattr(charts_mod, "render_favorite_badges", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "render_favorite_toggle", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod, "get_persistent_favorites", lambda: favorites_stub)
+    monkeypatch.setattr(charts_mod, "render_portfolio_exports", lambda *a, **k: None)
 
     df_view = pd.DataFrame(
         {

--- a/ui/export.py
+++ b/ui/export.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
-import streamlit as st
+from dataclasses import asdict
+from datetime import datetime
+from typing import Sequence
+
 import pandas as pd
+import streamlit as st
+
 from shared.export import df_to_csv_bytes
+from shared.portfolio_export import (
+    CHART_LOOKUP,
+    CHART_SPECS,
+    METRIC_LOOKUP,
+    METRIC_SPECS,
+    PortfolioSnapshotExport,
+    create_csv_bundle,
+    create_excel_workbook,
+)
 
 
 # Configuración común de Plotly para habilitar captura a PNG desde la barra de herramientas
@@ -12,3 +26,167 @@ PLOTLY_CONFIG = {"modeBarButtonsToAdd": ["toImage"]}
 def download_csv(df: pd.DataFrame, filename: str, *, label: str = "⬇️ Exportar CSV") -> None:
     """Renderice un botón de descarga para exportar DataFrame como CSV."""
     st.download_button(label, df_to_csv_bytes(df), file_name=filename, mime="text/csv")
+
+
+def render_portfolio_exports(
+    *,
+    snapshot,
+    df_view: pd.DataFrame,
+    totals,
+    historical_total: pd.DataFrame | None,
+    contribution_metrics,
+    filename_prefix: str = "portafolio",
+    default_metrics: Sequence[str] | None = None,
+    default_charts: Sequence[str] | None = None,
+    ranking_limit: int = 10,
+) -> None:
+    """Renderiza controles para exportar reportes enriquecidos del portafolio."""
+
+    if df_view is None or df_view.empty:
+        return
+
+    with st.expander("📦 Exportar análisis enriquecido", expanded=False):
+        st.write(
+            "Generá un paquete de CSV y un Excel con KPIs, rankings y gráficos listos para compartir."
+        )
+
+        metrics_options = [spec.key for spec in METRIC_SPECS]
+        default_metric_keys = [
+            key for key in (default_metrics or metrics_options[:5]) if key in METRIC_LOOKUP
+        ]
+        metric_selection = st.multiselect(
+            "Métricas a incluir",
+            metrics_options,
+            default=default_metric_keys,
+            format_func=lambda key: METRIC_LOOKUP[key].label,
+            key=f"metrics_{filename_prefix}",
+        )
+
+        chart_options = [spec.key for spec in CHART_SPECS]
+        default_chart_keys = [
+            key for key in (default_charts or chart_options[:3]) if key in CHART_LOOKUP
+        ]
+        chart_selection = st.multiselect(
+            "Gráficos a embeber en el Excel",
+            chart_options,
+            default=default_chart_keys,
+            format_func=lambda key: CHART_LOOKUP[key].title,
+            key=f"charts_{filename_prefix}",
+        )
+
+        include_rankings = st.checkbox(
+            "Incluir rankings de P/L y valorizado",
+            value=True,
+            key=f"rankings_{filename_prefix}",
+        )
+        include_history = st.checkbox(
+            "Incluir historial de totales",
+            value=True,
+            key=f"history_{filename_prefix}",
+        )
+        limit = st.slider(
+            "Elementos por ranking",
+            min_value=5,
+            max_value=50,
+            value=ranking_limit,
+            step=5,
+            key=f"limit_{filename_prefix}",
+        )
+
+        export_snapshot = _build_snapshot_export(
+            snapshot,
+            df_view=df_view,
+            totals=totals,
+            historical_total=historical_total,
+            contribution_metrics=contribution_metrics,
+            name=filename_prefix,
+        )
+
+        metric_keys = metric_selection or default_metric_keys or metrics_options[:5]
+
+        csv_bundle = create_csv_bundle(
+            export_snapshot,
+            metric_keys=metric_keys,
+            include_rankings=include_rankings,
+            include_history=include_history,
+            limit=limit,
+        )
+        st.download_button(
+            "⬇️ Descargar CSV (ZIP)",
+            csv_bundle,
+            file_name=f"{filename_prefix}_analisis.zip",
+            mime="application/zip",
+            key=f"csv_bundle_{filename_prefix}",
+        )
+
+        try:
+            excel_bytes = create_excel_workbook(
+                export_snapshot,
+                metric_keys=metric_keys,
+                chart_keys=chart_selection,
+                include_rankings=include_rankings,
+                include_history=include_history,
+                limit=limit,
+            )
+        except ValueError:
+            st.warning(
+                "No se pudieron generar los gráficos (depende de kaleido). Instálalo para habilitar la exportación a Excel."
+            )
+        else:
+            st.download_button(
+                "⬇️ Descargar Excel (.xlsx)",
+                excel_bytes,
+                file_name=f"{filename_prefix}_analisis.xlsx",
+                mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+                key=f"excel_bundle_{filename_prefix}",
+            )
+
+
+def _build_snapshot_export(
+    snapshot,
+    *,
+    df_view: pd.DataFrame,
+    totals,
+    historical_total: pd.DataFrame | None,
+    contribution_metrics,
+    name: str,
+) -> PortfolioSnapshotExport:
+    """Coerce los datos visibles en la UI a un payload exportable."""
+
+    if snapshot is not None:
+        return PortfolioSnapshotExport.from_snapshot(snapshot, name=name)
+
+    totals_dict: dict[str, float | None] = {}
+    if totals is not None:
+        try:
+            totals_dict = {
+                key: float(val) if val is not None else None
+                for key, val in asdict(totals).items()
+            }
+        except TypeError:
+            totals_dict = {}
+
+    history_df = df_to_frame(historical_total)
+    contrib_symbol = df_to_frame(getattr(contribution_metrics, "by_symbol", None))
+    contrib_type = df_to_frame(getattr(contribution_metrics, "by_type", None))
+
+    return PortfolioSnapshotExport(
+        name=name,
+        generated_at=datetime.now(),
+        positions=df_to_frame(df_view),
+        totals=totals_dict,
+        history=history_df,
+        contributions_by_symbol=contrib_symbol,
+        contributions_by_type=contrib_type,
+    )
+
+
+def df_to_frame(data) -> pd.DataFrame:
+    if isinstance(data, pd.DataFrame):
+        return data.copy()
+    if data is None:
+        return pd.DataFrame()
+    try:
+        return pd.DataFrame(data)
+    except ValueError:
+        return pd.DataFrame()


### PR DESCRIPTION
## Summary
- add a shared portfolio export toolkit to compute KPIs, rankings and figures and persist them as CSV/Excel
- wire the dashboard export panel to download enriched ZIP/Excel bundles and document the workflow
- publish a CLI script and usage docs to generate the same reports from persisted JSON snapshots

## Testing
- pytest shared/test/test_portfolio_export.py
- pytest tests/ui/test_portfolio_charts_rendering.py
- pytest tests/ui/test_portfolio_ui.py::test_render_basic_section_renders_timeline_and_heatmap

------
https://chatgpt.com/codex/tasks/task_e_68e054955cb48332ab098c66090c83df