### PR TITLE
Harden JSON snapshot storage with retention control

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -198,6 +198,14 @@ class Settings:
         self.snapshot_storage_path: str | None = os.getenv(
             "SNAPSHOT_STORAGE_PATH", cfg.get("SNAPSHOT_STORAGE_PATH")
         )
+        raw_retention = os.getenv("SNAPSHOT_RETENTION", cfg.get("SNAPSHOT_RETENTION"))
+        try:
+            self.snapshot_retention: int | None = (
+                int(raw_retention) if raw_retention not in (None, "") else None
+            )
+        except (TypeError, ValueError):
+            logger.warning("Valor inválido para SNAPSHOT_RETENTION: %s", raw_retention)
+            self.snapshot_retention = None
 
         primary_raw = os.getenv(
             "OHLC_PRIMARY_PROVIDER", cfg.get("OHLC_PRIMARY_PROVIDER", "alpha_vantage")

--- a/shared/settings.py
+++ b/shared/settings.py
@@ -37,6 +37,7 @@ STUB_MAX_RUNTIME_WARN: float = stub_max_runtime_warn
 # Snapshot storage configuration
 snapshot_backend: str = getattr(settings, "snapshot_backend", "json")
 snapshot_storage_path: str | None = getattr(settings, "snapshot_storage_path", None)
+snapshot_retention: int | None = getattr(settings, "snapshot_retention", None)
 
 # Notification thresholds
 risk_badge_threshold: float = getattr(settings, "RISK_BADGE_THRESHOLD", 0.75)
@@ -115,6 +116,7 @@ __all__ = [
     "STUB_MAX_RUNTIME_WARN",
     "snapshot_backend",
     "snapshot_storage_path",
+    "snapshot_retention",
     "YAHOO_FUNDAMENTALS_TTL",
     "YAHOO_QUOTES_TTL",
     "MIN_SCORE_THRESHOLD",


### PR DESCRIPTION
## Summary
- add a configurable `snapshot_retention` setting and expose it via `shared.settings`
- enforce retention when writing JSON snapshots and harden writes with `fsync` plus temp-file cleanup
- cover the retention behaviour and failure handling with a dedicated snapshot storage test

## Testing
- pytest services/test/test_snapshots.py

------
https://chatgpt.com/codex/tasks/task_e_68e171c8da78833289284a2036b50284