### PR TITLE
chore: release 0.3.30.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## [0.3.30.8] - 2025-10-06
+
+### Added
+- Sesiones legacy cacheadas para reutilizar credenciales válidas y reducir latencia al restaurar
+  contextos degradados.
+- Rate limiting integrado en los clientes de datos para proteger los umbrales de APIs externas y
+  evitar bloqueos al ejecutar pipelines intensivos.
+- Recuperación automática de valorizaciones recientes cuando la fuente primaria falla, garantizando
+  que la UI y los reportes mantengan cifras consistentes.
+
 ## [0.3.30.7] - 2025-10-05
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,16 +6,16 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.30.7)
+## Quick-start (release 0.3.30.8)
 
-La versión **0.3.30.7** consolida los fixes del fallback jerárquico introduciendo verificaciones
+La versión **0.3.30.8** consolida los fixes del fallback jerárquico introduciendo verificaciones
 escalonadas para los proveedores secundarios, corrigiendo la propagación del snapshot de contingencia y
 alineando los mensajes visibles en la UI. Mantiene intactos los pipelines de CI mientras bloquea las
 regresiones detectadas en los escenarios de degradación controlada.
 
-## Quick-start (release 0.3.30.7 — fallback jerárquico endurecido — 2025-10-05)
+## Quick-start (release 0.3.30.8 — fallback jerárquico endurecido — 2025-10-06)
 
-La versión **0.3.30.7** destaca cinco ejes principales:
+La versión **0.3.30.8** destaca cinco ejes principales:
 - El **endpoint `/Cotizacion`** sigue centralizando la obtención de precios normalizados y ahora marca
   explícitamente las respuestas provenientes del nuevo fallback endurecido.
 - El **manejo reforzado de errores 500** corrige las rutas que omitían el fallback secundario al
@@ -44,7 +44,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.7` junto con
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.8` junto con
    el timestamp generado por `TimeProvider`. Abre el panel **Salud del sistema**: además del estado de
    cada proveedor verás el bloque **Snapshots y almacenamiento**, que expone la ruta activa del disco,
    el contador de recuperaciones desde snapshot y la latencia agregada de escritura.
@@ -104,7 +104,7 @@ validar escenarios sin depender de módulos obsoletos.
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.30.7 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
+   release 0.3.30.8 conserva la última secuencia de degradación y ahora incluye el contador de snapshots
   reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
    `primario → secundario → snapshot` (o fallback estático si corresponde) con la marca temporal de cada
@@ -131,7 +131,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.30.7)
+### CI Checklist (0.3.30.8)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -148,7 +148,7 @@ validar escenarios sin depender de módulos obsoletos.
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
    presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 
-### Validaciones Markowitz reforzadas (0.3.30.7)
+### Validaciones Markowitz reforzadas (0.3.30.8)
 
 - `application.risk_service.markowitz_optimize` valida la invertibilidad de la matriz de covarianzas y
   degrada a pesos `NaN` cuando detecta singularidad o entradas inválidas, evitando excepciones en la UI
@@ -163,7 +163,7 @@ validar escenarios sin depender de módulos obsoletos.
   y `tests/integration/test_portfolio_tabs.py` cubren la degradación controlada y los mensajes visibles
   en la UI, por lo que cualquier regresión se detecta en pipelines.
 
-**Resiliencia de APIs (0.3.30.7).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.30.8).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening y la procedencia (`primario`, `secundario`, `snapshot`). Al
 relanzarlo, la telemetría agrega la procedencia del dato y clasifica la recuperación según la estrategia
 aplicada:
@@ -177,7 +177,7 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos.
 
-Estas novedades convierten a la release 0.3.30.7 en la referencia para validar onboarding, telemetría y
+Estas novedades convierten a la release 0.3.30.8 en la referencia para validar onboarding, telemetría y
 resiliencia multi-API: el endpoint `/Cotizacion` expone la versión activa desde la UI y las integraciones
 externas, el manejo de errores 500 asegura continuidad visible en dashboards y la prueba de cobertura
 protege el flujo frente a regresiones mientras las exportaciones enriquecidas mantienen paridad total
@@ -186,7 +186,7 @@ entre la visión en pantalla y los artefactos compartidos.
 
 ## Configuración de claves API
 
-La release 0.3.30.7 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
+La release 0.3.30.8 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
 
@@ -227,7 +227,7 @@ en ``~/.portafolio_iol/favorites.json`` con la siguiente estructura:
 - Podés borrar el archivo para reiniciar la lista; se volverá a generar cuando agregues un nuevo
   favorito.
 
-## Backend de snapshots para pipelines CI (0.3.30.7)
+## Backend de snapshots para pipelines CI (0.3.30.8)
 
 - Define `SNAPSHOT_BACKEND=null` para ejecutar suites sin escribir archivos persistentes; el módulo
   `services.snapshots` usará `NullSnapshotStorage` y evitará cualquier escritura en disco durante las
@@ -363,7 +363,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.30.7)
+##### Escenarios de fallback macro (0.3.30.8)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -512,11 +512,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.7".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.8".
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.7)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.8)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/banners/README
+++ b/banners/README
@@ -2,6 +2,6 @@
 
 Los assets de login y sidebar deben mostrar la versión activa de la aplicación.
 
-- Versión actual: 0.3.30.7
-- Fecha de publicación: 2025-10-05
+- Versión actual: 0.3.30.8
+- Fecha de publicación: 2025-10-06
 - Mensaje destacado: "Fallback jerárquico endurecido"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,7 +51,7 @@ result = monte_carlo_simulation(
 De esta manera cada test controla explícitamente la semilla sin depender de `numpy.random.seed`, y
 los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralelo.
 
-## CI Checklist (0.3.30.7)
+## CI Checklist (0.3.30.8)
 
 1. **Suite determinista sin legacy.** Ejecuta `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy` y
    verifica que el resumen final no recolecte casos desde `tests/legacy/`.
@@ -116,7 +116,7 @@ frecuentes:
 
 ### Validación de snapshots y almacenamiento persistente
 
-La release 0.3.30.7, orientada a cerrar los fixes del fallback jerárquico y propagar los indicadores
+La release 0.3.30.8, orientada a cerrar los fixes del fallback jerárquico y propagar los indicadores
 de procedencia corregidos, mantiene el foco en limpiar duplicados y completar la migración fuera de
 legacy. Refuerza los contadores de snapshots, la telemetría de almacenamiento y la verificación de
 artefactos en pipelines. Para cubrirlos en QA

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,11 +4,11 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Claves API
 
-> Nota: Esta guía corresponde a la release 0.3.30.7, enfocada en robustecer el fallback jerárquico,
+> Nota: Esta guía corresponde a la release 0.3.30.8, enfocada en robustecer el fallback jerárquico,
 > propagar los indicadores de procedencia corregidos y completar la migración fuera de módulos legacy
 > sin alterar los flujos funcionales documentados en la serie 0.3.30.x.
 
-## CI Checklist (0.3.30.7)
+## CI Checklist (0.3.30.8)
 
 - **Suite legacy detectada.** Si el resumen de `pytest` menciona archivos dentro de `tests/legacy/`,
   ajustá el comando (`pytest --ignore=tests/legacy`) o revisá `norecursedirs` en `pyproject.toml` para
@@ -60,7 +60,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **El timeline de resiliencia no persiste tras un rerun.**
   - **Síntomas:** Luego de presionar **⟳ Refrescar**, el bloque **Resiliencia de proveedores** se vacía.
-  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.7 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
+  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.8 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
   - **Resolución:**
     1. Actualiza el repositorio y reinstala dependencias si trabajas con un build antiguo.
     2. Comprueba que el stub de tests (`tests/conftest.py`) conserve los datos de sesión entre llamadas; limpia `st.session_state` solo al finalizar las aserciones.
@@ -164,7 +164,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.
-  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.7` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.8` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
   - **Resolución:**
     1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
     2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.30.7"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.8"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.30.7"
+DEFAULT_VERSION: str = "0.3.30.8"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.30.8 and sync the shared version module
- refresh README, docs and banner metadata so the UI displays the new release number
- document the 0.3.30.8 release with notes on sesiones cacheadas, rate limiting y valorizaciones recuperadas

## Testing
- pytest tests/test_version_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68e1c71e0b0483328890666957b1a015