### PR TITLE
Enhance quote telemetry metrics and logging

### DIFF
--- a/services/health.py
+++ b/services/health.py
@@ -785,12 +785,45 @@ def record_quote_load(
 ) -> None:
     """Persist response time and source for the latest quote load."""
     store = _store()
-    store["quotes"] = {
+    summary: Dict[str, Any] = {
         "elapsed_ms": float(elapsed_ms) if elapsed_ms is not None else None,
         "source": source,
         "count": int(count) if count is not None else None,
         "ts": time.time(),
     }
+
+    total_attempts = _as_optional_int(store.get("quotes_total"))
+    if total_attempts is not None:
+        summary["total"] = total_attempts
+
+    ok_attempts = _as_optional_int(store.get("quotes_ok"))
+    if ok_attempts is not None:
+        summary["ok"] = ok_attempts
+        if total_attempts:
+            summary["ok_ratio"] = ok_attempts / total_attempts
+
+    http_counters_raw = store.get("quote_http_counters")
+    if isinstance(http_counters_raw, Mapping):
+        counters: Dict[str, int] = {}
+        for key, value in http_counters_raw.items():
+            numeric = _as_optional_int(value)
+            if numeric is None or numeric <= 0:
+                continue
+            counters[str(key)] = numeric
+        if counters:
+            summary["http_counters"] = counters
+
+    by_provider_raw = store.get("quotes_by_provider")
+    if isinstance(by_provider_raw, Mapping):
+        provider_summary: Dict[str, Any] = {}
+        for key, value in by_provider_raw.items():
+            if not isinstance(value, Mapping):
+                continue
+            provider_summary[str(key)] = dict(value)
+        if provider_summary:
+            summary["by_provider"] = provider_summary
+
+    store["quotes"] = summary
 
 
 def record_quote_provider_usage(
@@ -799,6 +832,8 @@ def record_quote_provider_usage(
     elapsed_ms: Optional[float],
     stale: bool,
     source: Optional[str] = None,
+    http_status: Optional[str] = None,
+    ok: Optional[bool] = None,
 ) -> None:
     """Track per-provider latency and usage statistics for quotes."""
 
@@ -819,6 +854,9 @@ def record_quote_provider_usage(
 
     entry["provider"] = provider_key
     entry["label"] = _PROVIDER_LABELS.get(provider_key, provider_label)
+    total_prev = _as_optional_int(store.get("quotes_total")) or 0
+    store["quotes_total"] = total_prev + 1
+
     entry["count"] = int(entry.get("count", 0) or 0) + 1
     if stale:
         entry["stale_count"] = int(entry.get("stale_count", 0) or 0) + 1
@@ -833,23 +871,76 @@ def record_quote_provider_usage(
     now = time.time()
     entry["ts"] = now
 
+    ok_flag = bool(ok) if ok is not None else (not stale and elapsed_ms is not None)
+    if ok_flag:
+        entry["ok_count"] = int(entry.get("ok_count", 0) or 0) + 1
+    entry["ok_last"] = ok_flag
+
+    ok_prev = _as_optional_int(store.get("quotes_ok")) or 0
+    if ok_flag:
+        store["quotes_ok"] = ok_prev + 1
+    else:
+        store.setdefault("quotes_ok", ok_prev)
+
     if elapsed_ms is not None:
         elapsed_value = float(elapsed_ms)
         history_raw = entry.get("elapsed_history")
-        history: list[float] = []
-        if isinstance(history_raw, Iterable) and not isinstance(
-            history_raw, (str, bytes, bytearray)
-        ):
-            for value in history_raw:
-                numeric = _as_optional_float(value)
-                if numeric is not None:
-                    history.append(numeric)
+        history = _ensure_latency_history(history_raw, limit=_QUOTE_PROVIDER_HISTORY_LIMIT)
         history.append(elapsed_value)
-        entry["elapsed_history"] = history[-_QUOTE_PROVIDER_HISTORY_LIMIT:]
+        samples = list(history)
+        entry["elapsed_history"] = samples
         entry["elapsed_last"] = elapsed_value
+
+        percentiles = _compute_percentiles(samples, (0.5, 0.95)) if samples else {}
+        if percentiles:
+            p50 = percentiles.get("p50")
+            p95 = percentiles.get("p95")
+            if p50 is not None:
+                entry["p50_ms"] = float(p50)
+            if p95 is not None:
+                entry["p95_ms"] = float(p95)
+        else:
+            entry.pop("p50_ms", None)
+            entry.pop("p95_ms", None)
+    else:
+        entry.pop("elapsed_last", None)
+
+    if http_status:
+        status_key = str(http_status).strip()
+        if status_key:
+            http_raw = store.get("quote_http_counters")
+            if isinstance(http_raw, Mapping):
+                counters = dict(http_raw)
+            else:
+                counters = {}
+            current = _as_optional_int(counters.get(status_key)) or 0
+            counters[status_key] = current + 1
+            store["quote_http_counters"] = counters
+    else:
+        store.setdefault("quote_http_counters", store.get("quote_http_counters", {}))
 
     providers[provider_key] = entry
     store["quote_providers"] = providers
+
+    by_provider_raw = store.get("quotes_by_provider")
+    if isinstance(by_provider_raw, Mapping):
+        by_provider = dict(by_provider_raw)
+    else:
+        by_provider = {}
+
+    provider_summary: Dict[str, Any] = {
+        "provider": provider_key,
+        "label": entry["label"],
+        "total": int(entry.get("count", 0) or 0),
+        "ok": int(entry.get("ok_count", 0) or 0),
+        "stale": int(entry.get("stale_count", 0) or 0),
+    }
+    if "p50_ms" in entry:
+        provider_summary["p50_ms"] = entry["p50_ms"]
+    if "p95_ms" in entry:
+        provider_summary["p95_ms"] = entry["p95_ms"]
+    by_provider[provider_key] = provider_summary
+    store["quotes_by_provider"] = by_provider
 
 
 def _as_optional_int(value: Any) -> Optional[int]:
@@ -1555,6 +1646,7 @@ def get_health_metrics() -> Dict[str, Any]:
         providers: list[Dict[str, Any]] = []
         total_count = 0
         stale_total = 0
+        ok_total = 0
 
         for key, entry in raw_providers.items():
             if not isinstance(entry, Mapping):
@@ -1567,6 +1659,8 @@ def get_health_metrics() -> Dict[str, Any]:
             stale_count = _as_optional_int(entry.get("stale_count")) or 0
             total_count += count
             stale_total += max(stale_count, 0)
+            ok_count = _as_optional_int(entry.get("ok_count")) or 0
+            ok_total += max(ok_count, 0)
 
             label = str(entry.get("label") or entry.get("provider") or key)
 
@@ -1583,6 +1677,7 @@ def get_health_metrics() -> Dict[str, Any]:
             avg_ms: Optional[float] = None
             if latencies:
                 avg_ms = sum(latencies) / len(latencies)
+            percentiles = _compute_percentiles(latencies, (0.5, 0.95)) if latencies else {}
 
             provider_summary: Dict[str, Any] = {
                 "provider": str(key),
@@ -1591,12 +1686,22 @@ def get_health_metrics() -> Dict[str, Any]:
             }
             if stale_count:
                 provider_summary["stale_count"] = stale_count
+            if ok_count:
+                provider_summary["ok_count"] = ok_count
+                provider_summary["ok_ratio"] = ok_count / count if count else 0.0
 
             last_ms = _as_optional_float(entry.get("elapsed_last"))
             if avg_ms is not None:
                 provider_summary["avg_ms"] = avg_ms
             if last_ms is not None:
                 provider_summary["last_ms"] = last_ms
+            if percentiles:
+                p50 = percentiles.get("p50")
+                p95 = percentiles.get("p95")
+                if p50 is not None:
+                    provider_summary["p50_ms"] = float(p50)
+                if p95 is not None:
+                    provider_summary["p95_ms"] = float(p95)
 
             ts_value = _as_optional_float(entry.get("ts"))
             if ts_value is not None:
@@ -1615,9 +1720,37 @@ def get_health_metrics() -> Dict[str, Any]:
             return {}
 
         providers.sort(key=lambda item: str(item.get("label", "")).casefold())
-        summary = {"providers": providers, "total": total_count}
+        summary_total = _as_optional_int(store.get("quotes_total")) or total_count
+        summary: Dict[str, Any] = {"providers": providers, "total": summary_total}
         if stale_total:
             summary["stale_total"] = stale_total
+
+        ok_store = _as_optional_int(store.get("quotes_ok"))
+        effective_ok = ok_store if ok_store is not None else ok_total
+        if effective_ok:
+            summary["ok_total"] = effective_ok
+            summary["ok_ratio"] = effective_ok / summary_total if summary_total else 0.0
+
+        http_raw = store.get("quote_http_counters")
+        if isinstance(http_raw, Mapping):
+            http_counts: Dict[str, int] = {}
+            for name, value in http_raw.items():
+                numeric = _as_optional_int(value)
+                if numeric is None or numeric <= 0:
+                    continue
+                http_counts[str(name)] = numeric
+            if http_counts:
+                summary["http_counters"] = http_counts
+
+        by_provider_raw = store.get("quotes_by_provider")
+        if isinstance(by_provider_raw, Mapping):
+            by_provider: Dict[str, Any] = {}
+            for name, value in by_provider_raw.items():
+                if not isinstance(value, Mapping):
+                    continue
+                by_provider[str(name)] = dict(value)
+            if by_provider:
+                summary["by_provider"] = by_provider
         return summary
 
     def _summarize_adapter_fallbacks(raw_data: Any) -> Dict[str, Any]:

--- a/tests/ui/test_health_sidebar.py
+++ b/tests/ui/test_health_sidebar.py
@@ -48,14 +48,24 @@ def test_render_health_sidebar_with_success_metrics(health_sidebar) -> None:
         },
         "quote_providers": {
             "total": 6,
+            "ok_total": 5,
+            "ok_ratio": 5 / 6,
             "stale_total": 1,
+            "http_counters": {
+                "legacy_429": 2,
+                "legacy_auth_fail": 1,
+            },
             "providers": [
                 {
                     "provider": "iol",
                     "label": "IOL v2",
                     "count": 4,
+                    "ok_count": 4,
+                    "ok_ratio": 1.0,
                     "avg_ms": 120.0,
                     "last_ms": 100.0,
+                    "p50_ms": 110.0,
+                    "p95_ms": 180.0,
                     "ts": 7.0,
                     "source": "live",
                 },
@@ -63,9 +73,13 @@ def test_render_health_sidebar_with_success_metrics(health_sidebar) -> None:
                     "provider": "av",
                     "label": "Alpha Vantage",
                     "count": 2,
+                    "ok_count": 1,
+                    "ok_ratio": 0.5,
                     "stale_count": 1,
                     "avg_ms": 450.0,
                     "last_ms": 480.0,
+                    "p50_ms": 430.0,
+                    "p95_ms": 500.0,
                     "ts": 8.0,
                     "source": "fallback",
                     "stale_last": True,
@@ -172,6 +186,9 @@ def test_render_health_sidebar_with_success_metrics(health_sidebar) -> None:
     assert any("Uso de caché" in text for text in markdown_calls)
     assert any("💹 Cotizaciones" in text for text in markdown_calls)
     assert any("Total 6" in text for text in markdown_calls)
+    assert any("OK 5/6" in text for text in markdown_calls)
+    assert any("Legacy rate-limit 429" in text for text in markdown_calls)
+    assert any("Legacy auth fallida" in text for text in markdown_calls)
     assert any("Portafolio" in text and "200" in text for text in markdown_calls)
     assert any("Cotizaciones" in text and "350" in text for text in markdown_calls)
     assert any("Observabilidad" in text for text in markdown_calls)

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -419,12 +419,31 @@ def _format_quote_providers(data: Optional[Mapping[str, Any]]) -> Iterable[str]:
 
     total_val = data.get("total")
     total_int = int(total_val) if isinstance(total_val, (int, float)) else None
+    ok_val = data.get("ok_total")
+    ok_int = int(ok_val) if isinstance(ok_val, (int, float)) else None
+    ok_ratio = data.get("ok_ratio") if isinstance(data.get("ok_ratio"), (int, float)) else None
     stale_total_val = data.get("stale_total")
     stale_total = int(stale_total_val) if isinstance(stale_total_val, (int, float)) else 0
+    http_counters = {}
+    raw_counters = data.get("http_counters")
+    if isinstance(raw_counters, Mapping):
+        for key, value in raw_counters.items():
+            try:
+                numeric = int(value)
+            except (TypeError, ValueError):
+                continue
+            if numeric <= 0:
+                continue
+            http_counters[str(key)] = numeric
 
     header_parts: list[str] = []
     if total_int is not None:
         header_parts.append(f"Total {total_int}")
+    if ok_int is not None and total_int:
+        if ok_ratio is not None:
+            header_parts.append(f"OK {ok_int}/{total_int} ({ok_ratio:.0%})")
+        else:
+            header_parts.append(f"OK {ok_int}/{total_int}")
     if stale_total:
         header_parts.append(f"Stale {stale_total}")
 
@@ -432,14 +451,31 @@ def _format_quote_providers(data: Optional[Mapping[str, Any]]) -> Iterable[str]:
     if header_parts:
         lines.append(format_note("📊 " + " • ".join(header_parts)))
 
+    if http_counters:
+        iol_500 = http_counters.get("iolv2_500", 0)
+        legacy_429 = http_counters.get("legacy_429", 0)
+        legacy_auth = http_counters.get("legacy_auth_fail", 0)
+        if iol_500:
+            lines.append(format_note(f"⚠️ IOL v2 HTTP 500: {iol_500}"))
+        if legacy_429:
+            lines.append(format_note(f"🚦 Legacy rate-limit 429: {legacy_429}"))
+        if legacy_auth:
+            lines.append(format_note(f"🔐 Legacy auth fallida: {legacy_auth}"))
+
     for entry in entries:
         label = _sanitize_text(entry.get("label")) or str(entry.get("provider") or "desconocido")
         count_val = entry.get("count")
         count_int = int(count_val) if isinstance(count_val, (int, float)) else 0
         stale_count_val = entry.get("stale_count")
         stale_count = int(stale_count_val) if isinstance(stale_count_val, (int, float)) else 0
+        ok_count_val = entry.get("ok_count")
+        ok_count = int(ok_count_val) if isinstance(ok_count_val, (int, float)) else 0
+        ok_ratio_val = entry.get("ok_ratio")
+        ok_ratio = float(ok_ratio_val) if isinstance(ok_ratio_val, (int, float)) else None
         avg_ms = entry.get("avg_ms")
         last_ms = entry.get("last_ms")
+        p50_ms = entry.get("p50_ms")
+        p95_ms = entry.get("p95_ms")
         ts_value = entry.get("ts") if isinstance(entry.get("ts"), (int, float)) else None
         ts_text = _format_timestamp(ts_value)
         source_text = _sanitize_text(entry.get("source"))
@@ -452,10 +488,19 @@ def _format_quote_providers(data: Optional[Mapping[str, Any]]) -> Iterable[str]:
         parts = [f"{icon} {label}: {count_int} consultas"]
         if stale_count:
             parts.append(f"stale {stale_count}")
+        if ok_count:
+            if ok_ratio is not None:
+                parts.append(f"OK {ok_count}/{count_int} ({ok_ratio:.0%})")
+            else:
+                parts.append(f"OK {ok_count}/{count_int}")
         if isinstance(avg_ms, (int, float)):
             parts.append(f"prom. {float(avg_ms):.0f} ms")
         if isinstance(last_ms, (int, float)):
             parts.append(f"último {float(last_ms):.0f} ms")
+        if isinstance(p50_ms, (int, float)):
+            parts.append(f"p50 {float(p50_ms):.0f} ms")
+        if isinstance(p95_ms, (int, float)):
+            parts.append(f"p95 {float(p95_ms):.0f} ms")
         if source_text:
             parts.append(f"fuente: {source_text}")
         parts.append(ts_text)


### PR DESCRIPTION
## Summary
- capture aggregate quote totals, per-provider success rates, latency percentiles, and HTTP error counters in the health metrics store
- surface the new quote statistics and rate-limit/authentication alerts in the health sidebar
- add structured quote logging in the IOL client with HTTP failure tracking for telemetry correlation

## Testing
- pytest tests/ui/test_health_sidebar.py tests/infrastructure/test_iol_fallbacks.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c71a8f3883329dd813611507484c