### PR TITLE
Log snapshot backend fallbacks and warn UI

### DIFF
--- a/controllers/portfolio/portfolio.py
+++ b/controllers/portfolio/portfolio.py
@@ -259,6 +259,16 @@ def render_portfolio_section(
         view_model_service = get_portfolio_view_service(view_model_service_factory)
         notifications_service = get_notifications_service(notifications_service_factory)
 
+        if snapshot_service.is_null_backend():
+            backend_name = snapshot_service.current_backend_name()
+            st.warning(
+                "El almacenamiento de snapshots está deshabilitado "
+                f"(backend: {backend_name}). Configurá `SNAPSHOT_BACKEND` a "
+                "`json` o `sqlite` en `config.json` (o llamando a "
+                "`services.snapshots.configure_storage`) y verificá los permisos "
+                "definidos en `SNAPSHOT_STORAGE_PATH` para volver a habilitarlo."
+            )
+
         df_pos, all_symbols, available_types = load_portfolio_data(cli, psvc)
         favorites = get_persistent_favorites()
 


### PR DESCRIPTION
## Summary
- record a risk incident whenever the snapshot backend configuration falls back to the null backend and expose helpers to inspect the active storage
- surface a Streamlit warning in the portfolio section when snapshot persistence is disabled so users know how to reconfigure it
- add regression coverage that simulates permission errors and verifies the incident is recorded

## Testing
- pytest services/test/test_snapshots.py

------
https://chatgpt.com/codex/tasks/task_e_68e171c9ab508332827f17085f99423a