### PR TITLE
Refine export analysis CLI for snapshot exports

### DIFF
--- a/scripts/__init__.py
+++ b/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Helper scripts packaged for reuse in tests."""

--- a/scripts/export_analysis.py
+++ b/scripts/export_analysis.py
@@ -1,10 +1,3 @@
-"""Utilities to export enriched screening analyses.
-
-This helper script runs the deterministic screener stub and produces
-analysis exports ready to share with stakeholders. The resulting
-payload includes both the tabular data and the summary/notes metadata
-computed by the service, ensuring parity with the Streamlit UI.
-"""
 #!/usr/bin/env python3
 """Generador de reportes enriquecidos a partir de snapshots persistidos."""
 
@@ -12,8 +5,8 @@ from __future__ import annotations
 
 import argparse
 import json
-import sys
 import logging
+import sys
 from pathlib import Path
 from typing import Iterable, Sequence
 
@@ -22,96 +15,6 @@ import pandas as pd
 REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
-
-from application.screener.opportunities import run_screener_stub
-
-
-def _write_csv(df: pd.DataFrame, destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    df.to_csv(destination, index=False)
-
-
-def _write_json(df: pd.DataFrame, notes: Sequence[str], destination: Path) -> None:
-    destination.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "summary": df.attrs.get("summary", {}),
-        "notes": list(notes),
-        "rows": df.to_dict(orient="records"),
-    }
-    destination.write_text(json.dumps(payload, indent=2, ensure_ascii=False))
-
-
-def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(
-        description=(
-            "Genera una exportación enriquecida del screening basado en el "
-            "stub determinista, incluyendo notas y métricas agregadas."
-        )
-    )
-    parser.add_argument(
-        "--output",
-        type=Path,
-        default=Path("exports/opportunities_analysis.csv"),
-        help=(
-            "Ruta base donde se guardará la exportación. Cuando se usa el "
-            "formato 'both', se reutiliza la misma ruta para el CSV y se "
-            "genera un JSON paralelo con el mismo nombre."
-        ),
-    )
-    parser.add_argument(
-        "--format",
-        choices=("csv", "json", "both"),
-        default="csv",
-        help="Formato de salida a generar.",
-    )
-    parser.add_argument(
-        "--include-technicals",
-        action="store_true",
-        help="Incluye columnas de indicadores técnicos (RSI, SMAs, etc.).",
-    )
-    parser.add_argument(
-        "--max-results",
-        type=int,
-        default=None,
-        help="Limita la cantidad de filas exportadas tras aplicar los filtros.",
-    )
-    parser.add_argument(
-        "--min-score",
-        type=float,
-        default=None,
-        help="Filtra por puntaje compuesto mínimo antes de exportar.",
-    )
-    parser.add_argument(
-        "--sectors",
-        nargs="*",
-        default=None,
-        help="Lista opcional de sectores a priorizar (usa los nombres visibles en la UI).",
-    )
-    return parser.parse_args(list(argv) if argv is not None else None)
-
-
-def main(argv: Iterable[str] | None = None) -> None:
-    args = _parse_args(argv)
-
-    df, notes = run_screener_stub(
-        include_technicals=args.include_technicals,
-        max_results=args.max_results,
-        min_score_threshold=args.min_score,
-        sectors=args.sectors,
-    )
-
-    output = args.output
-
-    if args.format in {"csv", "both"}:
-        _write_csv(df, output if args.format == "csv" else output)
-
-    if args.format in {"json", "both"}:
-        json_path = output if args.format == "json" else output.with_suffix(".json")
-        _write_json(df, notes, json_path)
-
-
-if __name__ == "__main__":  # pragma: no cover - CLI entry-point
-    main()
 from shared.portfolio_export import (
     CHART_SPECS,
     METRIC_SPECS,
@@ -124,7 +27,7 @@ from shared.portfolio_export import (
 LOGGER = logging.getLogger(__name__)
 
 
-def _parse_args() -> argparse.Namespace:
+def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         description=(
             "Exporta KPIs, rankings y gráficos del portafolio en CSV/Excel a partir "
@@ -184,7 +87,7 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Habilita logs informativos durante la ejecución.",
     )
-    return parser.parse_args()
+    return parser.parse_args(list(argv) if argv is not None else None)
 
 
 def _available(options: Sequence) -> dict[str, str]:
@@ -235,8 +138,8 @@ def _load_snapshot(path: Path) -> PortfolioSnapshotExport | None:
     return snapshot
 
 
-def main() -> int:
-    args = _parse_args()
+def main(argv: Iterable[str] | None = None) -> int:
+    args = _parse_args(argv)
     logging.basicConfig(level=logging.INFO if args.verbose else logging.WARNING, format="%(levelname)s %(message)s")
 
     metric_keys = _resolve_metric_keys(args.metrics)

--- a/tests/scripts/test_export_analysis.py
+++ b/tests/scripts/test_export_analysis.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+from importlib import util
+from pathlib import Path
+import sys
+
+import pandas as pd
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "export_analysis.py"
+SPEC = util.spec_from_file_location("export_analysis", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+export_analysis = util.module_from_spec(SPEC)
+sys.modules.setdefault("export_analysis", export_analysis)
+SPEC.loader.exec_module(export_analysis)
+
+
+def _write_sample_snapshot(directory: Path) -> Path:
+    directory.mkdir(parents=True, exist_ok=True)
+    snapshot = {
+        "name": "sample",
+        "generated_at": "2024-01-02T10:30:00",
+        "positions": [
+            {
+                "simbolo": "AAPL",
+                "tipo": "ACCION",
+                "pl": 1500.0,
+                "valor_actual": 5200.0,
+            },
+            {
+                "simbolo": "MSFT",
+                "tipo": "ACCION",
+                "pl": -300.0,
+                "valor_actual": 3100.0,
+            },
+        ],
+        "totals": {
+            "total_value": 8300.0,
+            "total_cost": 7000.0,
+            "total_pl": 1300.0,
+            "total_pl_pct": 18.57,
+            "total_cash": 1200.0,
+        },
+        "history": [
+            {
+                "timestamp": "2024-01-01T12:00:00",
+                "total_value": 8000.0,
+                "total_cost": 6800.0,
+                "total_pl": 1200.0,
+            },
+            {
+                "timestamp": "2024-01-02T10:30:00",
+                "total_value": 8300.0,
+                "total_cost": 7000.0,
+                "total_pl": 1300.0,
+            },
+        ],
+        "contributions": {
+            "by_symbol": [
+                {"simbolo": "AAPL", "participacion": 62.65},
+                {"simbolo": "MSFT", "participacion": 37.35},
+            ],
+            "by_type": [
+                {"tipo": "ACCION", "participacion": 100.0},
+            ],
+        },
+    }
+    path = directory / "sample.json"
+    path.write_text(json.dumps(snapshot, ensure_ascii=False))
+    return path
+
+
+def test_main_generates_csv_exports(tmp_path: Path) -> None:
+    snapshots_dir = tmp_path / "snapshots"
+    _write_sample_snapshot(snapshots_dir)
+
+    output_dir = tmp_path / "exports"
+
+    exit_code = export_analysis.main(
+        [
+            "--input",
+            str(snapshots_dir),
+            "--output",
+            str(output_dir),
+            "--formats",
+            "csv",
+        ]
+    )
+
+    assert exit_code == 0
+
+    snapshot_output = output_dir / "sample"
+    assert snapshot_output.is_dir()
+
+    generated_files = {path.name for path in snapshot_output.glob("*.csv")}
+    assert {"kpis.csv", "positions.csv"}.issubset(generated_files)
+
+    summary_path = output_dir / "summary.csv"
+    assert summary_path.exists()
+
+    summary_df = pd.read_csv(summary_path)
+    assert "snapshot" in summary_df.columns
+    assert summary_df.loc[0, "snapshot"] == "sample"


### PR DESCRIPTION
## Summary
- remove the legacy screener-oriented CLI from `export_analysis` and keep the snapshot export entry point
- allow passing argument lists to `main` for easier testing and keep the CLI exit semantics
- add a smoke test covering CSV exports from sample snapshot data

## Testing
- pytest tests/scripts/test_export_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68e113ed2e5883329e88fe918a16c8ac