### PR TITLE
Fix PNG export regression and document Kaleido fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,12 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    directorio también encontrarás `summary.csv` con los KPIs (`raw_value`) de cada snapshot para
    facilitar comparaciones rápidas.
 
+   > **Dependencia de Kaleido.** Plotly utiliza `kaleido` para renderizar los gráficos como PNG.
+   > Instálalo con `pip install -r requirements.txt` (incluye la dependencia) o añádelo a tu entorno
+   > manualmente si usas una instalación mínima. Cuando `kaleido` no está disponible, la aplicación y
+   > los scripts continúan ofreciendo el ZIP de CSV y muestran una advertencia que indica cómo activar
+   > la exportación a Excel con imágenes.
+
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -171,6 +171,13 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
     para descartar un problema con rutas relativas. Verifica que se generen los CSV, el ZIP `analysis.zip`
     (cuando `--formats` incluya `csv`), el archivo `analysis.xlsx` y el resumen `summary.csv` dentro del
     subdirectorio del snapshot o en la raíz del directorio de exportaciones según corresponda.
+- **Kaleido ausente y sin PNG en las exportaciones.**
+  - **Síntomas:** `pytest` marca `kaleido no disponible` o la UI muestra una advertencia al generar el Excel.
+  - **Diagnóstico rápido:** Ejecuta `python -c "import kaleido"`; si falla, instala la dependencia incluida en `requirements.txt`.
+  - **Resolución:**
+    1. Instala Kaleido en el entorno activo (`pip install -r requirements.txt` o `pip install kaleido`).
+    2. Repite la exportación: el Excel incorporará los PNG y las suites de tests dejarán de saltar o advertir.
+    3. Si prefieres continuar sin la librería (por ejemplo, en CI minimalista), el flujo seguirá generando el ZIP de CSV y mostrará la advertencia para informar del fallback.
 - **Los snapshots persisten entre jobs en CI.**
   - **Síntomas:** Un job reutiliza datos de un pipeline anterior y la telemetría marca `snapshot_hits` altos aunque se espera un entorno limpio.
   - **Diagnóstico rápido:** Revisa si las variables `SNAPSHOT_BACKEND` y `SNAPSHOT_STORAGE_PATH` están configuradas en el pipeline.

--- a/shared/export.py
+++ b/shared/export.py
@@ -23,8 +23,8 @@ def _get_kaleido_scope():
 def fig_to_png_bytes(fig: go.Figure) -> bytes:
     """Devuelve la figura renderizada como bytes PNG usando kaleido."""
     try:
-        scope = _get_kaleido_scope()
-        return pio.to_image(fig, format="png", scope=scope)
+        _get_kaleido_scope()
+        return pio.to_image(fig, format="png")
     except (ValueError, RuntimeError, TypeError) as e:  # pragma: no cover - depende de librerías externas
         logger.exception("kaleido no disponible")
         raise ValueError("kaleido no disponible") from e

--- a/tests/shared/test_portfolio_export.py
+++ b/tests/shared/test_portfolio_export.py
@@ -1,0 +1,60 @@
+"""Tests for shared export helpers."""
+from __future__ import annotations
+
+import base64
+from pathlib import Path
+import sys
+
+import plotly.graph_objects as go
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from shared.export import fig_to_png_bytes
+
+
+_DUMMY_PNG = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+)
+
+
+def test_fig_to_png_bytes_uses_plotly_without_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    fig = go.Figure()
+    called: dict[str, object] = {}
+
+    def fake_get_scope() -> object:
+        called["scope_checked"] = True
+        return object()
+
+    def fake_to_image(fig_arg: go.Figure, *, format: str = "png", **kwargs) -> bytes:
+        called["fig"] = fig_arg
+        called["kwargs"] = kwargs
+        assert format == "png"
+        if "scope" in kwargs:
+            raise TypeError("scope argument is not supported")
+        return _DUMMY_PNG
+
+    monkeypatch.setattr("shared.export._get_kaleido_scope", fake_get_scope)
+    monkeypatch.setattr("shared.export.pio.to_image", fake_to_image)
+
+    result = fig_to_png_bytes(fig)
+
+    assert result == _DUMMY_PNG
+    assert called["fig"] is fig
+    assert called.get("scope_checked") is True
+    assert "scope" not in called.get("kwargs", {})
+
+
+def test_fig_to_png_bytes_raises_value_error_on_engine_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    fig = go.Figure()
+
+    def fake_to_image(*_args, **_kwargs) -> bytes:
+        raise RuntimeError("engine missing")
+
+    monkeypatch.setattr("shared.export._get_kaleido_scope", lambda: None)
+    monkeypatch.setattr("shared.export.pio.to_image", fake_to_image)
+
+    with pytest.raises(ValueError):
+        fig_to_png_bytes(fig)

--- a/tests/ui/test_portfolio_ui.py
+++ b/tests/ui/test_portfolio_ui.py
@@ -1093,7 +1093,14 @@ def test_render_portfolio_exports_generates_full_package(
     png_bytes = base64.b64decode(
         b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
     )
-    monkeypatch.setattr("shared.portfolio_export.fig_to_png_bytes", lambda fig: png_bytes)
+
+    def fake_to_image(fig, *, format="png", **kwargs):
+        assert format == "png"
+        assert "scope" not in kwargs
+        return png_bytes
+
+    monkeypatch.setattr("shared.export._get_kaleido_scope", lambda: object())
+    monkeypatch.setattr("shared.export.pio.to_image", fake_to_image)
 
     export_mod.render_portfolio_exports(
         snapshot=sample_export_snapshot["snapshot"],


### PR DESCRIPTION
## Summary
- remove the deprecated Kaleido scope parameter when exporting PNG images
- add shared and UI regression tests that validate PNG generation without the scope argument
- document the Kaleido dependency and the CSV-only fallback in the README and troubleshooting guide

## Testing
- pytest tests/shared/test_portfolio_export.py tests/ui/test_portfolio_ui.py -k export

------
https://chatgpt.com/codex/tasks/task_e_68e13c9482d88332b183fab04a385550