### PR TITLE
Improve legacy session auth backoff handling

### DIFF
--- a/tests/infrastructure/test_legacy_session.py
+++ b/tests/infrastructure/test_legacy_session.py
@@ -42,6 +42,7 @@ def test_ensure_authenticated_skips_when_auth_unavailable(
     first = legacy_session.ensure_authenticated("user", "pass", auth=None)
     assert first is None
     assert legacy_session.is_auth_unavailable() is True
+    assert legacy_session_module.st.session_state["legacy_auth_unavailable"] is True
     assert builder.call_count == 1
 
     second = legacy_session.ensure_authenticated("user", "pass", auth=None)
@@ -66,6 +67,7 @@ def test_fetch_with_backoff_retries_after_password_change(
         auth=None,
     )
     assert data is None and auth_failed is True
+    assert legacy_session_module.st.session_state["legacy_auth_unavailable"] is True
     assert builder.call_count == 1
 
     data, auth_failed = legacy_session.fetch_with_backoff(
@@ -127,5 +129,64 @@ def test_fetch_with_backoff_retries_after_token_change(
         auth=new_auth,
     )
     assert data is None and auth_failed is True
+    assert builder.call_count == 2
+
+
+def test_token_rotation_does_not_retry_until_values_change(
+    legacy_session: legacy_session_module.LegacySession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Token refreshes with identical values must honour the sticky failure flag."""
+
+    builder = MagicMock(side_effect=InvalidCredentialsError("boom"))
+    monkeypatch.setattr(legacy_session, "_build_session", builder)
+
+    stale_tokens = {"access_token": "tok", "refresh_token": "ref"}
+    auth = SimpleNamespace(tokens=stale_tokens)
+
+    assert legacy_session.ensure_authenticated("user", "", auth=auth) is None
+    assert builder.call_count == 1
+
+    # Simulate a rotation that reuses the same token values (common during refresh
+    # retries).  No additional authentication attempts should be triggered.
+    rotated_auth = SimpleNamespace(tokens={"access_token": "tok", "refresh_token": "ref"})
+    assert legacy_session.ensure_authenticated("user", "", auth=rotated_auth) is None
+    assert builder.call_count == 1
+
+    # Once the token payload actually changes, the sticky flag should be reset and
+    # a new attempt may occur.
+    fresh_auth = SimpleNamespace(tokens={"access_token": "tok-2", "refresh_token": "ref-2"})
+    assert legacy_session.ensure_authenticated("user", "", auth=fresh_auth) is None
+    assert builder.call_count == 2
+
+
+def test_sticky_flag_can_expire_after_cooldown(
+    legacy_session: legacy_session_module.LegacySession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """After the configured cooldown the session may retry even without changes."""
+
+    builder = MagicMock(side_effect=InvalidCredentialsError("boom"))
+    monkeypatch.setattr(legacy_session, "_build_session", builder)
+
+    monkeypatch.setattr(
+        legacy_session_module, "AUTH_FAILURE_COOLDOWN_SECONDS", 10, raising=False
+    )
+
+    # Start with a deterministic timestamp.
+    now = 100.0
+    monkeypatch.setattr(legacy_session_module.time, "monotonic", lambda: now)
+
+    assert legacy_session.ensure_authenticated("user", "pass", auth=None) is None
+    assert builder.call_count == 1
+
+    # Before the cooldown expires the attempt should be short-circuited.
+    now += 5
+    assert legacy_session.ensure_authenticated("user", "pass", auth=None) is None
+    assert builder.call_count == 1
+
+    # After the cooldown expires another attempt should be permitted.
+    now += 6
+    assert legacy_session.ensure_authenticated("user", "pass", auth=None) is None
     assert builder.call_count == 2
 


### PR DESCRIPTION
## Summary
- keep the legacy authentication failure sticky until credentials change or a cooldown elapses, tracking the failure timestamp
- make `fetch_with_backoff` propagate the sticky state via Streamlit session state and avoid redundant session builds
- add regression coverage for repeated token rotations and cooldown-driven retries

## Testing
- pytest --override-ini addopts='' tests/infrastructure/test_legacy_session.py

------
https://chatgpt.com/codex/tasks/task_e_68e1e00a3d088332b32c1a914eb24b92