### PR TITLE
Introduce shared legacy IOL session with fallback telemetry

### DIFF
--- a/infrastructure/iol/client.py
+++ b/infrastructure/iol/client.py
@@ -5,7 +5,6 @@ import json
 import logging
 import threading
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import Any, Dict, Iterable, Optional, Tuple
 
@@ -22,6 +21,7 @@ from shared.utils import _to_float
 from .auth import IOLAuth
 from .ports import IIOLProvider
 from services.health import record_quote_provider_usage
+from infrastructure.iol.legacy.session import LegacySession
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +68,8 @@ class IOLClient(IIOLProvider):
         self.iol_market: Optional[Iol] = None
         self._market_ready = False
         self._market_lock = threading.RLock()
+        self._quotes_lock = threading.RLock()
+        self._legacy_session = LegacySession.get()
         self._ensure_market_auth()
 
         safe_user = f"{self.user[:3]}***" if self.user else ""
@@ -462,133 +464,152 @@ class IOLClient(IIOLProvider):
         url = f"{base_url}/marketdata/{resolved_market}/{resolved_symbol}"
         url = f"{url}/{panel}" if panel else f"{url}/Cotizacion"
 
+        transitions = ["v2"]
+        start = time.time()
+        response: Optional[requests.Response] = None
+        v2_error: Exception | None = None
+
         try:
             response = self._request("GET", url)
-            if response is None:
-                logger.warning(
-                    "get_quote sin respuesta %s:%s (%s)",
-                    resolved_market,
-                    resolved_symbol,
-                    "response=None",
-                )
-                logger.info(
-                    "get_quote fallback -> legacy %s:%s",
-                    resolved_market,
-                    resolved_symbol,
-                )
-                legacy_payload = self._legacy_quote_fallback(
-                    resolved_market, resolved_symbol, panel
-                )
-                if legacy_payload is not None:
-                    provider_name = legacy_payload.get("provider") or "legacy"
-                    if legacy_payload.get("provider") is None:
-                        legacy_payload["provider"] = "legacy"
-                    record_quote_provider_usage(
-                        provider_name,
-                        elapsed_ms=None,
-                        stale=legacy_payload.get("last") is None,
-                        source="legacy",
-                    )
-                    return legacy_payload
-                record_quote_provider_usage(
-                    "legacy",
-                    elapsed_ms=None,
-                    stale=True,
-                    source="legacy",
-                )
-                fallback = self._fallback_quote_via_ohlc(
-                    resolved_market, resolved_symbol, panel=panel
-                )
-                if fallback is not None:
-                    return fallback
-                return {"last": None, "chg_pct": None, "asof": None, "provider": "stale"}
-            raise_for_status = getattr(response, "raise_for_status", None)
-            if callable(raise_for_status):
-                raise_for_status()
         except InvalidCredentialsError:
             raise
-        except requests.HTTPError as exc:
-            status_code = exc.response.status_code if exc.response is not None else None
-            if status_code == 500:
-                logger.warning("IOL 500 → omitiendo símbolo %s:%s", resolved_market, resolved_symbol)
-                try:
-                    from infrastructure.iol.legacy.iol_client import IOLClient as LegacyIOLClient
-
-                    legacy_client = LegacyIOLClient(
-                        self.user,
-                        self.password,
-                        tokens_file=getattr(self.auth, "tokens_path", None),
-                        auth=self.auth,
-                    )
-                    return legacy_client.get_quote(
-                        market=resolved_market,
-                        symbol=resolved_symbol,
-                        panel=panel,
-                    )
-                except Exception as fallback_exc:  # pragma: no cover - defensive guard
-                    logger.error(
-                        "Fallback legacy IOLClient.get_quote falló %s:%s -> %s",
-                        resolved_market,
-                        resolved_symbol,
-                        fallback_exc,
-                        exc_info=True,
-                    )
-                    fallback = self._fallback_quote_via_ohlc(
-                        resolved_market, resolved_symbol, panel=panel
-                    )
-                    if fallback is not None:
-                        return fallback
-                    return {
-                        "last": None,
-                        "chg_pct": None,
-                        "asof": None,
-                        "provider": "stale",
-                    }
-            raise
         except Exception as exc:  # pragma: no cover - defensive guard
-            logger.warning(
-                "get_quote sin respuesta %s:%s (%s)",
+            v2_error = exc
+
+        if response is not None:
+            status_code = getattr(response, "status_code", "n/a")
+            logger.debug("IOLClient.get_quote -> %s [%s]", url, status_code)
+            try:
+                data = response.json() or {}
+            except ValueError as exc:
+                v2_error = exc
+            else:
+                payload = self._normalize_quote_payload(data)
+                if payload.get("provider") is None:
+                    payload["provider"] = "iol"
+                elapsed_ms = (time.time() - start) * 1000.0
+                provider_name = payload.get("provider") or "iol"
+                record_quote_provider_usage(
+                    provider_name,
+                    elapsed_ms=elapsed_ms if payload.get("last") is not None else None,
+                    stale=payload.get("last") is None,
+                    source="v2",
+                )
+                return payload
+
+        if v2_error is None:
+            v2_error = RuntimeError("empty-response")
+
+        record_quote_provider_usage(
+            "iol",
+            elapsed_ms=None,
+            stale=True,
+            source="v2-error",
+        )
+        transitions.append("legacy")
+        logger.info(
+            "Quote fallback transition: %s for %s:%s -> %s",
+            " -> ".join(transitions[-2:]),
+            resolved_market,
+            resolved_symbol,
+            v2_error,
+        )
+
+        legacy_payload, legacy_flags = self._legacy_quote_fallback(
+            resolved_market, resolved_symbol, panel
+        )
+        legacy_auth_unavailable = bool(legacy_flags.get("legacy_auth_unavailable"))
+        legacy_provider = (
+            legacy_payload.get("provider")
+            if isinstance(legacy_payload, dict)
+            else "legacy"
+        ) or "legacy"
+
+        if (
+            legacy_payload is not None
+            and not legacy_auth_unavailable
+            and legacy_payload.get("last") is not None
+        ):
+            record_quote_provider_usage(
+                legacy_provider,
+                elapsed_ms=None,
+                stale=False,
+                source="v2->legacy",
+            )
+            logger.info(
+                "Quote fallback chain resolved: %s for %s:%s",
+                " -> ".join(transitions),
                 resolved_market,
                 resolved_symbol,
-                exc,
             )
-            fallback = self._fallback_quote_via_ohlc(
-                resolved_market, resolved_symbol, panel=panel
+            return legacy_payload
+
+        record_quote_provider_usage(
+            legacy_provider,
+            elapsed_ms=None,
+            stale=True,
+            source="v2->legacy",
+        )
+
+        transitions.append("ohlc")
+        logger.info(
+            "Quote fallback transition: %s for %s:%s",
+            " -> ".join(transitions[-2:]),
+            resolved_market,
+            resolved_symbol,
+        )
+        fallback = self._fallback_quote_via_ohlc(
+            resolved_market, resolved_symbol, panel=panel
+        )
+        if fallback is not None:
+            if legacy_auth_unavailable:
+                fallback = dict(fallback)
+                fallback["legacy_auth_unavailable"] = True
+            provider = fallback.get("provider") or "ohlc"
+            record_quote_provider_usage(
+                provider,
+                elapsed_ms=None,
+                stale=fallback.get("last") is None,
+                source="legacy->ohlc",
             )
-            if fallback is not None:
-                return fallback
-            return {"last": None, "chg_pct": None, "asof": None, "provider": "stale"}
-
-        status_code = getattr(response, "status_code", "n/a")
-        logger.debug("IOLClient.get_quote -> %s [%s]", url, status_code)
-
-        try:
-            data = response.json() or {}
-        except ValueError as exc:
-            logger.warning(
-                "get_quote sin respuesta %s:%s (%s)",
+            logger.info(
+                "Quote fallback chain resolved: %s for %s:%s",
+                " -> ".join(transitions),
                 resolved_market,
                 resolved_symbol,
-                exc,
             )
-            fallback = self._fallback_quote_via_ohlc(
-                resolved_market, resolved_symbol, panel=panel
-            )
-            if fallback is not None:
-                return fallback
-            return {"last": None, "chg_pct": None, "asof": None, "provider": "stale"}
+            return fallback
 
-        payload = self._normalize_quote_payload(data)
-        if payload.get("provider") is None:
-            payload["provider"] = "iol"
-        return payload
+        transitions.append("stale")
+        stale_payload: Dict[str, Optional[float]] = {
+            "last": None,
+            "chg_pct": None,
+            "asof": None,
+            "provider": "stale",
+        }
+        if legacy_auth_unavailable:
+            stale_payload["legacy_auth_unavailable"] = True
+        record_quote_provider_usage(
+            "stale",
+            elapsed_ms=None,
+            stale=True,
+            source="ohlc->stale",
+        )
+        logger.info(
+            "Quote fallback chain resolved: %s for %s:%s",
+            " -> ".join(transitions),
+            resolved_market,
+            resolved_symbol,
+        )
+        return stale_payload
 
     def _legacy_quote_fallback(
         self,
         resolved_market: str,
         resolved_symbol: str,
         panel: str | None,
-    ) -> Optional[Dict[str, Optional[float]]]:
+    ) -> tuple[Optional[Dict[str, Optional[float]]], Dict[str, bool]]:
+        flags: Dict[str, bool] = {}
         try:
             from infrastructure.iol.legacy.iol_client import IOLClient as LegacyIOLClient
 
@@ -613,7 +634,7 @@ class IOLClient(IIOLProvider):
                 resolved_symbol,
                 status or http_exc,
             )
-            return None
+            return None, flags
         except requests.RequestException as req_exc:
             logger.warning(
                 "Legacy IOLClient.get_quote request error %s:%s -> %s",
@@ -621,7 +642,7 @@ class IOLClient(IIOLProvider):
                 resolved_symbol,
                 req_exc,
             )
-            return None
+            return None, flags
         except Exception as fallback_exc:  # pragma: no cover - defensive guard
             logger.error(
                 "Fallback legacy IOLClient.get_quote falló %s:%s -> %s",
@@ -630,14 +651,16 @@ class IOLClient(IIOLProvider):
                 fallback_exc,
                 exc_info=True,
             )
-            return None
+            return None, flags
 
         if not isinstance(payload, dict):
-            return None
+            return None, flags
 
         normalized = dict(payload)
+        if normalized.get("legacy_auth_unavailable"):
+            flags["legacy_auth_unavailable"] = True
         normalized.setdefault("provider", "legacy")
-        return normalized
+        return normalized, flags
 
     def get_quotes_bulk(
         self,
@@ -673,31 +696,16 @@ class IOLClient(IIOLProvider):
         self._ensure_market_auth()
 
         result: Dict[Tuple[str, str], Dict[str, Optional[float]]] = {}
-        workers = min(max_workers, max(1, len(requests)))
-        with ThreadPoolExecutor(max_workers=workers) as executor:
-            future_map = {
-                executor.submit(self.get_quote, market, symbol, panel): (market, symbol)
-                for market, symbol, panel in requests
-            }
-            for future in as_completed(future_map):
-                key = future_map[future]
+        with self._quotes_lock:
+            for market, symbol, panel in requests:
                 try:
-                    payload = future.result()
-                    if payload is None:
-                        payload = {"last": None, "chg_pct": None}
-                    result[key] = payload
-                except requests.HTTPError as exc:
-                    response = exc.response
-                    if response is not None and response.status_code == 500:
-                        market, symbol = key
-                        logger.warning(
-                            "IOL 500 → omitiendo símbolo %s:%s", market, symbol
-                        )
-                        continue
-                    raise
+                    payload = self.get_quote(market, symbol, panel)
                 except Exception as exc:  # pragma: no cover - defensive guard
-                    logger.warning("get_quotes_bulk %s:%s error -> %s", key[0], key[1], exc)
-                    result[key] = {"last": None, "chg_pct": None}
+                    logger.warning("get_quotes_bulk %s:%s error -> %s", market, symbol, exc)
+                    payload = {"last": None, "chg_pct": None}
+                if payload is None:
+                    payload = {"last": None, "chg_pct": None}
+                result[(market, symbol)] = payload
         return result
 
 

--- a/infrastructure/iol/legacy/session.py
+++ b/infrastructure/iol/legacy/session.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import logging
+import threading
+import time
+import random
+from typing import Optional
+
+import streamlit as st
+import requests
+from iolConn import Iol
+from iolConn.common.exceptions import NoAuthException
+
+from shared.time_provider import TimeProvider
+from shared.errors import InvalidCredentialsError
+
+logger = logging.getLogger(__name__)
+
+
+class LegacySession:
+    """Singleton that provides a shared authenticated legacy ``Iol`` session."""
+
+    _instance: "LegacySession" | None = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._iol: Optional[Iol] = None
+        self._ready = False
+        self._user: str | None = None
+        self._password: str | None = None
+        self._legacy_auth_unavailable = False
+        self._tokens_snapshot: tuple[str | None, str | None] | None = None
+
+    # ------------------------------------------------------------------
+    # Singleton helpers
+    # ------------------------------------------------------------------
+    @classmethod
+    def get(cls) -> "LegacySession":
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+    def is_auth_unavailable(self) -> bool:
+        with self._lock:
+            return self._legacy_auth_unavailable
+
+    def invalidate(self) -> None:
+        with self._lock:
+            self._iol = None
+            self._ready = False
+
+    def ensure_authenticated(self, user: str, password: str, auth) -> Optional[Iol]:
+        """Return a shared authenticated ``Iol`` instance or ``None`` if auth fails."""
+
+        norm_user = (user or "").strip()
+        norm_password = (password or "").strip()
+        tokens = getattr(auth, "tokens", {}) if auth is not None else {}
+        bearer = tokens.get("access_token") if isinstance(tokens, dict) else None
+        refresh = tokens.get("refresh_token") if isinstance(tokens, dict) else None
+        tokens_snapshot = (str(bearer) if bearer else None, str(refresh) if refresh else None)
+
+        with self._lock:
+            creds_changed = (self._user, self._password) != (norm_user, norm_password)
+            tokens_changed = self._tokens_snapshot != tokens_snapshot
+            if creds_changed or tokens_changed:
+                self._ready = False
+                self._iol = None
+
+            if self._ready and self._iol is not None:
+                return self._iol
+
+            try:
+                session = self._build_session(norm_user, norm_password, bearer, refresh)
+                self._iol = session
+                self._ready = True
+                self._user = norm_user
+                self._password = norm_password
+                self._tokens_snapshot = tokens_snapshot
+                self._legacy_auth_unavailable = False
+                st.session_state.pop("legacy_auth_unavailable", None)
+                return self._iol
+            except InvalidCredentialsError:
+                self._mark_auth_unavailable()
+                return None
+            except NoAuthException as exc:
+                logger.warning("Legacy IOL auth failed: %s", exc)
+                self._mark_auth_unavailable()
+                return None
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _mark_auth_unavailable(self) -> None:
+        self._ready = False
+        self._iol = None
+        self._legacy_auth_unavailable = True
+        st.session_state["legacy_auth_unavailable"] = True
+
+    def _build_session(
+        self,
+        user: str,
+        password: str,
+        bearer: str | None,
+        refresh: str | None,
+    ) -> Iol:
+        session = Iol(user, password)
+        if bearer and refresh:
+            session.bearer = bearer
+            session.refresh_token = refresh
+            bearer_time = TimeProvider.now_datetime().replace(tzinfo=None)
+            session.bearer_time = bearer_time
+        elif not password:
+            st.session_state["force_login"] = True
+            raise InvalidCredentialsError("Token inválido")
+
+        try:
+            session.gestionar()
+            return session
+        except NoAuthException:
+            if not password:
+                st.session_state["force_login"] = True
+                raise InvalidCredentialsError("Token inválido")
+
+        password_session = Iol(user, password)
+        try:
+            password_session.gestionar()
+        except NoAuthException:
+            st.session_state["force_login"] = True
+            raise InvalidCredentialsError("Credenciales inválidas")
+
+        return password_session
+
+    def fetch_with_backoff(
+        self,
+        market: str,
+        symbol: str,
+        *,
+        panel: str | None = None,
+        auth_user: str,
+        auth_password: str,
+        auth,
+    ) -> tuple[Optional[dict], bool]:
+        """Fetch quote data handling retries for HTTP 429."""
+
+        session = self.ensure_authenticated(auth_user, auth_password, auth)
+        if session is None:
+            return None, True
+
+        delays = (0.5, 1.0, 2.0)
+        last_exc: Exception | None = None
+        for attempt, base_delay in enumerate(delays):
+            try:
+                data = session.price_to_json(mercado=market, simbolo=symbol, panel=panel)
+                return data if isinstance(data, dict) else None, False
+            except NoAuthException:
+                self.invalidate()
+                session = self.ensure_authenticated(auth_user, auth_password, auth)
+                if session is None:
+                    return None, True
+            except requests.HTTPError as exc:
+                last_exc = exc
+                status_code = exc.response.status_code if exc.response is not None else None
+                if status_code == 429 and attempt < len(delays) - 1:
+                    wait = base_delay + random.uniform(0, base_delay)
+                    time.sleep(wait)
+                    continue
+                raise
+            except requests.RequestException as exc:
+                last_exc = exc
+                raise
+
+        if last_exc:
+            raise last_exc
+        return None, False
+
+
+__all__ = ["LegacySession"]


### PR DESCRIPTION
## Summary
- add a shared `LegacySession` helper to cache authenticated iolConn sessions and flag legacy auth failures
- refactor the legacy market client to reuse the shared session, retry on HTTP 429 with jitter, and surface auth degradation flags
- update the primary IOL client to log fallback chains, serialize bulk quote access, and propagate fallback metrics/flags through legacy/OHLC/stale paths

## Testing
- python -m compileall infrastructure/iol
- pytest --override-ini addopts="" tests/infrastructure/test_iol_fallbacks.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c71a31408332a5987d312e4ae5b4