### PR TITLE
Add native IOL client and retire legacy adapter

### DIFF
--- a/application/test/test_portfolio_fallback.py
+++ b/application/test/test_portfolio_fallback.py
@@ -1,37 +1,33 @@
 import json
-
-import json
 import requests
+
 from infrastructure.iol import client as iol_client
 
 
-class _FailClient:
-    def get_portfolio(self):
-        raise requests.RequestException("boom")
+class DummyAuth:
+    def __init__(self) -> None:
+        self.tokens = {"access_token": "tok", "refresh_token": "ref"}
 
-
-class _OkClient:
-    def __init__(self, data):
-        self._data = data
-
-    def get_portfolio(self):
-        return self._data
+    def auth_header(self) -> dict:  # pragma: no cover - unused
+        return {"Authorization": "Bearer tok"}
 
 
 def test_portfolio_fallback(monkeypatch, tmp_path):
     cache_file = tmp_path / "cache.json"
     monkeypatch.setattr(iol_client, "PORTFOLIO_CACHE", cache_file)
+    monkeypatch.setattr(iol_client.IOLClient, "_ensure_market_auth", lambda self: None, raising=False)
 
-    # Éxito inicial guarda cache
-    adapter = iol_client.IOLClientAdapter.__new__(iol_client.IOLClientAdapter)
-    adapter._cli = _OkClient({"activos": [1]})
-    assert adapter.get_portfolio() == {"activos": [1]}
+    client = iol_client.IOLClient("user", "pass", auth=DummyAuth())
+
+    monkeypatch.setattr(client, "_fetch_portfolio_live", lambda: {"activos": [1]}, raising=False)
+    assert client.get_portfolio() == {"activos": [1]}
     assert json.loads(cache_file.read_text()) == {"activos": [1]}
 
-    # Falla posterior usa cache
-    adapter._cli = _FailClient()
-    assert adapter.get_portfolio() == {"activos": [1]}
+    def fail():
+        raise requests.RequestException("boom")
 
-    # Sin cache devuelve estructura vacía
+    monkeypatch.setattr(client, "_fetch_portfolio_live", fail, raising=False)
+    assert client.get_portfolio() == {"activos": [1]}
+
     cache_file.unlink()
-    assert adapter.get_portfolio() == {"activos": []}
+    assert client.get_portfolio() == {"activos": []}

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -44,9 +44,9 @@ usa los stubs deterministas para mantener resultados reproducibles.
    confirma que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
    adjuntos. Si falta alguno, la ejecución debe considerarse fallida.
 
-### Suites legacy
+### Suites legacy (deprecated)
 
-La carpeta `tests/legacy/` contiene casos heredados que duplican escenarios ya cubiertos en la suite principal. Se excluye de la recolección estándar para mantener los tiempos de CI. Si necesitas auditarlos manualmente, ejecútalos de forma explícita:
+El paquete `infrastructure.iol.legacy` permanece disponible únicamente para mantener compatibilidad con integraciones antiguas; su importación ahora emite una advertencia de deprecación y no participa del flujo principal. La carpeta `tests/legacy/` conserva los escenarios originales para auditorías puntuales y continúa excluida de la recolección estándar para preservar los tiempos de CI. Si necesitás ejecutarlos manualmente, hacelo de forma explícita:
 
 ```bash
 pytest tests/legacy

--- a/infrastructure/iol/client.py
+++ b/infrastructure/iol/client.py
@@ -1,75 +1,351 @@
-# infrastructure\iol\client.py
+# infrastructure/iol/client.py
 from __future__ import annotations
+
 import json
 import logging
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
-import requests
+from typing import Any, Dict, Iterable, Optional, Tuple
 
-from .ports import IIOLProvider
+import requests
+import streamlit as st
+from iolConn import Iol
+from iolConn.common.exceptions import NoAuthException
+
+from shared.config import settings
+from shared.errors import InvalidCredentialsError
+from shared.time_provider import TimeProvider
+from shared.utils import _to_float
+
 from .auth import IOLAuth
-from .legacy.iol_client import IOLClient as _LegacyIOLClient  # <- ahora desde legacy
+from .ports import IIOLProvider
 
 logger = logging.getLogger(__name__)
-PORTFOLIO_CACHE = Path(".cache/last_portfolio.json")
 
-class IOLClientAdapter(IIOLProvider):
+PORTFOLIO_CACHE = Path(".cache/last_portfolio.json")
+PORTFOLIO_URL = "https://api.invertironline.com/api/v2/portafolio"
+
+REQ_TIMEOUT = 30
+RETRIES = 1
+BACKOFF_SEC = 0.5
+USER_AGENT = "IOL-Portfolio/1.0 (+iol_client)"
+
+
+def _elapsed_ms(start_ts: float) -> int:
+    return int((time.time() - start_ts) * 1000)
+
+
+class IOLClient(IIOLProvider):
+    """Native IOL client implementing the IIOLProvider contract."""
+
     def __init__(
         self,
         user: str,
         password: str,
         tokens_file: Path | str | None = None,
         auth: IOLAuth | None = None,
-    ):
-        self._cli = _LegacyIOLClient(
-            user,
-            password,
-            tokens_file=tokens_file,
-            auth=auth,
-        )
+    ) -> None:
+        self.user = (user or "").strip()
+        self.password = (password or "").strip()
+        if auth is not None:
+            self.auth = auth
+        else:
+            self.auth = IOLAuth(
+                self.user,
+                self.password,
+                tokens_file=tokens_file,
+                allow_plain_tokens=settings.allow_plain_tokens,
+            )
 
-        safe_user = (user or "").strip()
-        if safe_user:
-            safe_user = f"{safe_user[:3]}***"
-        auth = getattr(self._cli, "auth", None)
-        tokens_path = str(getattr(auth, "tokens_file", tokens_file))
-        has_refresh = bool(getattr(auth, "refresh", None))
+        self.session = requests.Session()
+        self.session.headers.update({"User-Agent": USER_AGENT})
+
+        self.iol_market: Optional[Iol] = None
+        self._market_ready = False
+        self._market_lock = threading.RLock()
+        self._ensure_market_auth()
+
+        safe_user = f"{self.user[:3]}***" if self.user else ""
+        tokens_path = getattr(self.auth, "tokens_path", str(tokens_file))
+        has_refresh = bool(getattr(self.auth, "refresh", None))
         logger.info(
-            "IOLClientAdapter init",
+            "IOLClient init",
             extra={"user": safe_user, "tokens_file": tokens_path, "has_refresh": has_refresh},
         )
 
-
-    def get_portfolio(self) -> dict:
-        try:
-            data = self._cli.get_portfolio() or {}
+    # ------------------------------------------------------------------
+    # HTTP helpers
+    # ------------------------------------------------------------------
+    def _request(self, method: str, url: str, **kwargs) -> Optional[requests.Response]:
+        last_exc: Optional[Exception] = None
+        for attempt in range(RETRIES + 1):
+            headers = kwargs.pop("headers", {})
+            headers.update(self.auth.auth_header())
             try:
-                PORTFOLIO_CACHE.parent.mkdir(parents=True, exist_ok=True)
-                PORTFOLIO_CACHE.write_text(
-                    json.dumps(data, ensure_ascii=False, indent=2),
-                    encoding="utf-8",
+                response = self.session.request(
+                    method,
+                    url,
+                    headers=headers,
+                    timeout=REQ_TIMEOUT,
+                    **kwargs,
                 )
-            except OSError as e:
-                logger.warning("No se pudo guardar cache portafolio: %s", e, exc_info=True)
+                if response.status_code == 401:
+                    try:
+                        self.auth.refresh()
+                    except InvalidCredentialsError:
+                        raise
+                    headers = kwargs.pop("headers", {})
+                    headers.update(self.auth.auth_header())
+                    response = self.session.request(
+                        method,
+                        url,
+                        headers=headers,
+                        timeout=REQ_TIMEOUT,
+                        **kwargs,
+                    )
+                    if response.status_code == 401:
+                        raise InvalidCredentialsError("Credenciales inválidas")
+                response.raise_for_status()
+                return response
+            except requests.HTTPError as exc:
+                last_exc = exc
+                if exc.response is not None and exc.response.status_code == 404:
+                    logger.warning("%s %s devolvió 404", method, url)
+                    return None
+            except requests.RequestException as exc:
+                last_exc = exc
+
+            if attempt < RETRIES:
+                time.sleep(BACKOFF_SEC * (attempt + 1))
+
+        if last_exc:
+            logger.warning("Request %s %s falló: %s", method, url, last_exc)
+        return None
+
+    # ------------------------------------------------------------------
+    # Portfolio
+    # ------------------------------------------------------------------
+    def _fetch_portfolio_live(self) -> Dict[str, Any]:
+        start = time.time()
+        response = self._request("GET", PORTFOLIO_URL)
+        elapsed = _elapsed_ms(start)
+        logger.info("get_portfolio %s ms", elapsed)
+        if response is None:
+            raise requests.RequestException("Respuesta vacía del endpoint de portafolio")
+        try:
+            data = response.json() or {}
+        except ValueError as exc:
+            raise requests.RequestException("Respuesta inválida de portafolio") from exc
+        return data
+
+    def _write_portfolio_cache(self, data: Dict[str, Any]) -> None:
+        try:
+            PORTFOLIO_CACHE.parent.mkdir(parents=True, exist_ok=True)
+            PORTFOLIO_CACHE.write_text(
+                json.dumps(data, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except OSError as exc:  # pragma: no cover - warning path
+            logger.warning("No se pudo guardar cache portafolio: %s", exc, exc_info=True)
+
+    def _load_portfolio_cache(self) -> Dict[str, Any]:
+        try:
+            raw = PORTFOLIO_CACHE.read_text(encoding="utf-8")
+            return json.loads(raw)
+        except (OSError, json.JSONDecodeError) as exc:
+            logger.error("No se pudo leer cache portafolio: %s", exc, exc_info=True)
+            return {"activos": []}
+
+    def get_portfolio(self) -> Dict[str, Any]:
+        try:
+            data = self._fetch_portfolio_live()
+        except InvalidCredentialsError:
+            raise
+        except requests.RequestException as exc:
+            logger.warning("get_portfolio falló: %s", exc, exc_info=True)
+            return self._load_portfolio_cache()
+        except Exception:
+            logger.exception("get_portfolio falló inesperadamente")
+            raise
+        else:
+            self._write_portfolio_cache(data)
             return data
-        except requests.RequestException as e:
-            logger.warning("get_portfolio falló: %s", e, exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Market helpers
+    # ------------------------------------------------------------------
+    def _ensure_market_auth(self) -> None:
+        if self._market_ready and self.iol_market is not None:
+            return
+        with self._market_lock:
+            if self._market_ready and self.iol_market is not None:
+                return
+
+            self.iol_market = Iol(self.user, self.password)
+            bearer = self.auth.tokens.get("access_token")
+            refresh = self.auth.tokens.get("refresh_token")
+            if bearer and refresh:
+                self.iol_market.bearer = bearer
+                self.iol_market.refresh_token = refresh
+                bearer_time = TimeProvider.now_datetime().replace(tzinfo=None)
+                self.iol_market.bearer_time = bearer_time
+            elif not self.password:
+                st.session_state["force_login"] = True
+                raise InvalidCredentialsError("Token inválido")
+
             try:
-                data = json.loads(PORTFOLIO_CACHE.read_text(encoding="utf-8"))
-                return data
-            except (OSError, json.JSONDecodeError) as e:
-                logger.error("No se pudo leer cache portafolio: %s", e, exc_info=True)
-                return {"activos": []}
+                logger.debug("Autenticando mercado con bearer")
+                self.iol_market.gestionar()
+                logger.info("Autenticación mercado con bearer ok")
+            except NoAuthException:
+                logger.info("Bearer inválido; autenticando con contraseña")
+                self.iol_market = Iol(self.user, self.password)
+                try:
+                    self.iol_market.gestionar()
+                    logger.info("Autenticación mercado con contraseña ok")
+                except NoAuthException as exc:
+                    logger.error("Autenticación mercado con contraseña falló", exc_info=True)
+                    raise exc
+            self._market_ready = True
 
-    def get_last_price(self, mercado: str, simbolo: str):
-        return self._cli.get_last_price(mercado=mercado, simbolo=simbolo)
+    # ------------------------------------------------------------------
+    # Quote parsing helpers
+    # ------------------------------------------------------------------
+    @staticmethod
+    def _parse_price_fields(data: Dict[str, Any]) -> Optional[float]:
+        if not isinstance(data, dict):
+            return None
+        for key in ("ultimoPrecio", "ultimo", "last", "lastPrice", "precio", "cierre", "close"):
+            value = data.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+            if isinstance(value, str):
+                parsed = _to_float(value)
+                if parsed is not None:
+                    return parsed
+            if isinstance(value, dict):
+                for nested_key in ("value", "amount", "precio"):
+                    nested_value = value.get(nested_key)
+                    parsed = _to_float(nested_value)
+                    if parsed is not None:
+                        return parsed
+        return None
 
-    def get_quote(self, mercado: str, simbolo: str):
-        return self._cli.get_quote(mercado=mercado, simbolo=simbolo)
+    @staticmethod
+    def _parse_chg_pct_fields(data: Dict[str, Any], last: Optional[float] = None) -> Optional[float]:
+        if not isinstance(data, dict):
+            return None
+
+        for key in ("variacion", "variacionPorcentual", "cambioPorcentual", "changePercent"):
+            value = data.get(key)
+            if isinstance(value, (int, float)):
+                return float(value)
+            if isinstance(value, str):
+                value = value.replace("%", "").strip()
+                parsed = _to_float(value)
+                if parsed is not None:
+                    return parsed
+
+        prev_close: Optional[float] = None
+        for key in ("cierreAnterior", "previousClose"):
+            prev_close = _to_float(data.get(key))
+            if prev_close is not None:
+                break
+
+        if prev_close is None:
+            return None
+
+        delta = _to_float(data.get("puntosVariacion"))
+        if delta is not None:
+            return delta / prev_close * 100 if prev_close else None
+
+        if last is None:
+            last = IOLClient._parse_price_fields(data)
+        if last is None:
+            return None
+
+        return (last - prev_close) / prev_close * 100
+
+    # ------------------------------------------------------------------
+    # Quotes
+    # ------------------------------------------------------------------
+    def get_last_price(self, *, mercado: str, simbolo: str) -> Optional[float]:
+        mercado = (mercado or "bcba").lower()
+        simbolo = (simbolo or "").upper()
+        try:
+            self._ensure_market_auth()
+            data = self.iol_market.price_to_json(mercado=mercado, simbolo=simbolo)
+        except NoAuthException:
+            self._market_ready = False
+            self._ensure_market_auth()
+            data = self.iol_market.price_to_json(mercado=mercado, simbolo=simbolo)
+        except Exception as exc:
+            logger.warning("get_last_price error %s:%s -> %s", mercado, simbolo, exc)
+            return None
+
+        return self._parse_price_fields(data) if isinstance(data, dict) else None
+
+    def get_quote(self, *, mercado: str, simbolo: str) -> Dict[str, Optional[float]]:
+        mercado = (mercado or "bcba").lower()
+        simbolo = (simbolo or "").upper()
+        try:
+            self._ensure_market_auth()
+            data = self.iol_market.price_to_json(mercado=mercado, simbolo=simbolo)
+        except NoAuthException:
+            self._market_ready = False
+            self._ensure_market_auth()
+            data = self.iol_market.price_to_json(mercado=mercado, simbolo=simbolo)
+        except Exception as exc:
+            logger.warning("get_quote error %s:%s -> %s", mercado, simbolo, exc)
+            return {"last": None, "chg_pct": None}
+
+        if not isinstance(data, dict):
+            return {"last": None, "chg_pct": None}
+
+        last = self._parse_price_fields(data)
+        chg_pct = self._parse_chg_pct_fields(data, last)
+        if chg_pct is None:
+            logger.warning("chg_pct indeterminado para %s:%s", mercado, simbolo)
+        return {"last": last, "chg_pct": chg_pct}
+
+    def get_quotes_bulk(
+        self,
+        items: Iterable[Tuple[str, str]],
+        max_workers: int = 8,
+    ) -> Dict[Tuple[str, str], Dict[str, Optional[float]]]:
+        pairs = [((m or "bcba").lower(), (s or "").upper()) for (m, s) in items]
+        if not pairs:
+            return {}
+        self._ensure_market_auth()
+
+        result: Dict[Tuple[str, str], Dict[str, Optional[float]]] = {}
+        workers = min(max_workers, max(1, len(pairs)))
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_map = {executor.submit(self.get_quote, m, s): (m, s) for (m, s) in pairs}
+            for future in as_completed(future_map):
+                key = future_map[future]
+                try:
+                    result[key] = future.result()
+                except Exception as exc:  # pragma: no cover - defensive guard
+                    logger.warning("get_quotes_bulk %s:%s error -> %s", key[0], key[1], exc)
+                    result[key] = {"last": None, "chg_pct": None}
+        return result
+
+
+class IOLClientAdapter(IOLClient):
+    """Backward compatible alias for the old adapter name."""
+
 
 def build_iol_client(
     user: str,
     password: str,
     tokens_file: Path | str | None = None,
     auth: IOLAuth | None = None,
-) -> IOLClientAdapter:
-    return IOLClientAdapter(user, password, tokens_file=tokens_file, auth=auth)
+) -> IOLClient:
+    return IOLClient(user, password, tokens_file=tokens_file, auth=auth)
+
+
+__all__ = ["IOLClient", "IOLClientAdapter", "build_iol_client"]
+

--- a/infrastructure/iol/legacy/__init__.py
+++ b/infrastructure/iol/legacy/__init__.py
@@ -1,0 +1,16 @@
+"""Deprecated IOL legacy package kept for backwards compatibility."""
+
+from __future__ import annotations
+
+import warnings
+
+from . import iol_client as iol_client
+
+warnings.warn(
+    "`infrastructure.iol.legacy` está deprecado; utiliza `infrastructure.iol.client.IOLClient`.",
+    DeprecationWarning,
+    stacklevel=2,
+)
+
+__all__ = ["iol_client"]
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ markers = [
     "live_yahoo: Tests that call the live Yahoo Finance API (enable with RUN_LIVE_YF=1)",
     "slow: Performance-sensitive tests that may take several seconds to finish",
 ]
+# Legacy suite retained únicamente para auditorías del cliente antiguo.
 norecursedirs = [
     "tests/legacy",
 ]

--- a/services/cache.py
+++ b/services/cache.py
@@ -138,10 +138,12 @@ def _get_quote_cached(
         q = cli.get_quote(mercado=key[0], simbolo=key[1]) or {}
         data = _normalize_quote(q)
     except InvalidCredentialsError:
-        try:
-            cli._cli.auth.clear_tokens()
-        except Exception:
-            pass
+        auth = getattr(cli, "auth", None)
+        if auth is not None:
+            try:
+                auth.clear_tokens()
+            except Exception:
+                pass
         _trigger_logout()
         data = {"last": None, "chg_pct": None}
     except Exception as e:
@@ -187,10 +189,12 @@ def fetch_portfolio(_cli: IIOLProvider):
     try:
         data = _cli.get_portfolio()
     except InvalidCredentialsError:
-        try:
-            _cli._cli.auth.clear_tokens()
-        except Exception:
-            pass
+        auth = getattr(_cli, "auth", None)
+        if auth is not None:
+            try:
+                auth.clear_tokens()
+            except Exception:
+                pass
         _trigger_logout()
         logger.info(
             "fetch_portfolio using cache due to invalid credentials",

--- a/test/test_iol_client_additional.py
+++ b/test/test_iol_client_additional.py
@@ -1,24 +1,27 @@
+"""Additional coverage for the native IOL client helpers."""
+
+from __future__ import annotations
+
 import pytest
 import requests
 
-from infrastructure.iol.legacy import iol_client as legacy_module
+from infrastructure.iol import client as client_module
 from iolConn.common.exceptions import NoAuthException
 
 
 class DummyAuth:
-    def __init__(self):
+    def __init__(self) -> None:
         self.refreshed = False
         self.tokens = {"access_token": "a", "refresh_token": "r"}
 
-    def auth_header(self):
+    def auth_header(self) -> dict:
         return {"Authorization": "Bearer tok"}
 
-    def refresh(self):
+    def refresh(self) -> None:
         self.refreshed = True
 
 
 def _noop_auth(self):
-    # helper to bypass real market auth
     self._market_ready = True
 
 
@@ -33,7 +36,7 @@ def _noop_auth(self):
     ],
 )
 def test_parse_price_fields_various(data, expected):
-    assert legacy_module.IOLClient._parse_price_fields(data) == expected
+    assert client_module.IOLClient._parse_price_fields(data) == expected
 
 
 @pytest.mark.parametrize(
@@ -49,12 +52,12 @@ def test_parse_price_fields_various(data, expected):
     ],
 )
 def test_parse_chg_pct_fields_various(data, last, expected):
-    assert legacy_module.IOLClient._parse_chg_pct_fields(data, last) == expected
+    assert client_module.IOLClient._parse_chg_pct_fields(data, last) == expected
 
 
-def test_request_refresh_on_401(monkeypatch):
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", _noop_auth, raising=False)
-    client = legacy_module.IOLClient("u", "p", auth=DummyAuth())
+def test_request_refresh_on_401(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", _noop_auth, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
 
     class DummyResp:
         def __init__(self, code):
@@ -80,9 +83,9 @@ def test_request_refresh_on_401(monkeypatch):
     assert count["n"] == 2
 
 
-def test_request_returns_none_on_404(monkeypatch):
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", _noop_auth, raising=False)
-    client = legacy_module.IOLClient("u", "p", auth=DummyAuth())
+def test_request_returns_none_on_404(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", _noop_auth, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
 
     class DummyResp:
         status_code = 404
@@ -100,23 +103,23 @@ def test_request_returns_none_on_404(monkeypatch):
     assert not client.auth.refreshed
 
 
-def test_ensure_market_auth_noauth_both(monkeypatch):
+def test_ensure_market_auth_noauth_both(monkeypatch: pytest.MonkeyPatch) -> None:
     dummy_st = type("ST", (), {"session_state": {}})()
-    monkeypatch.setattr(legacy_module, "st", dummy_st)
+    monkeypatch.setattr(client_module, "st", dummy_st)
 
     class DummyIol:
-        def __init__(self, *a, **k):
+        def __init__(self, *args, **kwargs):
             pass
 
         def gestionar(self):
             raise NoAuthException("fail")
 
-    monkeypatch.setattr(legacy_module, "Iol", DummyIol)
+    monkeypatch.setattr(client_module, "Iol", DummyIol)
 
-    orig_ensure = legacy_module.IOLClient._ensure_market_auth
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", lambda self: None, raising=False)
-    client = legacy_module.IOLClient("u", "p", auth=DummyAuth())
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", orig_ensure, raising=False)
+    orig_ensure = client_module.IOLClient._ensure_market_auth
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", lambda self: None, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", orig_ensure, raising=False)
 
     client._market_ready = False
     with pytest.raises(NoAuthException):
@@ -124,42 +127,43 @@ def test_ensure_market_auth_noauth_both(monkeypatch):
     assert not client._market_ready
 
 
-def test_get_last_price_fallback(monkeypatch):
+def test_get_last_price_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyMarket:
-        def price_to_json(self, *a, **k):
+        def price_to_json(self, *args, **kwargs):
             raise Exception("boom")
 
     def fake_ensure(self):
         self.iol_market = DummyMarket()
         self._market_ready = True
 
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", fake_ensure, raising=False)
-    client = legacy_module.IOLClient("u", "p", auth=DummyAuth())
-    assert client.get_last_price("m", "s") is None
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", fake_ensure, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
+    assert client.get_last_price(mercado="m", simbolo="s") is None
 
 
-def test_get_quote_fallback(monkeypatch):
+def test_get_quote_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
     class DummyMarket:
-        def price_to_json(self, *a, **k):
+        def price_to_json(self, *args, **kwargs):
             return "nondict"
 
     def fake_ensure(self):
         self.iol_market = DummyMarket()
         self._market_ready = True
 
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", fake_ensure, raising=False)
-    client = legacy_module.IOLClient("u", "p", auth=DummyAuth())
-    quote = client.get_quote("m", "s")
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", fake_ensure, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
+    quote = client.get_quote(mercado="m", simbolo="s")
     assert quote == {"last": None, "chg_pct": None}
 
 
-def test_get_quotes_bulk_handles_errors(monkeypatch):
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", _noop_auth, raising=False)
+def test_get_quotes_bulk_handles_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", _noop_auth, raising=False)
 
     def bad_get_quote(self, m, s):
         raise ValueError("fail")
 
-    monkeypatch.setattr(legacy_module.IOLClient, "get_quote", bad_get_quote, raising=False)
-    client = legacy_module.IOLClient("u", "p", auth=DummyAuth())
+    monkeypatch.setattr(client_module.IOLClient, "get_quote", bad_get_quote, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
     result = client.get_quotes_bulk([("m", "SYM")])
     assert result == {("m", "SYM"): {"last": None, "chg_pct": None}}
+

--- a/test/test_iol_client_exceptions.py
+++ b/test/test_iol_client_exceptions.py
@@ -1,39 +1,47 @@
+from __future__ import annotations
+
 import json
+
 import pytest
 import requests
 
 from infrastructure.iol import client as client_module
 
 
-class DummyLegacyClientError:
-    def __init__(self, *args, **kwargs):
-        pass
+class DummyAuth:
+    def __init__(self) -> None:
+        self.tokens = {"access_token": "tok", "refresh_token": "ref"}
 
-    def get_portfolio(self):
-        raise requests.RequestException("boom")
+    def auth_header(self) -> dict:  # pragma: no cover - unused in this test
+        return {"Authorization": "Bearer tok"}
 
-
-class DummyLegacyClientUnexpected:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def get_portfolio(self):
-        raise ValueError("unexpected")
+    def refresh(self) -> None:  # pragma: no cover - unused in this test
+        raise AssertionError
 
 
-def test_get_portfolio_uses_cache_on_network_error(monkeypatch, tmp_path):
-    monkeypatch.setattr(client_module, "_LegacyIOLClient", DummyLegacyClientError)
+def test_get_portfolio_uses_cache_on_network_error(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
     cache = tmp_path / "portfolio.json"
     cache.write_text(json.dumps({"activos": [1]}), encoding="utf-8")
-    monkeypatch.setattr(client_module, "PORTFOLIO_CACHE", cache)
+    monkeypatch.setattr("infrastructure.iol.client.PORTFOLIO_CACHE", cache)
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", lambda self: None, raising=False)
 
-    adapter = client_module.IOLClientAdapter("u", "p")
-    assert adapter.get_portfolio() == {"activos": [1]}
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
+
+    def fail():
+        raise requests.RequestException("boom")
+
+    monkeypatch.setattr(client, "_fetch_portfolio_live", fail, raising=False)
+    assert client.get_portfolio() == {"activos": [1]}
 
 
-def test_get_portfolio_propagates_unexpected(monkeypatch, tmp_path):
-    monkeypatch.setattr(client_module, "_LegacyIOLClient", DummyLegacyClientUnexpected)
-    monkeypatch.setattr(client_module, "PORTFOLIO_CACHE", tmp_path / "portfolio.json")
-    adapter = client_module.IOLClientAdapter("u", "p")
+def test_get_portfolio_propagates_unexpected(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    monkeypatch.setattr("infrastructure.iol.client.PORTFOLIO_CACHE", tmp_path / "portfolio.json")
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", lambda self: None, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
+
+    def unexpected():
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr(client, "_fetch_portfolio_live", unexpected, raising=False)
     with pytest.raises(ValueError):
-        adapter.get_portfolio()
+        client.get_portfolio()

--- a/test/test_iol_logging.py
+++ b/test/test_iol_logging.py
@@ -1,42 +1,50 @@
+"""Logging behaviour for the native IOL client."""
+
+from __future__ import annotations
+
+import importlib
 import logging
 
 import pytest
 import requests
-import logging
-import json
-from cryptography.fernet import Fernet
-import importlib
 
 from infrastructure.iol import client as client_module
-from infrastructure.iol.legacy import iol_client as legacy_module
 
 
-class DummyLegacyClient:
-    def __init__(self, *args, **kwargs):
-        pass
+class DummyAuth:
+    def __init__(self) -> None:
+        self.tokens = {"access_token": "tok", "refresh_token": "ref"}
 
-    def get_portfolio(self):
+    def auth_header(self) -> dict:
+        return {"Authorization": "Bearer tok"}
+
+    def refresh(self) -> None:  # pragma: no cover - refresh not expected
+        raise AssertionError("refresh should not be called")
+
+
+def test_client_get_portfolio_logs(monkeypatch: pytest.MonkeyPatch, tmp_path, caplog) -> None:
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", lambda self: None, raising=False)
+    monkeypatch.setattr("infrastructure.iol.client.PORTFOLIO_CACHE", tmp_path / "portfolio.json")
+
+    def fail(self):
         raise requests.RequestException("network error")
 
+    monkeypatch.setattr(client_module.IOLClient, "_fetch_portfolio_live", fail, raising=False)
 
-def test_adapter_get_portfolio_logs(monkeypatch, tmp_path, caplog):
-    monkeypatch.setattr(client_module, "_LegacyIOLClient", DummyLegacyClient)
-    monkeypatch.setattr(client_module, "PORTFOLIO_CACHE", tmp_path / "portfolio.json")
-
-    adapter = client_module.IOLClientAdapter("user", "pass")
+    client = client_module.IOLClient("user", "pass", auth=DummyAuth())
 
     with caplog.at_level(logging.WARNING):
-        result = adapter.get_portfolio()
+        result = client.get_portfolio()
 
     assert result == {"activos": []}
-    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-    errors = [r for r in caplog.records if r.levelno == logging.ERROR]
-    assert any("get_portfolio falló" in r.message for r in warnings)
-    assert any("No se pudo leer cache portafolio" in r.message for r in errors)
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    errors = [record for record in caplog.records if record.levelno == logging.ERROR]
+    assert any("get_portfolio falló" in record.message for record in warnings)
+    assert any("No se pudo leer cache portafolio" in record.message for record in errors)
 
 
 class DummyMarket:
-    def price_to_json(self, *args, **kwargs):
+    def price_to_json(self, *args, **kwargs):  # pragma: no cover - used in tests only
         raise Exception("network fail")
 
 
@@ -45,19 +53,16 @@ def fake_ensure_market_auth(self):
     self._market_ready = True
 
 
-def test_legacy_get_last_price_logs(monkeypatch, tmp_path, caplog):
-    key = Fernet.generate_key()
-    monkeypatch.setenv("IOL_TOKENS_KEY", key.decode())
-    from shared import config
-    config.settings.tokens_key = key.decode()
+def test_client_get_last_price_logs(monkeypatch: pytest.MonkeyPatch, caplog) -> None:
     import infrastructure.iol.auth as auth_module
+
     importlib.reload(auth_module)
-    importlib.reload(legacy_module)
-    monkeypatch.setattr(legacy_module.IOLClient, "_ensure_market_auth", fake_ensure_market_auth, raising=False)
-    client = legacy_module.IOLClient("u", "p", tokens_file=tmp_path / "tokens.json")
+    monkeypatch.setattr(client_module.IOLClient, "_ensure_market_auth", fake_ensure_market_auth, raising=False)
+    client = client_module.IOLClient("u", "p", auth=DummyAuth())
 
     with caplog.at_level(logging.WARNING):
-        price = client.get_last_price("m", "SYM")
+        price = client.get_last_price(mercado="m", simbolo="SYM")
 
     assert price is None
-    assert any("get_last_price error" in r.message for r in caplog.records)
+    assert any("get_last_price error" in record.message for record in caplog.records)
+

--- a/test/test_refresh_flow.py
+++ b/test/test_refresh_flow.py
@@ -8,7 +8,7 @@ import pytest
 
 
 def test_refresh_flow_uses_refresh_token(monkeypatch):
-    from infrastructure.iol.legacy.iol_client import IOLClient
+    from infrastructure.iol.client import IOLClient
 
     class DummyAuth:
         def __init__(self, user, password, tokens_file=None, allow_plain_tokens=False):
@@ -26,7 +26,7 @@ def test_refresh_flow_uses_refresh_token(monkeypatch):
             self.calls.append("login")
             return self.tokens
 
-    monkeypatch.setattr("infrastructure.iol.legacy.iol_client.IOLAuth", DummyAuth)
+    monkeypatch.setattr("infrastructure.iol.client.IOLAuth", DummyAuth)
     monkeypatch.setattr(IOLClient, "_ensure_market_auth", lambda self: None)
 
     calls = {"n": 0}
@@ -65,7 +65,7 @@ def test_rerun_preserves_session(monkeypatch):
     def fake_rerun():
         called["ok"] = True
 
-    monkeypatch.setattr(st, "rerun", fake_rerun)
+    monkeypatch.setattr(st, "rerun", fake_rerun, raising=False)
     st.rerun()
     assert called.get("ok") is True
     assert st.session_state["tokens"] == {"a": 1}

--- a/tests/infrastructure/test_iol_client.py
+++ b/tests/infrastructure/test_iol_client.py
@@ -1,4 +1,5 @@
-"""Tests for the legacy IOL client integration with bearer tokens."""
+"""Tests for the native IOL client integration with bearer tokens."""
+
 from __future__ import annotations
 
 import sys
@@ -13,7 +14,7 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from infrastructure.iol.legacy import iol_client as iol_client_module
+from infrastructure.iol import client as iol_client_module
 
 
 class FakeAuth:


### PR DESCRIPTION
## Summary
- replace the adapter wrapper with a native `IOLClient` that manages auth, caching, and pricing without the legacy module
- adjust cache helpers, documentation, and pytest config to reflect the migration and deprecate `infrastructure.iol.legacy`
- refresh the test suites to target the new client implementation and add coverage for its helpers

## Testing
- `pytest tests/infrastructure/test_iol_client.py test/test_refresh_flow.py test/test_iol_logging.py test/test_iol_client_exceptions.py application/test/test_portfolio_fallback.py test/test_iol_client_additional.py`
- `PYTHONPATH=. pytest infrastructure/test/test_iol_auth_client.py`


------
https://chatgpt.com/codex/tasks/task_e_68e14948db9083329204744b1e8e6ffe