### PR TITLE
Bump release to 0.3.29 and refresh documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+## [0.3.29] - 2025-11-20
+
+### Changed
+- Sincronización del versionado 0.3.29 entre `pyproject.toml`, `shared.version` y las superficies
+  visibles para mantener la trazabilidad durante el hardening de CI.
+
+### Documentation
+- README, guías de pruebas y troubleshooting alineados con la numeración 0.3.29 y con ejemplos de
+  exportación actualizados (`--input`, `--formats`, directorios de salida) que reflejan el
+  comportamiento real de `scripts/export_analysis.py`.
+
+### Tests
+- Recordatorios de ejecución en CI y validaciones manuales actualizados para utilizar la versión
+  0.3.29 al verificar banners y reportes exportados.
+
 ## [0.3.28.1] - 2025-11-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,24 +6,26 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.28.1)
+## Quick-start (release 0.3.29)
 
-La versión **0.3.28.1** es una release de hardening y CI que refuerza los pipelines automáticos y
-las verificaciones de integridad, manteniendo las mejoras funcionales introducidas en la rama
-0.3.28. Consolida la persistencia de snapshots del portafolio, habilita exportaciones enriquecidas
+La versión **0.3.29** es una release de hardening y CI que refuerza los pipelines automáticos y
+las verificaciones de integridad, manteniendo las mejoras funcionales introducidas en la serie
+0.3.28 y extendiéndolas en la nueva iteración. Consolida la persistencia de snapshots del portafolio,
+habilita exportaciones enriquecidas
 listas para compartir y extiende la observabilidad de la plataforma con métricas de almacenamiento y
 telemetría unificadas.
 
-## Quick-start (release 0.3.28.1 — hardening/CI — 2025-11-15)
+## Quick-start (release 0.3.29 — hardening/CI — 2025-11-20)
 
-La versión **0.3.28.1** destaca tres ejes principales:
+La versión **0.3.29** destaca tres ejes principales:
 - El **almacenamiento de snapshots** conserva los resultados del screening y del portafolio entre
   sesiones. Los controles persistentes del sidebar (`st.session_state["controls_snapshot"]`) y el
   servicio `PortfolioViewSnapshot` permiten reanudar análisis sin repetir descargas ni recomputar
   agregados.
 - Las **exportaciones enriquecidas** consolidan la tabla visible, los KPIs y las notas de telemetría
-  en un mismo paquete. El nuevo script `scripts/export_analysis.py` genera CSV/JSON con los mismos
-  datos mostrados en la UI y añade el resumen agregado (`df.attrs["summary"]`).
+  en un mismo paquete. El nuevo script `scripts/export_analysis.py` genera tablas CSV y, opcionalmente,
+  un workbook de Excel con los mismos datos mostrados en la UI y añade el resumen agregado
+  (`df.attrs["summary"]`).
 - La **observabilidad extendida** agrega métricas de almacenamiento y persistencia al health sidebar.
   Los contadores de resiliencia ahora muestran los hits de snapshots, los reintentos fallidos y la
   procedencia del último dato consolidado (primario, secundario o snapshot de contingencia).
@@ -43,7 +45,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.28.1` junto con
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.29` junto con
    el timestamp generado por `TimeProvider`. Abre el panel **Salud del sistema**: además del estado de
    cada proveedor verás el bloque **Snapshots y almacenamiento**, que expone la ruta activa del disco,
    el contador de recuperaciones desde snapshot y la latencia agregada de escritura.
@@ -58,16 +60,16 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
      del almacenamiento persistente como parte de la secuencia.
 4. **Exporta el análisis enriquecido.** Con la app cerrada o en paralelo, ejecuta el script:
    ```bash
-   python scripts/export_analysis.py --format both --output exports/screener.csv
+   python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports
    ```
-   El comando genera `exports/screener.csv` con la grilla del screening y `exports/screener.json` con
-   notas, métricas agregadas y distribución sectorial. Abre el JSON para confirmar que el bloque
-   `summary` replica los KPI mostrados en la UI.
+   El comando crea un subdirectorio por snapshot dentro de `exports/` con la grilla del screening y
+   los KPIs en CSV, además del Excel enriquecido (`analysis.xlsx`) si seleccionás `--formats both`.
+   Abre `exports/<snapshot>/kpis.csv` para validar que los KPI coincidan con los mostrados en la UI.
 
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.28.1 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
+   release 0.3.29 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
    reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
    `primario → secundario → snapshot` (o fallback estático si corresponde) con la marca temporal de cada
@@ -94,7 +96,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-**Resiliencia de APIs (0.3.28.1).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.29).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening y la procedencia (`primario`, `secundario`, `snapshot`). Al
 relanzarlo, la telemetría agrega la procedencia del dato y clasifica la recuperación según la estrategia
 aplicada:
@@ -108,7 +110,7 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos.
 
-Estas novedades convierten a la release 0.3.28.1 en la referencia para validar onboarding, telemetría y
+Estas novedades convierten a la release 0.3.29 en la referencia para validar onboarding, telemetría y
 resiliencia multi-API: toda la UI recuerda la versión activa, expone KPIs agregados de disponibilidad y
 almacenamiento en el health sidebar y las exportaciones enriquecidas aseguran paridad total entre la
 visión en pantalla y los artefactos compartidos.
@@ -116,7 +118,7 @@ visión en pantalla y los artefactos compartidos.
 
 ## Configuración de claves API
 
-La release 0.3.28.1 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
+La release 0.3.29 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
 
@@ -221,7 +223,7 @@ La aplicación permite llevarte un paquete completo de métricas, rankings y vis
 2. Seleccioná las métricas que querés incluir en el reporte (valor total, P/L, cantidad de posiciones, etc.). Cada opción muestra una breve descripción para que identifiques rápidamente qué KPI estás incorporando.
 3. Elegí los gráficos que se van a embeber en el Excel (por defecto se incluyen P/L Top N, composición por tipo, distribución valorizada, la evolución histórica y el mapa de calor por símbolo/tipo). Si Kaleido no está disponible la UI te lo indicará para que habilites la dependencia.
 4. Activá o desactivá la exportación de rankings e historial y definí el límite de filas para cada ranking.
-5. Descargá el ZIP con los CSV (`kpis.csv`, `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.) o el Excel enriquecido (`*_analisis.xlsx`) que incluye todas las tablas en hojas dedicadas y los gráficos renderizados como imágenes.
+5. Descargá el ZIP con los CSV (`kpis.csv`, `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.) o el Excel enriquecido (`analysis.xlsx`) que incluye todas las tablas en hojas dedicadas y los gráficos renderizados como imágenes.
 
 ### Desde la línea de comandos
 
@@ -271,7 +273,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.28.1)
+##### Escenarios de fallback macro (0.3.29)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -420,11 +422,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.28.1".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.29".
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.28.1)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.29)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -66,7 +66,7 @@ frecuentes:
 
 ### Validación de snapshots y almacenamiento persistente
 
-La release 0.3.28.1, orientada a hardening/CI, introduce contadores de snapshots y telemetría de
+La release 0.3.29, orientada a hardening/CI, introduce contadores de snapshots y telemetría de
 almacenamiento. Para cubrirlos en QA combina pruebas automáticas y verificaciones manuales:
 
 - `pytest tests/test_sidebar_controls.py -k snapshot`: comprueba que los presets persistan en
@@ -82,10 +82,11 @@ Para reproducir la telemetría manualmente:
    bloque **Snapshots y almacenamiento** aumenta `snapshot_hits` en la segunda corrida.
 2. Exporta el análisis enriquecido desde la línea de comandos para validar la paridad con la UI:
    ```bash
-   python scripts/export_analysis.py --format both --output exports/manual_check.csv
+   python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/manual_checks
    ```
-   Revisa `exports/manual_check.json` y confirma que el bloque `summary.snapshot_hits` coincida con
-   el valor mostrado en el health sidebar.
+   Revisa `exports/manual_checks/<snapshot>/kpis.csv` y confirma que la columna `generated_at`
+   coincida con el valor mostrado en el health sidebar. El archivo `exports/manual_checks/summary.csv`
+   resume los KPI crudos (`raw_value`) para comparar rápidamente contra la UI.
 
 ## Pruebas con APIs en vivo
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,9 +4,9 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Claves API
 
-> Nota: Esta guía corresponde a la release 0.3.28.1, enfocada en hardening/CI para reforzar los
+> Nota: Esta guía corresponde a la release 0.3.29, enfocada en hardening/CI para reforzar los
 > pipelines automáticos y las verificaciones de integridad sin alterar los flujos funcionales
-> documentados en la serie 0.3.28.
+> documentados en la serie 0.3.29.
 
 - **Falta una clave y los servicios quedan en `disabled`.**
   - **Síntomas:** El health sidebar indica `disabled` para Alpha Vantage/Polygon/FMP/FRED/World Bank y el log muestra `Missing API key`.
@@ -41,7 +41,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **El timeline de resiliencia no persiste tras un rerun.**
   - **Síntomas:** Luego de presionar **⟳ Refrescar**, el bloque **Resiliencia de proveedores** se vacía.
-  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.28.1 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
+  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.29 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
   - **Resolución:**
     1. Actualiza el repositorio y reinstala dependencias si trabajas con un build antiguo.
     2. Comprueba que el stub de tests (`tests/conftest.py`) conserve los datos de sesión entre llamadas; limpia `st.session_state` solo al finalizar las aserciones.
@@ -64,7 +64,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
   - **Resolución:**
     1. Crea manualmente el directorio (`mkdir -p ~/.portafolio_iol/snapshots`) y asigna permisos de escritura al usuario que ejecuta Streamlit.
     2. Asegura que ningún job de CI limpie el directorio entre corridas si necesitas comparar métricas persistentes; monta un volumen dedicado al ejecutar contenedores.
-    3. Reinicia la app y lanza dos screenings con los mismos filtros. El contador `snapshot_hits` debería incrementarse en la segunda corrida y `scripts/export_analysis.py` reflejará el valor en `summary.snapshot_hits`.
+    3. Reinicia la app y lanza dos screenings con los mismos filtros. El contador `snapshot_hits` debería incrementarse en la segunda corrida y, al exportar con `scripts/export_analysis.py`, el archivo `kpis.csv` mostrará los KPI actualizados con la marca temporal correspondiente.
 
 - **La jerarquía de fallback no coincide con las notas del screening.**
   - **Síntomas:** El health sidebar marca como último éxito un proveedor distinto del mostrado en las notas (`Datos macro (World Bank)` etc.).
@@ -129,7 +129,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.
-  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.28.1` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.29` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
   - **Resolución:**
     1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
     2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.
@@ -146,13 +146,13 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
   - **Síntomas:** El script termina con `FileNotFoundError` o `PermissionError` al escribir en `exports/`.
   - **Diagnóstico rápido:** Comprueba que la ruta indicada en `--output` exista y que el usuario tenga permisos de escritura. Ejecuta:
     ```bash
-    python scripts/export_analysis.py --output /tmp/probe.csv --format csv
+    python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats csv --output /tmp/exports_probe
     ```
     para descartar un problema con rutas relativas.
   - **Resolución:**
     1. Crea el directorio de destino (`mkdir -p exports`) o usa una ruta absoluta accesible.
     2. Verifica que `pandas` esté instalado en el entorno (`pip install -r requirements.txt`).
-    3. Si necesitas incorporar indicadores técnicos en la exportación, añade `--include-technicals`; si falta alguna columna en el resultado, confirma que `run_screener_stub` siga intacto y que no se hayan modificado los nombres esperados.
+    3. Si necesitas ampliar el contenido, utiliza `--metrics help` o `--charts help` para revisar las claves disponibles y vuelve a ejecutar el comando con las opciones deseadas.
 
 - **Los tests con Yahoo (`pytest -m live_yahoo`) fallan por rate limiting.**
   - **Síntomas:** `pytest` reporta `HTTPError` o `Timeout` al consultar Yahoo Finance.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "portafolio-iol"
-version = "0.3.28.1"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.29"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 
 [tool.pytest.ini_options]
 markers = [

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.28.1"
+DEFAULT_VERSION: str = "0.3.29"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project metadata to version 0.3.29 to keep shared.version and pyproject aligned
- refresh README, testing, and troubleshooting guides to reference release 0.3.29 and document the corrected export commands
- record the 0.3.29 hardening notes in the changelog with emphasis on CI/documentation updates

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e11d885fac8332985b45f934ba5b8e