### PR TITLE
chore: release 0.3.30.1 and document legacy migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+## [0.3.30.1] - 2025-12-01
+
+### Changed
+- Limpieza de escenarios duplicados y migración final de controladores/servicios fuera de
+  `infrastructure.iol.legacy`, consolidando el uso de `IOLClientAdapter` y
+  `PortfolioViewModelService` como fuentes únicas para la UI y los scripts.
+- Ajuste de los pipelines para auditar importaciones legacy con `rg` y reforzar que `pytest` sólo
+  recolecte suites modernas.
+
+### Documentation
+- README, guía de pruebas y troubleshooting actualizados con la versión 0.3.30.1, instrucciones de
+  migración (helpers reemplazados, stub oficial de Streamlit) y comandos para ejecutar suites sin
+  módulos legacy.
+
+### Tests
+- Checklist de CI actualizada para exigir `pytest --ignore=tests/legacy`, auditorías de importaciones
+  legacy y verificación de artefactos (`coverage.xml`, `htmlcov/`, `analysis.zip`, `analysis.xlsx`,
+  `summary.csv`).
+
 ## [0.3.29.2] - 2025-11-24
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -6,36 +6,34 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.29.2)
+## Quick-start (release 0.3.30.1)
 
-La versión **0.3.29.2** es una release de hardening y CI que refuerza los pipelines automáticos y
-las verificaciones de integridad, manteniendo las mejoras funcionales introducidas en la serie
-0.3.28 y extendiéndolas en la nueva iteración. Consolida la persistencia de snapshots del portafolio,
-habilita exportaciones enriquecidas
-listas para compartir y extiende la observabilidad de la plataforma con métricas de almacenamiento y
-telemetría unificadas.
+La versión **0.3.30.1** completa la migración fuera de los módulos legacy y elimina duplicados de la
+suite de pruebas. El foco está puesto en limpiar helpers heredados, alinear los controladores con los
+servicios modernos (`PortfolioViewModelService`, `IOLClientAdapter`) y reforzar los pipelines de CI
+para que operen únicamente con el stack vigente.
 
-## Quick-start (release 0.3.29.2 — hardening/CI — 2025-11-24)
+## Quick-start (release 0.3.30.1 — migración fuera de legacy — 2025-12-01)
 
-La versión **0.3.29.2** destaca cinco ejes principales:
-- El **almacenamiento de snapshots** conserva los resultados del screening y del portafolio entre
-  sesiones. Los controles persistentes del sidebar (`st.session_state["controls_snapshot"]`) y el
-  servicio `PortfolioViewSnapshot` permiten reanudar análisis sin repetir descargas ni recomputar
-  agregados.
-- Las **exportaciones enriquecidas** consolidan la tabla visible, los KPIs y las notas de telemetría
-  en un mismo paquete. El script `scripts/export_analysis.py` genera carpetas con CSV, un ZIP con
-  esos mismos CSV y un Excel enriquecido con tablas y gráficos embebidos, además de un
-  `summary.csv` global para comparar snapshots.
-- Las **validaciones Markowitz endurecidas** detienen presets cuando los pesos no respetan los
-  límites configurados o la matriz de covarianza queda degenerada; la UI informa el incidente en el
-  banner de screening y registra la causa en telemetría para seguir la traza en CI.
-- La **observabilidad extendida** agrega métricas de almacenamiento y persistencia al health sidebar.
-  Los contadores de resiliencia ahora muestran los hits de snapshots, los reintentos fallidos y la
-  procedencia del último dato consolidado (primario, secundario o snapshot de contingencia).
-- La **CI Checklist reforzada** agrega verificaciones previas a merge: `pytest --cov` debe adjuntar
-  `coverage.xml` y `htmlcov/`, los jobs de exportación tienen que publicar `analysis.zip`,
-  `analysis.xlsx` y `summary.csv`, y la documentación lista los pasos rápidos para auditar esos
-  artefactos antes de aprobar una release.
+La versión **0.3.30.1** destaca cinco ejes principales:
+- El **almacenamiento de snapshots** continúa siendo el camino dorado para screenings rápidos y ahora
+  documenta cómo migrar presets que dependían de helpers duplicados. El servicio
+  `PortfolioViewSnapshot` sigue siendo el punto único para recuperar y persistir resultados, con los
+  controles del sidebar (`st.session_state["controls_snapshot"]`) reutilizando los snapshots generados.
+- Las **exportaciones enriquecidas** se mantienen disponibles con `scripts/export_analysis.py` y se
+  alinean a la nueva nomenclatura: cualquier script que antes invocaba utilidades legacy debe
+  interactuar con `services.portfolio_view.PortfolioViewModelService` para producir datasets
+  consistentes antes de exportar.
+- La **migración del cliente de IOL** reemplaza importaciones directas a
+  `infrastructure.iol.legacy.iol_client.IOLClient` por el adaptador moderno
+  `infrastructure.iol.client.IOLClientAdapter` (disponible mediante
+  `services.cache.build_iol_client`). Esto unifica la trazabilidad de tokens, cache y logging.
+- La **limpieza de duplicados** consolida los escenarios funcionales en `tests/controllers/`,
+  `tests/ui/` y `tests/integration/`. Los directorios legacy permanecen sólo como referencia histórica
+  y quedan excluidos de `pytest` vía `norecursedirs`.
+- La **CI Checklist reforzada** valida que todos los jobs ejecuten `pytest` sin dependencias legacy,
+  publiquen `coverage.xml`/`htmlcov/` y generen las exportaciones (`analysis.zip`, `analysis.xlsx`,
+  `summary.csv`) utilizando los nuevos helpers documentados.
 
 Sigue estos pasos para reproducir el flujo completo y validar las novedades clave:
 
@@ -53,7 +51,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.29.2` junto con
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.1` junto con
    el timestamp generado por `TimeProvider`. Abre el panel **Salud del sistema**: además del estado de
    cada proveedor verás el bloque **Snapshots y almacenamiento**, que expone la ruta activa del disco,
    el contador de recuperaciones desde snapshot y la latencia agregada de escritura.
@@ -74,8 +72,8 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    `exports/screener/sample/`) con todos los CSV (`kpis.csv`, `positions.csv`, `history.csv`,
    `contribution_by_symbol.csv`, etc.), empaqueta esos archivos en `analysis.zip` y genera un
    `analysis.xlsx` con todas las tablas en hojas dedicadas más los gráficos solicitados. En la raíz del
-   directorio también encontrarás `summary.csv` con los KPIs (`raw_value`) de cada snapshot para
-   facilitar comparaciones rápidas.
+ directorio también encontrarás `summary.csv` con los KPIs (`raw_value`) de cada snapshot para
+  facilitar comparaciones rápidas.
 
    > **Dependencia de Kaleido.** Plotly utiliza `kaleido` para renderizar los gráficos como PNG.
    > Instálalo con `pip install -r requirements.txt` (incluye la dependencia) o añádelo a tu entorno
@@ -83,11 +81,38 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    > los scripts continúan ofreciendo el ZIP de CSV y muestran una advertencia que indica cómo activar
    > la exportación a Excel con imágenes.
 
+### Migración fuera de módulos legacy
+
+1. **Cliente de IOL.** Sustituí cualquier importación a `infrastructure.iol.legacy.iol_client.IOLClient`
+   por el adaptador moderno:
+   ```python
+   from services.cache import build_iol_client
+
+   client, error = build_iol_client(user="...", tokens_file="...")
+   ```
+   Si necesitás construirlo manualmente (por ejemplo, en scripts), usá
+   `infrastructure.iol.client.IOLClientAdapter` para mantener el cache de portafolio y el manejo de
+   tokens consistentes.
+2. **Helpers de portfolio.** Los flujos que antes dependían de helpers duplicados en `tests/legacy/`
+   deben migrar a `services.portfolio_view.PortfolioViewModelService` y a
+   `application.portfolio_viewmodel.build_portfolio_viewmodel`. Estos componentes concentran la
+   normalización de posiciones, la clasificación de activos y la materialización del view-model.
+3. **Stub de Streamlit.** Las suites de UI utilizan el fixture `streamlit_stub` definido en
+   `tests/conftest.py`. Si mantenías stubs manuales en carpetas legacy, actualizá tus pruebas para
+   consumir el fixture e interactuar con helpers como `streamlit_stub.get_records("header")` o
+   `streamlit_stub.set_form_submit_result(...)`.
+4. **Ejecución de suites.** `pytest` ignora `tests/legacy/` gracias a `norecursedirs`, por lo que basta
+   con lanzar `pytest --maxfail=1 --disable-warnings -q` para cubrir la batería moderna. Ejecutá
+   `pytest tests/legacy` sólo cuando necesites auditar comparativas históricas.
+
+Con estos pasos la base de código queda alineada a los servicios actuales y los pipelines de CI pueden
+validar escenarios sin depender de módulos obsoletos.
+
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.29.2 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
-   reutilizados (`snapshot_hits`).
+   release 0.3.30.1 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
+  reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
    `primario → secundario → snapshot` (o fallback estático si corresponde) con la marca temporal de cada
    intento y la insignia que indica si la recuperación provino del almacenamiento persistente.
@@ -113,22 +138,24 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.29.2)
+### CI Checklist (0.3.30.1)
 
-1. **Ejecuta la suite determinista.** Lanza `pytest --maxfail=1 --disable-warnings -q` para asegurar que
-   los stubs cubran la funcionalidad completa antes de generar artefactos.
+1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
+   (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
 2. **Publica cobertura.** Corre `pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=html --cov-report=xml`
    y confirma que el pipeline adjunte `coverage.xml` y el directorio `htmlcov/` (verificable desde los
    artefactos del job).
-3. **Valida exportaciones.** Ejecuta `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
+3. **Audita importaciones legacy.** Incluye un paso que ejecute `rg "infrastructure\.iol\.legacy" application controllers services tests`
+   y falla el job si aparecen coincidencias fuera de `tests/legacy/`.
+4. **Valida exportaciones.** Ejecuta `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
    o reutiliza los snapshots de `tmp_path`. Revisa que cada snapshot genere los CSV (`kpis.csv`,
    `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
    `analysis.xlsx` y el resumen `summary.csv` en la raíz de `exports/ci`.
-4. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
+5. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
    presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 
-### Validaciones Markowitz reforzadas (0.3.29.2)
+### Validaciones Markowitz reforzadas (0.3.30.1)
 
 - `application.risk_service.markowitz_optimize` valida la invertibilidad de la matriz de covarianzas y
   degrada a pesos `NaN` cuando detecta singularidad o entradas inválidas, evitando excepciones en la UI
@@ -143,7 +170,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
   y `tests/integration/test_portfolio_tabs.py` cubren la degradación controlada y los mensajes visibles
   en la UI, por lo que cualquier regresión se detecta en pipelines.
 
-**Resiliencia de APIs (0.3.29.2).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.30.1).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening y la procedencia (`primario`, `secundario`, `snapshot`). Al
 relanzarlo, la telemetría agrega la procedencia del dato y clasifica la recuperación según la estrategia
 aplicada:
@@ -157,7 +184,7 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos.
 
-Estas novedades convierten a la release 0.3.29.2 en la referencia para validar onboarding, telemetría y
+Estas novedades convierten a la release 0.3.30.1 en la referencia para validar onboarding, telemetría y
 resiliencia multi-API: toda la UI recuerda la versión activa, expone KPIs agregados de disponibilidad y
 almacenamiento en el health sidebar y las exportaciones enriquecidas aseguran paridad total entre la
 visión en pantalla y los artefactos compartidos.
@@ -165,7 +192,7 @@ visión en pantalla y los artefactos compartidos.
 
 ## Configuración de claves API
 
-La release 0.3.29.2 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
+La release 0.3.30.1 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
 
@@ -206,7 +233,7 @@ en ``~/.portafolio_iol/favorites.json`` con la siguiente estructura:
 - Podés borrar el archivo para reiniciar la lista; se volverá a generar cuando agregues un nuevo
   favorito.
 
-## Backend de snapshots para pipelines CI (0.3.29.2)
+## Backend de snapshots para pipelines CI (0.3.30.1)
 
 - Define `SNAPSHOT_BACKEND=null` para ejecutar suites sin escribir archivos persistentes; el módulo
   `services.snapshots` usará `NullSnapshotStorage` y evitará cualquier escritura en disco durante las
@@ -341,7 +368,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.29.2)
+##### Escenarios de fallback macro (0.3.30.1)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -490,11 +517,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.29.2".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.1".
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.29.2)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.1)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -30,23 +30,31 @@ pytest
 El proyecto incorpora `pytest.ini` con marcadores y configuración de logging. La ejecución completa
 usa los stubs deterministas para mantener resultados reproducibles.
 
-## CI Checklist (0.3.29.2)
+## CI Checklist (0.3.30.1)
 
-1. **Suite determinista.** Ejecuta `pytest --maxfail=1 --disable-warnings -q` para validar que las
-   regresiones funcionales se detecten antes de publicar artefactos.
+1. **Suite determinista sin legacy.** Ejecuta `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy` y
+   verifica que el resumen final no recolecte casos desde `tests/legacy/`.
 2. **Cobertura obligatoria.** Corre `pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=html --cov-report=xml`
    y asegúrate de subir `coverage.xml` y el directorio `htmlcov/` como artefactos del job.
-3. **Exportaciones consistentes.** Invoca `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
+3. **Auditoría de importaciones legacy.** Añade un paso que ejecute
+   `rg "infrastructure\.iol\.legacy" application controllers services tests` y marque el pipeline como
+   fallido si aparecen coincidencias fuera de `tests/legacy/` o de fixtures destinados a compatibilidad.
+4. **Exportaciones consistentes.** Invoca `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
    (o reutiliza `tmp_path` en las suites) y revisa que cada snapshot incluya los CSV (`kpis.csv`,
    `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
    `analysis.xlsx` y el resumen `summary.csv` en la raíz del directorio de exportaciones.
-4. **Checklist previa al merge.** Antes de aprobar la release inspecciona los artefactos del pipeline y
+5. **Checklist previa al merge.** Antes de aprobar la release inspecciona los artefactos del pipeline y
    confirma que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
    adjuntos. Si falta alguno, la ejecución debe considerarse fallida.
 
 ### Suites legacy
 
-La carpeta `tests/legacy/` contiene casos heredados que duplican escenarios ya cubiertos en la suite principal. Se excluye de la recolección estándar para mantener los tiempos de CI. Si necesitas auditarlos manualmente, ejecútalos de forma explícita:
+La carpeta `tests/legacy/` contiene casos heredados que duplican escenarios ya cubiertos en la suite
+principal. Se excluye de la recolección estándar para mantener los tiempos de CI y sirve como
+histórico para comparar comportamientos. Los flujos modernos deben utilizar
+`services.portfolio_view.PortfolioViewModelService`, `application.portfolio_viewmodel` y los fixtures
+de `tests/conftest.py` (especialmente `streamlit_stub`) en lugar de helpers legacy. Si necesitas
+auditarlos manualmente, ejecútalos de forma explícita:
 
 ```bash
 pytest tests/legacy
@@ -81,8 +89,9 @@ frecuentes:
 
 ### Validación de snapshots y almacenamiento persistente
 
-La release 0.3.29.2, orientada a hardening/CI y cobertura, refuerza los contadores de snapshots, la
-telemetría de almacenamiento y la verificación de artefactos en pipelines. Para cubrirlos en QA
+La release 0.3.30.1, enfocada en limpiar duplicados y completar la migración fuera de legacy,
+refuerza los contadores de snapshots, la telemetría de almacenamiento y la verificación de artefactos
+en pipelines. Para cubrirlos en QA
 combina pruebas automáticas y verificaciones manuales:
 
 - `pytest tests/test_sidebar_controls.py -k snapshot`: comprueba que los presets persistan en

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,12 +4,18 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Claves API
 
-> Nota: Esta guía corresponde a la release 0.3.29.2, enfocada en hardening/CI para reforzar los
-> pipelines automáticos, la cobertura y las verificaciones de integridad sin alterar los flujos
-> funcionales documentados en la serie 0.3.29.2.
+> Nota: Esta guía corresponde a la release 0.3.30.1, centrada en limpiar duplicados, completar la
+> migración fuera de módulos legacy y reforzar los pipelines de CI sin alterar los flujos funcionales
+> documentados en la serie 0.3.30.1.
 
-## CI Checklist (0.3.29.2)
+## CI Checklist (0.3.30.1)
 
+- **Suite legacy detectada.** Si el resumen de `pytest` menciona archivos dentro de `tests/legacy/`,
+  ajustá el comando (`pytest --ignore=tests/legacy`) o revisá `norecursedirs` en `pyproject.toml` para
+  evitar recolectar escenarios duplicados.
+- **Importaciones legacy en código activo.** Ejecuta `rg "infrastructure\.iol\.legacy" application controllers services tests`
+  y bloqueá el pipeline si aparecen coincidencias fuera de `tests/legacy/` o de pruebas de compatibilidad
+  explícitas.
 - **Pipelines sin artefactos.** Si un job finaliza sin adjuntar `coverage.xml`, `htmlcov/`, `analysis.zip`,
   `analysis.xlsx` o `summary.csv`, márcalo como fallido y reejecuta las etapas de `pytest --cov` y
   `scripts/export_analysis.py`. Los pasos deben apuntar al mismo directorio temporal (`$RUNNER_TEMP` o
@@ -54,7 +60,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **El timeline de resiliencia no persiste tras un rerun.**
   - **Síntomas:** Luego de presionar **⟳ Refrescar**, el bloque **Resiliencia de proveedores** se vacía.
-  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.29.2 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
+  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.1 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
   - **Resolución:**
     1. Actualiza el repositorio y reinstala dependencias si trabajas con un build antiguo.
     2. Comprueba que el stub de tests (`tests/conftest.py`) conserve los datos de sesión entre llamadas; limpia `st.session_state` solo al finalizar las aserciones.
@@ -150,7 +156,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.
-  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.29.2` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.1` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
   - **Resolución:**
     1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
     2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.29.2"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.1"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.29.2"
+DEFAULT_VERSION: str = "0.3.30.1"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project metadata to version 0.3.30.1 and keep `shared.version` aligned
- document the 0.3.30.1 release in the changelog with legacy cleanup and CI audit notes
- update README, testing, and troubleshooting guides with migration steps away from legacy helpers and refreshed CI checklist commands

## Testing
- pytest tests/test_version_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68e14949aa88833283da874a5eed1510