### PR TITLE
chore: set UV_USE_REQUIREMENTS env var across builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+env:
+  UV_USE_REQUIREMENTS: 'true'
+
 on:
   push:
   pull_request:

--- a/.github/workflows/dependency-update.yml
+++ b/.github/workflows/dependency-update.yml
@@ -1,5 +1,8 @@
 name: dependency-update
 
+env:
+  UV_USE_REQUIREMENTS: 'true'
+
 on:
   schedule:
     - cron: '0 0 1 * *'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,14 @@
 # syntax=docker/dockerfile:1
 
 FROM python:3.10-slim AS builder
+ENV UV_USE_REQUIREMENTS=true
 WORKDIR /app
 # Install only production dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 FROM python:3.10-slim
+ENV UV_USE_REQUIREMENTS=true
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
 COPY --from=builder /usr/local /usr/local

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: streamlit run app.py --server.port=$PORT --server.address=0.0.0.0
+web: UV_USE_REQUIREMENTS=true streamlit run app.py --server.port=$PORT --server.address=0.0.0.0

--- a/app.py
+++ b/app.py
@@ -70,6 +70,7 @@ def main(argv: list[str] | None = None):
         st.session_state["session_id"] = uuid4().hex
     args = _parse_args(argv or [])
     configure_logging(level=args.log_level, json_format=(args.log_format == "json") if args.log_format else None)
+    logger.info("requirements.txt es la fuente autorizada de dependencias.")
     ensure_tokens_key()
 
     if st.session_state.get("force_login"):

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 set -e
 
+export UV_USE_REQUIREMENTS=true
+
 if [ -z "$IOL_TOKENS_KEY" ]; then
   echo "Error: IOL_TOKENS_KEY debe estar definida" >&2
   exit 1


### PR DESCRIPTION
## Summary
- export `UV_USE_REQUIREMENTS=true` in the Dockerfile, runtime launcher, and Procfile so uv uses requirements.txt without warnings
- propagate the environment variable to CI and dependency-update workflows to keep logs quiet in automation
- log a startup INFO message clarifying requirements.txt is the authoritative dependency source

## Testing
- pytest test/test_logging_configuration.py

------
https://chatgpt.com/codex/tasks/task_e_68e26e6178688332bae49911bbc152d5