### PR TITLE
Delay snapshot autoconfiguration and add testing helpers

### DIFF
--- a/services/snapshots.py
+++ b/services/snapshots.py
@@ -15,6 +15,7 @@ records and compute comparisons between arbitrary entries.
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
 import json
 import logging
@@ -280,34 +281,143 @@ class _SQLiteSnapshotStorage(_BaseSnapshotStorage):
 
 
 _STORAGE: _BaseSnapshotStorage = _NullSnapshotStorage()
+_AUTO_CONFIGURED = False
 
 
-def configure_storage(*, backend: str | None = None, path: str | os.PathLike[str] | None = None) -> None:
-    """Configure the snapshot backend based on the provided parameters."""
-
-    backend = (backend or "json").strip().lower()
+def _resolve_storage(
+    *,
+    backend: str | None = None,
+    path: str | os.PathLike[str] | None = None,
+    raise_on_error: bool = False,
+) -> _BaseSnapshotStorage:
+    backend_name = (backend or "json").strip().lower()
     storage_path = Path(path) if path else None
 
     try:
-        if backend == "json":
-            storage = _JSONSnapshotStorage(storage_path or Path("data/snapshots.json"))
-        elif backend in {"sqlite", "sqlite3"}:
-            storage = _SQLiteSnapshotStorage(storage_path or Path("data/snapshots.db"))
-        elif backend in {"null", "none", "disabled"}:
-            storage = _NullSnapshotStorage()
-        else:
-            raise SnapshotStorageError(f"Backend no soportado: {backend}")
+        if backend_name == "json":
+            return _JSONSnapshotStorage(storage_path or Path("data/snapshots.json"))
+        if backend_name in {"sqlite", "sqlite3"}:
+            return _SQLiteSnapshotStorage(storage_path or Path("data/snapshots.db"))
+        if backend_name in {"null", "none", "disabled"}:
+            return _NullSnapshotStorage()
+        raise SnapshotStorageError(f"Backend no soportado: {backend_name}")
     except SnapshotStorageError:
-        logger.exception("Fallo la configuración del backend de snapshots (%s)", backend)
-        storage = _NullSnapshotStorage()
+        if raise_on_error:
+            raise
+        logger.exception(
+            "Fallo la configuración del backend de snapshots (%s)", backend_name
+        )
+        return _NullSnapshotStorage()
 
-    global _STORAGE
-    _STORAGE = storage
+
+def _ensure_configured() -> None:
+    global _AUTO_CONFIGURED
+    if not _AUTO_CONFIGURED:
+        _auto_configure_from_settings()
+        _AUTO_CONFIGURED = True
+
+
+class SnapshotSession:
+    """Facade that exposes the snapshot helpers for a specific storage backend."""
+
+    def __init__(self, storage: _BaseSnapshotStorage) -> None:
+        self._storage = storage
+
+    @property
+    def storage(self) -> _BaseSnapshotStorage:
+        return self._storage
+
+    def save_snapshot(
+        self,
+        kind: str,
+        payload: SnapshotPayload,
+        metadata: SnapshotMetadata | None = None,
+    ) -> Mapping[str, Any]:
+        payload = _to_plain_mapping(payload)
+        metadata = _to_plain_mapping(metadata)
+        try:
+            return self._storage.save_snapshot(kind, payload, metadata)
+        except SnapshotStorageError:
+            logger.exception("Error al guardar snapshot %s", kind)
+            raise
+
+    def load_snapshot(self, snapshot_id: str) -> Mapping[str, Any] | None:
+        try:
+            return self._storage.load_snapshot(snapshot_id)
+        except SnapshotStorageError:
+            logger.exception("Error al cargar snapshot %s", snapshot_id)
+            raise
+
+    def list_snapshots(
+        self,
+        kind: str | None = None,
+        *,
+        limit: int | None = None,
+        order: str = "desc",
+    ) -> Sequence[Mapping[str, Any]]:
+        try:
+            return self._storage.list_snapshots(kind, limit=limit, order=order)
+        except SnapshotStorageError:
+            logger.exception("Error al listar snapshots kind=%s", kind)
+            raise
+
+    def compare_snapshots(self, id_a: str, id_b: str) -> Mapping[str, Any] | None:
+        try:
+            return _compare_snapshots_with_storage(self._storage, id_a, id_b)
+        except SnapshotStorageError:
+            logger.exception("Error al comparar snapshots %s vs %s", id_a, id_b)
+            raise
+
+
+def configure_storage(
+    *, backend: str | None = None, path: str | os.PathLike[str] | None = None
+) -> None:
+    """Configure the snapshot backend based on the provided parameters."""
+
+    global _STORAGE, _AUTO_CONFIGURED
+    _STORAGE = _resolve_storage(backend=backend, path=path)
+    _AUTO_CONFIGURED = True
+
+
+def create_storage(
+    *,
+    backend: str | None = None,
+    path: str | os.PathLike[str] | None = None,
+    raise_on_error: bool = False,
+) -> _BaseSnapshotStorage:
+    """Instantiate a snapshot backend without mutating the global configuration."""
+
+    return _resolve_storage(
+        backend=backend, path=path, raise_on_error=raise_on_error
+    )
+
+
+@contextmanager
+def temporary_snapshot_storage(
+    *,
+    backend: str | None = None,
+    path: str | os.PathLike[str] | None = None,
+    storage: _BaseSnapshotStorage | None = None,
+    raise_on_error: bool = False,
+):
+    """Yield a :class:`SnapshotSession` without altering the module level storage."""
+
+    storage_instance = storage or create_storage(
+        backend=backend, path=path, raise_on_error=raise_on_error
+    )
+    session = SnapshotSession(storage_instance)
+    try:
+        yield session
+    finally:
+        closer = getattr(storage_instance, "close", None)
+        if callable(closer):
+            closer()
 
 
 def save_snapshot(kind: str, payload: SnapshotPayload, metadata: SnapshotMetadata | None = None) -> Mapping[str, Any]:
     """Persist a snapshot and return the stored record."""
 
+    _ensure_configured()
     payload = _to_plain_mapping(payload)
     metadata = _to_plain_mapping(metadata)
     try:
@@ -320,6 +430,7 @@ def save_snapshot(kind: str, payload: SnapshotPayload, metadata: SnapshotMetadat
 def load_snapshot(snapshot_id: str) -> Mapping[str, Any] | None:
     """Load a snapshot by identifier."""
 
+    _ensure_configured()
     try:
         return _STORAGE.load_snapshot(snapshot_id)
     except SnapshotStorageError:
@@ -332,6 +443,7 @@ def list_snapshots(
 ) -> Sequence[Mapping[str, Any]]:
     """Return historical snapshots for the requested kind."""
 
+    _ensure_configured()
     try:
         return _STORAGE.list_snapshots(kind, limit=limit, order=order)
     except SnapshotStorageError:
@@ -350,8 +462,19 @@ def compare_snapshots(id_a: str, id_b: str) -> Mapping[str, Any] | None:
     if not id_a or not id_b:
         return None
 
-    snap_a = load_snapshot(id_a)
-    snap_b = load_snapshot(id_b)
+    _ensure_configured()
+    try:
+        return _compare_snapshots_with_storage(_STORAGE, id_a, id_b)
+    except SnapshotStorageError:
+        logger.exception("Error al comparar snapshots %s vs %s", id_a, id_b)
+        raise
+
+
+def _compare_snapshots_with_storage(
+    storage: _BaseSnapshotStorage, id_a: str, id_b: str
+) -> Mapping[str, Any] | None:
+    snap_a = storage.load_snapshot(id_a)
+    snap_b = storage.load_snapshot(id_b)
     if not snap_a or not snap_b:
         return None
 
@@ -419,7 +542,4 @@ def _auto_configure_from_settings() -> None:
     except Exception:  # pragma: no cover - safeguards for early imports
         logger.exception("No se pudo inicializar el backend de snapshots, se usará NullStorage")
         configure_storage(backend="null")
-
-
-_auto_configure_from_settings()
 


### PR DESCRIPTION
## Summary
- defer the snapshot storage auto-configuration until first use and expose helpers to create or temporarily use backends without mutating the global storage
- add a `SnapshotSession` facade plus `temporary_snapshot_storage` context manager for isolated backends used in tests and scripts
- document the lazy configuration flow and CI recommendations for forcing the null backend in `docs/testing.md`

## Testing
- pytest services/test/test_snapshots.py

------
https://chatgpt.com/codex/tasks/task_e_68e171c7a7508332a70c400af9eaa193

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a session-based interface for snapshot operations with improved error handling.
  - Enables explicit, isolated, and temporary storage configuration without affecting global state.
  - Defers automatic storage setup until first use, with smarter backend selection (e.g., JSON, SQLite, or null).
- Documentation
  - Updates CI guidance to prevent artifacts in shared workspaces.
  - Adds examples for disabling snapshot persistence and using temporary or ephemeral storage in tests.
  - Clarifies patterns that isolate test backends and maintain a clean workspace after runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->