### PR TITLE
Bump version to 0.3.30.4 and refresh release docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## [0.3.30.4] - 2025-10-04
+
+### Added
+- Nuevo endpoint `/Cotizacion` que publica cotizaciones normalizadas para los consumidores internos y externos.
+
+### Fixed
+- Manejo reforzado de errores HTTP 500 provenientes de upstream para evitar caídas en dashboards y telemetría.
+
+### Tests
+- Prueba de cobertura dedicada que valida los flujos de cotización bajo escenarios de error y resiliencia.
+
 ## [0.3.30.3] - 2025-10-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,34 +6,28 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.30.3)
+## Quick-start (release 0.3.30.4)
 
-La versión **0.3.30.3** completa la migración fuera de los módulos legacy y elimina duplicados de la
-suite de pruebas. El foco está puesto en limpiar helpers heredados, alinear los controladores con los
-servicios modernos (`PortfolioViewModelService`, `IOLClientAdapter`) y reforzar los pipelines de CI
-para que operen únicamente con el stack vigente.
+La versión **0.3.30.4** publica el endpoint `/Cotizacion`, refuerza el manejo de errores HTTP 500 y
+añade una prueba de cobertura dedicada para el flujo de cotizaciones. A la vez mantiene la limpieza de
+duplicados y la migración fuera de los módulos legacy, asegurando que los controladores modernos y los
+pipelines de CI permanezcan alineados con el stack vigente.
 
-## Quick-start (release 0.3.30.3 — migración fuera de legacy — 2025-10-04)
+## Quick-start (release 0.3.30.4 — resiliencia de cotizaciones — 2025-10-04)
 
-La versión **0.3.30.3** destaca cinco ejes principales:
-- El **almacenamiento de snapshots** continúa siendo el camino dorado para screenings rápidos y ahora
-  documenta cómo migrar presets que dependían de helpers duplicados. El servicio
-  `PortfolioViewSnapshot` sigue siendo el punto único para recuperar y persistir resultados, con los
-  controles del sidebar (`st.session_state["controls_snapshot"]`) reutilizando los snapshots generados.
-- Las **exportaciones enriquecidas** se mantienen disponibles con `scripts/export_analysis.py` y se
-  alinean a la nueva nomenclatura: cualquier script que antes invocaba utilidades legacy debe
-  interactuar con `services.portfolio_view.PortfolioViewModelService` para producir datasets
-  consistentes antes de exportar.
-- La **migración del cliente de IOL** reemplaza importaciones directas a
-  `infrastructure.iol.legacy.iol_client.IOLClient` por el adaptador moderno
-  `infrastructure.iol.client.IOLClientAdapter` (disponible mediante
-  `services.cache.build_iol_client`). Esto unifica la trazabilidad de tokens, cache y logging.
-- La **limpieza de duplicados** consolida los escenarios funcionales en `tests/controllers/`,
-  `tests/ui/` y `tests/integration/`. Los directorios legacy permanecen sólo como referencia histórica
-  y quedan excluidos de `pytest` vía `norecursedirs`.
-- La **CI Checklist reforzada** valida que todos los jobs ejecuten `pytest` sin dependencias legacy,
-  publiquen `coverage.xml`/`htmlcov/` y generen las exportaciones (`analysis.zip`, `analysis.xlsx`,
-  `summary.csv`) utilizando los nuevos helpers documentados.
+La versión **0.3.30.4** destaca cinco ejes principales:
+- El **endpoint `/Cotizacion`** centraliza la obtención de precios normalizados y unifica el consumo
+  entre la UI y los consumidores externos, reutilizando los servicios modernos documentados.
+- El **manejo reforzado de errores 500** encapsula degradaciones desde los proveedores upstream y
+  activa el fallback jerárquico sin interrumpir dashboards ni telemetría.
+- La **prueba de cobertura dedicada** asegura que el flujo de cotizaciones quede bloqueado en CI si se
+  pierde cobertura sobre escenarios de resiliencia y fallback.
+- El **almacenamiento de snapshots** continúa siendo el camino dorado para screenings rápidos y se
+  integra con el nuevo endpoint para reutilizar datos calculados, manteniendo los controles del sidebar
+  (`st.session_state["controls_snapshot"]`) alineados con los resultados persistidos.
+- La **CI Checklist reforzada** valida que los jobs publiquen `coverage.xml`/`htmlcov/`, mantengan las
+  exportaciones (`analysis.zip`, `analysis.xlsx`, `summary.csv`) y ejecuten la batería moderna sin
+  dependencias legacy.
 
 Sigue estos pasos para reproducir el flujo completo y validar las novedades clave:
 
@@ -51,7 +45,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.3` junto con
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.4` junto con
    el timestamp generado por `TimeProvider`. Abre el panel **Salud del sistema**: además del estado de
    cada proveedor verás el bloque **Snapshots y almacenamiento**, que expone la ruta activa del disco,
    el contador de recuperaciones desde snapshot y la latencia agregada de escritura.
@@ -111,7 +105,7 @@ validar escenarios sin depender de módulos obsoletos.
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.30.3 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
+   release 0.3.30.4 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
   reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
    `primario → secundario → snapshot` (o fallback estático si corresponde) con la marca temporal de cada
@@ -138,13 +132,13 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.30.3)
+### CI Checklist (0.3.30.4)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
-2. **Publica cobertura.** Corre `pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=html --cov-report=xml`
-   y confirma que el pipeline adjunte `coverage.xml` y el directorio `htmlcov/` (verificable desde los
-   artefactos del job).
+2. **Publica cobertura y bloquea regresiones de `/Cotizacion`.** Corre `pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=html --cov-report=xml`
+   y confirma que el pipeline adjunte `coverage.xml` y el directorio `htmlcov/`, incluyendo los módulos
+   vinculados al endpoint de cotizaciones dentro del reporte.
 3. **Audita importaciones legacy.** Incluye un paso que ejecute `rg "infrastructure\.iol\.legacy" application controllers services tests`
    y falla el job si aparecen coincidencias fuera de `tests/legacy/`.
 4. **Valida exportaciones.** Ejecuta `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
@@ -155,7 +149,7 @@ validar escenarios sin depender de módulos obsoletos.
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
    presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 
-### Validaciones Markowitz reforzadas (0.3.30.3)
+### Validaciones Markowitz reforzadas (0.3.30.4)
 
 - `application.risk_service.markowitz_optimize` valida la invertibilidad de la matriz de covarianzas y
   degrada a pesos `NaN` cuando detecta singularidad o entradas inválidas, evitando excepciones en la UI
@@ -170,7 +164,7 @@ validar escenarios sin depender de módulos obsoletos.
   y `tests/integration/test_portfolio_tabs.py` cubren la degradación controlada y los mensajes visibles
   en la UI, por lo que cualquier regresión se detecta en pipelines.
 
-**Resiliencia de APIs (0.3.30.3).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.30.4).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening y la procedencia (`primario`, `secundario`, `snapshot`). Al
 relanzarlo, la telemetría agrega la procedencia del dato y clasifica la recuperación según la estrategia
 aplicada:
@@ -184,15 +178,16 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos.
 
-Estas novedades convierten a la release 0.3.30.3 en la referencia para validar onboarding, telemetría y
-resiliencia multi-API: toda la UI recuerda la versión activa, expone KPIs agregados de disponibilidad y
-almacenamiento en el health sidebar y las exportaciones enriquecidas aseguran paridad total entre la
-visión en pantalla y los artefactos compartidos.
+Estas novedades convierten a la release 0.3.30.4 en la referencia para validar onboarding, telemetría y
+resiliencia multi-API: el endpoint `/Cotizacion` expone la versión activa desde la UI y las integraciones
+externas, el manejo de errores 500 asegura continuidad visible en dashboards y la prueba de cobertura
+protege el flujo frente a regresiones mientras las exportaciones enriquecidas mantienen paridad total
+entre la visión en pantalla y los artefactos compartidos.
 
 
 ## Configuración de claves API
 
-La release 0.3.30.3 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
+La release 0.3.30.4 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
 
@@ -233,7 +228,7 @@ en ``~/.portafolio_iol/favorites.json`` con la siguiente estructura:
 - Podés borrar el archivo para reiniciar la lista; se volverá a generar cuando agregues un nuevo
   favorito.
 
-## Backend de snapshots para pipelines CI (0.3.30.3)
+## Backend de snapshots para pipelines CI (0.3.30.4)
 
 - Define `SNAPSHOT_BACKEND=null` para ejecutar suites sin escribir archivos persistentes; el módulo
   `services.snapshots` usará `NullSnapshotStorage` y evitará cualquier escritura en disco durante las
@@ -369,7 +364,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.30.3)
+##### Escenarios de fallback macro (0.3.30.4)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -518,11 +513,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.3".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.4".
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.3)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.4)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,12 +51,13 @@ result = monte_carlo_simulation(
 De esta manera cada test controla explícitamente la semilla sin depender de `numpy.random.seed`, y
 los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralelo.
 
-## CI Checklist (0.3.30.3)
+## CI Checklist (0.3.30.4)
 
 1. **Suite determinista sin legacy.** Ejecuta `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy` y
    verifica que el resumen final no recolecte casos desde `tests/legacy/`.
-2. **Cobertura obligatoria.** Corre `pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=html --cov-report=xml`
-   y asegúrate de subir `coverage.xml` y el directorio `htmlcov/` como artefactos del job.
+2. **Cobertura obligatoria con foco en `/Cotizacion`.** Corre `pytest --cov=application --cov=controllers --cov-report=term-missing --cov-report=html --cov-report=xml`
+   y asegúrate de subir `coverage.xml` y el directorio `htmlcov/` como artefactos del job, revisando que
+   las rutas del endpoint de cotizaciones queden dentro del reporte.
 3. **Auditoría de importaciones legacy.** Añade un paso que ejecute
    `rg "infrastructure\.iol\.legacy" application controllers services tests` y marque el pipeline como
    fallido si aparecen coincidencias fuera de `tests/legacy/` o de fixtures destinados a compatibilidad.
@@ -115,9 +116,10 @@ frecuentes:
 
 ### Validación de snapshots y almacenamiento persistente
 
-La release 0.3.30.3, enfocada en limpiar duplicados y completar la migración fuera de legacy,
-refuerza los contadores de snapshots, la telemetría de almacenamiento y la verificación de artefactos
-en pipelines. Para cubrirlos en QA
+La release 0.3.30.4, centrada en publicar el endpoint `/Cotizacion`, reforzar los manejos de errores 500
+y sostener la cobertura obligatoria, mantiene el foco en limpiar duplicados y completar la migración
+fuera de legacy. Refuerza los contadores de snapshots, la telemetría de almacenamiento y la verificación
+de artefactos en pipelines. Para cubrirlos en QA
 combina pruebas automáticas y verificaciones manuales:
 
 - `pytest tests/test_sidebar_controls.py -k snapshot`: comprueba que los presets persistan en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.30.3"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.4"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.30.3"
+DEFAULT_VERSION: str = "0.3.30.4"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project metadata and shared version helper to 0.3.30.4
- add the 0.3.30.4 entry to the changelog covering the new endpoint, 500 handling, and coverage test
- refresh README and testing/troubleshooting guides so the new release and its resilience focus are highlighted

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e19d2beb748332965fbac57410760a