### PR TITLE
Adopt pyproject as canonical dependency source

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    pip install -r requirements.txt
    ```
    Para entornos de desarrollo agrega `requirements-dev.txt` si necesitas las herramientas de QA.
+   > Las dependencias declaradas viven en `[project.dependencies]` de `pyproject.toml`. Ejecuta `python scripts/sync_requirements.py` cada vez que modifiques esa sección para regenerar `requirements.txt` con las versiones fijadas que usa CI y producción.
 2. **Levanta la aplicación y valida los banners persistentes.** Con el entorno activado ejecuta:
    ```bash
    streamlit run app.py
@@ -512,6 +513,8 @@ El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.29.2)** que lis
 pip install -r requirements.txt
 ```
 
+> El archivo `requirements.txt` se genera con `python scripts/sync_requirements.py` a partir de `[project.dependencies]` en `pyproject.toml`. Cualquier ajuste debe aplicarse en ese archivo y luego sincronizarse para mantener la lista plana que consumen los despliegues.
+
 Para un entorno de desarrollo con herramientas de linting y pruebas:
 
 ```bash
@@ -756,15 +759,23 @@ PY
 
 ## Actualización de dependencias
 
-Las versiones de las dependencias están fijadas en `requirements.txt`. Para actualizarlas de forma segura:
+`pyproject.toml` es ahora la fuente de verdad para las dependencias de producción: todas las versiones quedan fijadas en `[project.dependencies]`. El archivo `requirements.txt` se regenera automáticamente a partir de esa sección para mantener la compatibilidad con los entornos de despliegue y los jobs de CI que consumen listas de paquetes planas.
+
+### Flujo recomendado
 
 ```bash
 bash scripts/update_dependencies.sh
 ```
 
-El script actualiza los paquetes a sus últimas versiones, ejecuta las pruebas y, si todo pasa, escribe las nuevas versiones en `requirements.txt`. Este proceso también se ejecuta mensualmente mediante [GitHub Actions](.github/workflows/dependency-update.yml).
+El script actualiza los paquetes a sus últimas versiones disponibles, ejecuta la suite de pruebas, sincroniza los pines en `pyproject.toml` y finalmente recrea `requirements.txt` con `python scripts/sync_requirements.py`. Este proceso también se ejecuta mensualmente mediante [GitHub Actions](.github/workflows/dependency-update.yml).
 
-La guía interna que detalla cómo recrear los assets del dashboard se apoya en el script generador correspondiente; a partir de ahora `matplotlib` queda instalada automáticamente al ejecutar `pip install -r requirements.txt`, por lo que no hace falta agregarla manualmente antes de correr ese flujo.
+### Ajustes manuales
+
+1. Edita `[project.dependencies]` en `pyproject.toml` y guarda los cambios.
+2. Regenera la lista plana para CI: `python scripts/sync_requirements.py`.
+3. Reinstala las dependencias en tu entorno virtual (`pip install -r requirements.txt`) y ejecuta las suites necesarias.
+
+La guía interna que detalla cómo recrear los assets del dashboard se apoya en el script generador correspondiente; `matplotlib` y `kaleido` se incluyen automáticamente al instalar `requirements.txt`, por lo que no hace falta agregarlos manualmente antes de correr ese flujo.
 
 ## Políticas de sesión y manejo de tokens
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -10,6 +10,7 @@ proyecto, incluyendo las verificaciones opcionales que dependen de servicios ext
   ```bash
   pip install -r requirements.txt -r requirements-dev.txt
   ```
+  > `requirements.txt` se sincroniza desde `[project.dependencies]` de `pyproject.toml` con `python scripts/sync_requirements.py`. Asegurate de correrlo si cambiaste las versiones fijadas antes de reinstalar dependencias.
 - No es necesario instalar Streamlit para ejecutar la suite. Los tests incorporan un stub local
   que reemplaza al módulo y provee las APIs utilizadas por la UI.
 - Variables de entorno opcionales para pruebas específicas:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -146,6 +146,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
        pip install -r requirements.txt -r requirements-dev.txt
        streamlit run app.py
        ```
+       > Si modificaste las dependencias en `pyproject.toml`, sincroniza la lista plana con `python scripts/sync_requirements.py` antes de reinstalar.
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,26 @@
+[build-system]
+requires = ["setuptools>=69", "wheel"]
+build-backend = "setuptools.build_meta"
+
 [project]
 name = "portafolio-iol"
 version = "0.3.29.2"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+dependencies = [
+    "streamlit==1.49.1",
+    "pandas==2.3.2",
+    "numpy==2.3.3",
+    "requests==2.31.0",
+    "python-dotenv==1.1.1",
+    "iolConn==0.4.2",
+    "plotly==6.3.0",
+    "matplotlib==3.10.6",
+    "kaleido==1.1.0",
+    "XlsxWriter==3.2.0",
+    "tomli==2.0.1",
+    "cryptography==41.0.3",
+    "yfinance==0.2.65",
+    "ta==0.11.0",
+]
 
 [tool.pytest.ini_options]
 markers = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
+# This file is auto-generated from pyproject.toml.
+# Run `python scripts/sync_requirements.py` after editing [project.dependencies].
 streamlit==1.49.1
 pandas==2.3.2
 numpy==2.3.3
 requests==2.31.0
-#urllib3==2.2.2
 python-dotenv==1.1.1
 iolConn==0.4.2
 plotly==6.3.0
@@ -10,8 +11,6 @@ matplotlib==3.10.6
 kaleido==1.1.0
 XlsxWriter==3.2.0
 tomli==2.0.1
-# Utilidades varias
 cryptography==41.0.3
-# Dependencias obligatorias para datos e indicadores técnicos
 yfinance==0.2.65
 ta==0.11.0

--- a/scripts/sync_requirements.py
+++ b/scripts/sync_requirements.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Synchronize requirements.txt with pyproject.toml dependencies."""
+
+from __future__ import annotations
+
+import pathlib
+import sys
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for <=3.10
+    import tomli as tomllib  # type: ignore
+
+
+HEADER = """# This file is auto-generated from pyproject.toml.
+# Run `python scripts/sync_requirements.py` after editing [project.dependencies]."""
+
+
+def main() -> int:
+    repo_root = pathlib.Path(__file__).resolve().parents[1]
+    pyproject_path = repo_root / "pyproject.toml"
+    requirements_path = repo_root / "requirements.txt"
+
+    with pyproject_path.open("rb") as stream:
+        data = tomllib.load(stream)
+
+    dependencies = data.get("project", {}).get("dependencies", [])
+    if not dependencies:
+        print("No dependencies found in pyproject.toml", file=sys.stderr)
+        return 1
+
+    content_lines = [HEADER, *dependencies]
+    requirements_path.write_text("\n".join(content_lines) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 # Navigate to repository root
 cd "$(dirname "$0")/.."
 
-# Packages managed in requirements.txt
+# Packages managed from pyproject.toml
 PACKAGES=(
   streamlit
   pandas
@@ -15,6 +15,8 @@ PACKAGES=(
   plotly
   matplotlib
   kaleido
+  XlsxWriter
+  tomli
   cryptography
   yfinance
   ta
@@ -26,5 +28,38 @@ python -m pip install --upgrade "${PACKAGES[@]}"
 # Run test suite to ensure updates don't break the project
 pytest
 
-# Freeze the exact versions back into requirements.txt
-python -m pip freeze | grep -i -E '^(streamlit|pandas|numpy|requests|python-dotenv|iolConn|plotly|matplotlib|kaleido|cryptography|yfinance|ta)==' > requirements.txt
+# Update pinned versions in pyproject.toml based on the installed packages
+python - <<'PY'
+import importlib.metadata as metadata
+import pathlib
+import re
+import tomllib
+
+root = pathlib.Path(__file__).resolve().parents[1]
+pyproject_path = root / "pyproject.toml"
+data = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+
+dependencies = data.get("project", {}).get("dependencies", [])
+if not dependencies:
+    raise SystemExit("No dependencies found in pyproject.toml")
+
+updated_lines = []
+for entry in dependencies:
+    package, _, _ = entry.partition("==")
+    if not package:
+        raise SystemExit(f"Invalid dependency entry: {entry}")
+    version = metadata.version(package)
+    updated_lines.append(f'    "{package}=={version}",')
+
+new_block = "dependencies = [\n" + "\n".join(updated_lines) + "\n]"
+
+pattern = re.compile(r"dependencies = \[(?:\n.*?)*?\n\]", re.DOTALL)
+original_text = pyproject_path.read_text(encoding="utf-8")
+if not pattern.search(original_text):
+    raise SystemExit("Could not locate dependencies block in pyproject.toml")
+
+pyproject_path.write_text(pattern.sub(new_block, original_text, count=1), encoding="utf-8")
+PY
+
+# Regenerate requirements.txt from pyproject.toml
+python scripts/sync_requirements.py


### PR DESCRIPTION
## Summary
- declare the production dependencies in `[project.dependencies]` inside `pyproject.toml`
- add a sync script and update the dependency maintenance helper to regenerate `requirements.txt`
- document the pip-based workflow across the README and troubleshooting guides

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e13c94cb9c833291424a3579d0c1fd