### PR TITLE
Ensure matplotlib font manager logging is suppressed

### DIFF
--- a/shared/config.py
+++ b/shared/config.py
@@ -462,6 +462,8 @@ def configure_logging(level: str | None = None, json_format: bool | None = None)
             datefmt="%Y-%m-%d %H:%M:%S",
         )
 
+    logging.getLogger("matplotlib.font_manager").setLevel(logging.WARNING)
+
 @lru_cache(maxsize=1)
 def get_config() -> dict:
     path = os.getenv("PORTFOLIO_CONFIG_PATH", "config.json")

--- a/tests/shared/test_logging_configuration.py
+++ b/tests/shared/test_logging_configuration.py
@@ -1,0 +1,29 @@
+import logging
+
+import pytest
+
+from shared import config
+
+
+@pytest.mark.parametrize("json_format", [False, True])
+def test_configure_logging_sets_matplotlib_font_manager_level(json_format):
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    original_handlers = root_logger.handlers[:]
+    original_matplotlib_level = logging.getLogger("matplotlib.font_manager").level
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+
+    try:
+        config.configure_logging(level="INFO", json_format=json_format)
+        assert logging.getLogger("matplotlib.font_manager").level == logging.WARNING
+    finally:
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+
+        root_logger.setLevel(original_level)
+        logging.getLogger("matplotlib.font_manager").setLevel(original_matplotlib_level)


### PR DESCRIPTION
## Summary
- ensure `configure_logging` always forces the `matplotlib.font_manager` logger to WARNING after configuring handlers
- add a smoke test that covers both plain text and JSON logging paths

## Testing
- PYTHONPATH=. pytest -c /dev/null tests/shared/test_logging_configuration.py

------
https://chatgpt.com/codex/tasks/task_e_68e26e623f1083328326fa84b8a20d5b