### PR TITLE
Avoid global fallback for portfolio service registry when session state is missing

### DIFF
--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -36,9 +36,6 @@ _NOTIFICATIONS_SERVICE_KEY = "notifications_service"
 _NOTIFICATIONS_FACTORY_KEY = "notifications_service_factory"
 _SNAPSHOT_BACKEND_KEY = "snapshot_backend_override"
 
-_FALLBACK_SESSION_STATE: dict[str, Any] = {}
-
-
 def _get_service_registry() -> dict[str, Any]:
     """Return the per-session registry that stores portfolio services."""
 
@@ -60,11 +57,7 @@ def _get_service_registry() -> dict[str, Any]:
         if isinstance(registry, dict):
             return registry
 
-    registry = _FALLBACK_SESSION_STATE.get(_SERVICE_REGISTRY_KEY)
-    if not isinstance(registry, dict):
-        registry = {}
-        _FALLBACK_SESSION_STATE[_SERVICE_REGISTRY_KEY] = registry
-    return registry
+    return {}
 
 
 def default_view_model_service_factory() -> PortfolioViewModelService:
@@ -137,6 +130,9 @@ def get_notifications_service(
 def reset_portfolio_services() -> None:
     """Clear cached portfolio services for the current session."""
 
+    if getattr(st, "session_state", None) is None:
+        return
+
     registry = _get_service_registry()
     for key in (
         _VIEW_MODEL_SERVICE_KEY,
@@ -149,6 +145,9 @@ def reset_portfolio_services() -> None:
 
 def configure_snapshot_backend(snapshot_backend: Any | None) -> None:
     """Override the snapshot backend used by the cached portfolio service."""
+
+    if getattr(st, "session_state", None) is None:
+        return
 
     registry = _get_service_registry()
     registry[_SNAPSHOT_BACKEND_KEY] = snapshot_backend

--- a/tests/controllers/test_portfolio_services.py
+++ b/tests/controllers/test_portfolio_services.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from controllers.portfolio import portfolio
+
+
+class _StreamlitStub:
+    """Stub streamlit module that mimics a missing session_state attribute."""
+
+    def __init__(self, state_stub: object):
+        self._state_stub = state_stub
+
+    @property
+    def session_state(self):
+        raise AttributeError(f"session_state missing: {self._state_stub}")
+
+
+def test_get_portfolio_view_service_without_session_state_is_not_shared(monkeypatch):
+    """Ensure services are not reused when session_state is unavailable."""
+
+    first_state_stub = object()
+    second_state_stub = object()
+
+    first_instance = object()
+    second_instance = object()
+
+    monkeypatch.setattr(portfolio, "st", _StreamlitStub(first_state_stub))
+    service_one = portfolio.get_portfolio_view_service(lambda: first_instance)
+
+    monkeypatch.setattr(portfolio, "st", _StreamlitStub(second_state_stub))
+    service_two = portfolio.get_portfolio_view_service(lambda: second_instance)
+
+    assert service_one is first_instance
+    assert service_two is second_instance
+    assert service_one is not service_two
+


### PR DESCRIPTION
## Summary
- remove the module-level fallback registry and rely solely on `st.session_state` for caching portfolio services
- guard the reset and snapshot backend helpers so they become no-ops when the Streamlit session state is unavailable
- add a regression test that stubs `st.session_state` to ensure portfolio services are not shared without a session

## Testing
- `pytest tests/controllers/test_portfolio_services.py`


------
https://chatgpt.com/codex/tasks/task_e_68e171821e9c8332b75949c10e606924

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of portfolio features when session data is unavailable, ensuring safer initialization and no unintended cross-session sharing of services.
  * Operations that depend on session state now gracefully no-op when the session isn’t initialized, reducing edge-case errors.

* **Tests**
  * Added tests to verify isolated service instances and correct behavior when session data is missing, strengthening confidence in session-scoped functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->