### PR TITLE
Add ZIP bundle to export_analysis CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,9 @@ La versión **0.3.28.1** destaca tres ejes principales:
   servicio `PortfolioViewSnapshot` permiten reanudar análisis sin repetir descargas ni recomputar
   agregados.
 - Las **exportaciones enriquecidas** consolidan la tabla visible, los KPIs y las notas de telemetría
-  en un mismo paquete. El nuevo script `scripts/export_analysis.py` genera CSV/JSON con los mismos
-  datos mostrados en la UI y añade el resumen agregado (`df.attrs["summary"]`).
+  en un mismo paquete. El script `scripts/export_analysis.py` genera carpetas con CSV, un ZIP con
+  esos mismos CSV y un Excel enriquecido con tablas y gráficos embebidos, además de un
+  `summary.csv` global para comparar snapshots.
 - La **observabilidad extendida** agrega métricas de almacenamiento y persistencia al health sidebar.
   Los contadores de resiliencia ahora muestran los hits de snapshots, los reintentos fallidos y la
   procedencia del último dato consolidado (primario, secundario o snapshot de contingencia).
@@ -58,11 +59,14 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
      del almacenamiento persistente como parte de la secuencia.
 4. **Exporta el análisis enriquecido.** Con la app cerrada o en paralelo, ejecuta el script:
    ```bash
-   python scripts/export_analysis.py --format both --output exports/screener.csv
+   python scripts/export_analysis.py --format both --output exports/screener
    ```
-   El comando genera `exports/screener.csv` con la grilla del screening y `exports/screener.json` con
-   notas, métricas agregadas y distribución sectorial. Abre el JSON para confirmar que el bloque
-   `summary` replica los KPI mostrados en la UI.
+   El comando crea una carpeta por snapshot dentro de `exports/screener/` (por ejemplo,
+   `exports/screener/sample/`) con los CSV (`kpis.csv`, `positions.csv`, `history.csv`,
+   `contribution_by_symbol.csv`, etc.), empaqueta esos archivos en `analysis.zip` y genera un
+   `analysis.xlsx` con todas las tablas en hojas dedicadas más los gráficos solicitados. En la raíz del
+   directorio también encontrarás `summary.csv` con los KPIs (`raw_value`) de cada snapshot para
+   facilitar comparaciones rápidas.
 
 ### Validar el fallback jerárquico desde el health sidebar
 
@@ -225,7 +229,7 @@ La aplicación permite llevarte un paquete completo de métricas, rankings y vis
 
 ### Desde la línea de comandos
 
-El script `scripts/export_analysis.py` procesa snapshots serializados en JSON (por ejemplo los generados por jobs batch o instrumentación de QA) y genera los mismos artefactos enriquecidos que la UI.
+El script `scripts/export_analysis.py` procesa snapshots serializados en JSON (por ejemplo los generados por jobs batch o instrumentación de QA) y genera los mismos artefactos enriquecidos que la UI: CSV individuales, un ZIP compacto con esos CSV, un Excel (`analysis.xlsx`) con tablas y gráficos, y el `summary.csv` agregado.
 
 ```bash
 python scripts/export_analysis.py \
@@ -237,8 +241,8 @@ python scripts/export_analysis.py \
 ```
 
 - El argumento `--metrics help` lista todos los KPIs disponibles; `--charts help` hace lo propio con los gráficos.
-- Con `--formats csv` o `--formats excel` podés limitar la salida a un solo formato.
-- Cada snapshot genera un subdirectorio dentro de `--output` con todos los CSV y, si corresponde, el Excel `analysis.xlsx`.
+- El argumento `--formats` (o su alias `--format`) acepta `csv`, `excel` o `both`.
+- Cada snapshot genera un subdirectorio dentro de `--output` con todos los CSV, el ZIP `analysis.zip` y, si corresponde, el Excel `analysis.xlsx`.
 - Se adjunta además `summary.csv` en la raíz con los KPIs crudos (`raw_value`) de cada snapshot para facilitar comparaciones rápidas o integraciones en pipelines.
 
 > Dependencias: asegurate de instalar `kaleido` y `XlsxWriter` (ambos incluidos en `requirements.txt`) para que el script pueda renderizar los gráficos y escribir el Excel correctamente.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -82,10 +82,11 @@ Para reproducir la telemetría manualmente:
    bloque **Snapshots y almacenamiento** aumenta `snapshot_hits` en la segunda corrida.
 2. Exporta el análisis enriquecido desde la línea de comandos para validar la paridad con la UI:
    ```bash
-   python scripts/export_analysis.py --format both --output exports/manual_check.csv
+   python scripts/export_analysis.py --format both --output exports/manual_check
    ```
-   Revisa `exports/manual_check.json` y confirma que el bloque `summary.snapshot_hits` coincida con
-   el valor mostrado en el health sidebar.
+   Verifica que `exports/manual_check/summary.csv` incluya la fila del snapshot con el valor correcto
+   de `snapshot_hits` y que cada subdirectorio contenga los CSV, el ZIP (`analysis.zip`) y el Excel con
+   los mismos datos visibles en la UI.
 
 ## Pruebas con APIs en vivo
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -146,13 +146,13 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
   - **Síntomas:** El script termina con `FileNotFoundError` o `PermissionError` al escribir en `exports/`.
   - **Diagnóstico rápido:** Comprueba que la ruta indicada en `--output` exista y que el usuario tenga permisos de escritura. Ejecuta:
     ```bash
-    python scripts/export_analysis.py --output /tmp/probe.csv --format csv
+    python scripts/export_analysis.py --output /tmp/probe --format csv
     ```
     para descartar un problema con rutas relativas.
   - **Resolución:**
     1. Crea el directorio de destino (`mkdir -p exports`) o usa una ruta absoluta accesible.
     2. Verifica que `pandas` esté instalado en el entorno (`pip install -r requirements.txt`).
-    3. Si necesitas incorporar indicadores técnicos en la exportación, añade `--include-technicals`; si falta alguna columna en el resultado, confirma que `run_screener_stub` siga intacto y que no se hayan modificado los nombres esperados.
+    3. Revisa que `analysis.zip` y los CSV (`kpis.csv`, `positions.csv`, etc.) se generen dentro del subdirectorio del snapshot; si falta alguna columna en el resultado, confirma que `run_screener_stub` siga intacto y que no se hayan modificado los nombres esperados.
 
 - **Los tests con Yahoo (`pytest -m live_yahoo`) fallan por rate limiting.**
   - **Síntomas:** `pytest` reporta `HTTPError` o `Timeout` al consultar Yahoo Finance.

--- a/scripts/export_analysis.py
+++ b/scripts/export_analysis.py
@@ -20,6 +20,7 @@ from shared.portfolio_export import (
     METRIC_SPECS,
     PortfolioSnapshotExport,
     compute_kpis,
+    create_csv_bundle,
     create_excel_workbook,
     write_tables_to_directory,
 )
@@ -66,6 +67,7 @@ def _parse_args(argv: Iterable[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--formats",
+        "--format",
         choices=["csv", "excel", "both"],
         default="both",
         help="Formartos a generar (default: both).",
@@ -178,6 +180,14 @@ def main(argv: Iterable[str] | None = None) -> int:
                 include_history=include_history,
                 limit=limit,
             )
+            zip_bytes = create_csv_bundle(
+                snapshot,
+                metric_keys=metric_keys,
+                include_rankings=include_rankings,
+                include_history=include_history,
+                limit=limit,
+            )
+            (target_dir / "analysis.zip").write_bytes(zip_bytes)
         if excel_enabled:
             excel_bytes = create_excel_workbook(
                 snapshot,

--- a/tests/scripts/test_export_analysis.py
+++ b/tests/scripts/test_export_analysis.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import json
+import zipfile
+import xml.etree.ElementTree as ET
 from importlib import util
 from pathlib import Path
 import sys
 
 import pandas as pd
+import pytest
 
 MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "export_analysis.py"
 SPEC = util.spec_from_file_location("export_analysis", MODULE_PATH)
@@ -70,7 +73,7 @@ def _write_sample_snapshot(directory: Path) -> Path:
     return path
 
 
-def test_main_generates_csv_exports(tmp_path: Path) -> None:
+def test_main_generates_csv_and_zip_exports(tmp_path: Path) -> None:
     snapshots_dir = tmp_path / "snapshots"
     _write_sample_snapshot(snapshots_dir)
 
@@ -95,9 +98,62 @@ def test_main_generates_csv_exports(tmp_path: Path) -> None:
     generated_files = {path.name for path in snapshot_output.glob("*.csv")}
     assert {"kpis.csv", "positions.csv"}.issubset(generated_files)
 
+    kpis_df = pd.read_csv(snapshot_output / "kpis.csv")
+    assert "snapshot" in kpis_df.columns
+    assert kpis_df.loc[0, "snapshot"] == "sample"
+
+    zip_path = snapshot_output / "analysis.zip"
+    assert zip_path.exists()
+
+    with zipfile.ZipFile(zip_path) as zf:
+        zip_contents = set(zf.namelist())
+    assert "kpis.csv" in zip_contents
+    assert "positions.csv" in zip_contents
+
     summary_path = output_dir / "summary.csv"
     assert summary_path.exists()
 
     summary_df = pd.read_csv(summary_path)
     assert "snapshot" in summary_df.columns
     assert summary_df.loc[0, "snapshot"] == "sample"
+    assert "total_value" in summary_df.columns
+
+
+def test_main_generates_excel_with_charts(tmp_path: Path) -> None:
+    snapshot_path = _write_sample_snapshot(tmp_path / "snapshots")
+
+    output_dir = tmp_path / "exports"
+    if not export_analysis.CHART_SPECS:
+        pytest.skip("No hay gráficos configurados para la exportación")
+    chart_key = export_analysis.CHART_SPECS[0].key
+
+    exit_code = export_analysis.main(
+        [
+            "--input",
+            str(snapshot_path),
+            "--output",
+            str(output_dir),
+            "--format",
+            "excel",
+            "--charts",
+            chart_key,
+        ]
+    )
+
+    assert exit_code == 0
+
+    summary_path = output_dir / "summary.csv"
+    assert summary_path.exists()
+
+    excel_path = output_dir / "sample" / "analysis.xlsx"
+    assert excel_path.exists()
+
+    with zipfile.ZipFile(excel_path) as zf:
+        workbook_xml = ET.fromstring(zf.read("xl/workbook.xml"))
+    ns = {"main": "http://schemas.openxmlformats.org/spreadsheetml/2006/main"}
+    sheets_parent = workbook_xml.find("main:sheets", ns)
+    assert sheets_parent is not None
+    sheet_names = [sheet.attrib.get("name") for sheet in sheets_parent.findall("main:sheet", ns)]
+    assert "KPIs" in sheet_names
+    assert "Posiciones" in sheet_names
+    assert "Gráficos" in sheet_names


### PR DESCRIPTION
## Summary
- allow the export_analysis CLI to accept the --format alias and emit ZIP bundles alongside CSV tables
- document the generated CSV, ZIP and Excel artifacts across the README and docs
- extend the export script tests to cover ZIP content, Excel generation and chart selection

## Testing
- pytest tests/scripts/test_export_analysis.py

------
https://chatgpt.com/codex/tasks/task_e_68e11d705fb88332b1791eee7632a351