### PR TITLE
Handle missing quote provider HTTP counters gracefully

### DIFF
--- a/tests/ui/test_health_sidebar.py
+++ b/tests/ui/test_health_sidebar.py
@@ -249,6 +249,45 @@ def test_render_health_sidebar_with_missing_metrics(health_sidebar) -> None:
     assert "_Sin incidencias de riesgo registradas._" in markdown_calls
 
 
+def test_render_health_sidebar_quote_providers_without_http_counters(
+    health_sidebar,
+) -> None:
+    metrics = {
+        "iol_refresh": {"status": "success", "detail": "Tokens OK", "ts": 1},
+        "yfinance": None,
+        "fx_api": None,
+        "fx_cache": None,
+        "portfolio": None,
+        "quotes": None,
+        "quote_providers": {
+            "total": 2,
+            "ok_total": 2,
+            "providers": [
+                {
+                    "provider": "iol",
+                    "label": "IOL v2",
+                    "count": 2,
+                    "ok_count": 2,
+                    "ok_ratio": 1.0,
+                    "ts": 12.0,
+                }
+            ],
+        },
+        "tab_latencies": None,
+        "adapter_fallbacks": None,
+        "macro_api": None,
+        "opportunities": None,
+        "opportunities_history": None,
+        "opportunities_stats": None,
+        "risk_incidents": None,
+    }
+
+    _render(health_sidebar, metrics)
+
+    markdown_calls = health_sidebar.st.sidebar.markdowns
+    assert any("IOL v2" in text for text in markdown_calls)
+
+
 def test_render_health_sidebar_with_yfinance_history(
     health_sidebar, _dummy_metrics
 ) -> None:

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -458,6 +458,9 @@ def _format_quote_providers(data: Optional[Mapping[str, Any]]) -> Iterable[str]:
     if header_parts:
         lines.append(format_note("📊 " + " • ".join(header_parts)))
 
+    http_counters_val = data.get("http_counters") if isinstance(data.get("http_counters"), Mapping) else None
+    http_counters: Mapping[str, Any] = http_counters_val or {}
+
     if http_counters:
         iol_500 = http_counters.get("iolv2_500", 0)
         legacy_429 = http_counters.get("legacy_429", 0)


### PR DESCRIPTION
## Summary
- guard the health sidebar quote provider formatter against missing `http_counters`
- add a regression test covering quote provider metrics that omit HTTP counters

## Testing
- pytest -o addopts= tests/ui/test_health_sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68e1eb75f1588332aa65981a4e00c614