### PR TITLE
Update IOL quotes endpoint to Cotizacion path

### DIFF
--- a/infrastructure/iol/client.py
+++ b/infrastructure/iol/client.py
@@ -301,7 +301,7 @@ class IOLClient(IIOLProvider):
         resolved_market = (mercado if mercado is not None else market or "bcba").lower()
         resolved_symbol = (simbolo if simbolo is not None else symbol or "").upper()
         params = {"panel": panel} if panel else None
-        url = f"{self.api_base}/marketdata/{resolved_market}/{resolved_symbol}"
+        url = f"{self.api_base}/marketdata/{resolved_market}/{resolved_symbol}/Cotizacion"
 
         try:
             response = self._request("GET", url, params=params)


### PR DESCRIPTION
## Summary
- update the IOL client quote request to hit the Cotizacion endpoint
- add a regression test that captures the expected URL and payload parsing
- pull in SimpleNamespace to simplify the mocked response object

## Testing
- pytest --override-ini addopts="" tests/infrastructure/test_iol_client.py -k valid_payload

------
https://chatgpt.com/codex/tasks/task_e_68e19d2b924c8332a5fe8486bf5b0704