### PR TITLE
Fix quote provider ok_total handling

### DIFF
--- a/services/health.py
+++ b/services/health.py
@@ -1692,6 +1692,7 @@ def get_health_metrics() -> Dict[str, Any]:
         providers: list[Dict[str, Any]] = []
         total_count = 0
         stale_total = 0
+        ok_total = 0
         rate_total = 0
         rate_wait_total = 0.0
 
@@ -1799,6 +1800,8 @@ def get_health_metrics() -> Dict[str, Any]:
         summary: Dict[str, Any] = {"providers": providers, "total": summary_total}
         if stale_total:
             summary["stale_total"] = stale_total
+        if ok_total:
+            summary["ok_total"] = ok_total
         if rate_total:
             summary["rate_limit_total"] = rate_total
         if rate_wait_total:

--- a/tests/services/test_health_metrics.py
+++ b/tests/services/test_health_metrics.py
@@ -1,0 +1,55 @@
+from pathlib import Path
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+from services import health  # noqa: E402
+
+
+def test_quote_provider_summary_handles_mixed_data(monkeypatch):
+    fake_state: dict[str, dict] = {}
+    monkeypatch.setattr(health, "st", SimpleNamespace(session_state=fake_state))
+
+    store = health._store()
+    store["quote_providers"] = {
+        "alpha": {
+            "count": 3,
+            "ok_count": 2,
+            "stale_count": 1,
+            "elapsed_history": [0.1, 0.2, 0.3],
+        },
+        "beta": {
+            "count": 5,
+            "stale_count": 0,
+        },
+        "gamma": {
+            "count": 4,
+            "ok_count": 0,
+        },
+    }
+    store[health._QUOTE_RATE_LIMIT_KEY] = {
+        "alpha": {
+            "count": 1,
+            "wait_total": 0.1,
+            "wait_last": 0.05,
+        }
+    }
+
+    summary = health.get_health_metrics()["quote_providers"]
+
+    assert summary["total"] == 12
+    assert summary["ok_total"] == 2
+
+    providers = {entry["provider"]: entry for entry in summary["providers"]}
+    alpha = providers["alpha"]
+    assert alpha["ok_count"] == 2
+    assert alpha["ok_ratio"] == pytest.approx(2 / 3)
+    assert "rate_limit_count" in alpha
+


### PR DESCRIPTION
## Summary
- initialize `ok_total` when summarizing quote providers so totals always exist and are reported when present
- add a unit test exercising mixed provider data to ensure quote summary handles ok counts without errors

## Testing
- pytest tests/services/test_health_metrics.py

------
https://chatgpt.com/codex/tasks/task_e_68e1d6e18c3483329507ed11acf43400