### PR TITLE
Release 0.3.30.10: restore logging/export coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## [0.3.30.10] - 2025-10-15
+
+### Fixed
+- Se restableció la tubería de logging para que todos los flujos de screening y exportación vuelvan a
+  registrar eventos en `analysis.log`, incluyendo los `snapshot_hits`, degradaciones controladas y la
+  procedencia de los datos consumidos por la UI.
+- Los exports (`analysis.zip`, `analysis.xlsx`, `summary.csv`) vuelven a generarse con el set completo
+  de archivos, preservan los timestamps de ejecución y adjuntan la bitácora consolidada en los artefactos
+  de CI.
+
+### Documentation
+- README, guías de troubleshooting y banners actualizados para recalcar la release 0.3.30.10 y los
+  fixes de logging/export que devuelven la trazabilidad a pipelines y operadores.
+
 ## [0.3.30.9] - 2025-10-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,26 +6,27 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.30.9)
+## Quick-start (release 0.3.30.10)
 
-La versión **0.3.30.9** restablece el flujo de cotizaciones en vivo alineando los endpoints
-`/Titulos/Cotizacion` y `/Cotizacion`, incorpora el país de cada instrumento directamente en el
-portafolio y corrige el sidebar para que la UI refleje el estado real del entorno. Mantiene los refuerzos
-de resiliencia introducidos previamente mientras entrega métricas consistentes en pipelines y en la app.
+La versión **0.3.30.10** restituye la bitácora unificada y la exportación multi-formato tras los
+incidentes de logging/export, manteniendo a la vez el flujo de cotizaciones en vivo, los metadatos por
+país y el sidebar corregido. Los pipelines recuperan la trazabilidad completa y la UI vuelve a exhibir
+los mensajes de auditoría en tiempo real.
 
-## Quick-start (release 0.3.30.9 — cotizaciones live restauradas — 2025-10-10)
+## Quick-start (release 0.3.30.10 — logging y exports restaurados — 2025-10-15)
 
-La versión **0.3.30.9** destaca cinco ejes principales:
-- El **endpoint `/Titulos/Cotizacion`** vuelve a ofrecer precios en vivo sincronizados con `/Cotizacion`,
+La versión **0.3.30.10** destaca cinco ejes principales:
+- El **logging consolidado** vuelve a persistir `analysis.log` en cada screening, captura los
+  `snapshot_hits`, la procedencia de datos y las degradaciones controladas que la UI refleja en vivo.
+- Los **exports enriquecidos** garantizan que `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
+  presentes en cada corrida, conservando los timestamps y adjuntando la bitácora en los artefactos de CI.
+- El **endpoint `/Titulos/Cotizacion`** mantiene los precios en vivo sincronizados con `/Cotizacion`,
   incluyendo la marca de procedencia y el fallback jerárquico cuando el feed live se degrada.
 - El **portafolio integrado por país** añade metadatos de origen para cada posición y desbloquea filtros
   y dashboards por país en la UI y en los exports.
-- El **sidebar corregido** muestra la versión activa `0.3.30.9`, reordena los bloques de salud y garantiza
-  que la etiqueta de live quotes refleje si la aplicación está consumiendo datos frescos o snapshots.
-- La **prueba de cobertura dedicada a cotizaciones** sigue bloqueando regresiones del flujo live e incluye
-  asserts sobre la procedencia del precio para `Titulos` y portafolio multi-país.
 - La **CI Checklist reforzada** conserva los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`)
-  y añade una validación para que los banners del login/sidebar indiquen "Cotizaciones live restauradas".
+  y valida que los banners del login/sidebar indiquen "Logging y exports restaurados" para evidenciar el
+  fix.
 
 Sigue estos pasos para reproducir el flujo completo y validar las novedades clave:
 
@@ -43,8 +44,8 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.9` junto con
-   el mensaje "Cotizaciones live restauradas" y el timestamp generado por `TimeProvider`. Abre el panel
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.10` junto con
+   el mensaje "Logging y exports restaurados" y el timestamp generado por `TimeProvider`. Abre el panel
    **Salud del sistema**: además del estado de cada proveedor verás el bloque **Snapshots y
    almacenamiento**, que expone la ruta activa del disco, el contador de recuperaciones desde snapshot,
    la insignia que confirma si `/Titulos/Cotizacion` está entregando precios en vivo y la latencia
@@ -105,7 +106,8 @@ validar escenarios sin depender de módulos obsoletos.
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.30.9 conserva la última secuencia de degradación, muestra el estado del feed
+   release 0.3.30.10 conserva la última secuencia de degradación, vuelve a dejar trazas en `analysis.log`,
+   muestra el estado del feed
    `/Titulos/Cotizacion` y ahora incluye el contador de snapshots reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
    `primario → secundario → snapshot` (o fallback estático si corresponde) con la marca temporal de cada
@@ -132,7 +134,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.30.9)
+### CI Checklist (0.3.30.10)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -144,12 +146,12 @@ validar escenarios sin depender de módulos obsoletos.
 4. **Valida exportaciones.** Ejecuta `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
    o reutiliza los snapshots de `tmp_path`. Revisa que cada snapshot genere los CSV (`kpis.csv`,
    `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
-   `analysis.xlsx` y el resumen `summary.csv` en la raíz de `exports/ci`.
+   `analysis.xlsx`, el resumen `summary.csv` y el log consolidado `analysis.log` en la raíz de `exports/ci`.
 5. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
-   y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
-   presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
+   y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
+   `analysis.log` estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 
-### Validaciones Markowitz reforzadas (0.3.30.9)
+### Validaciones Markowitz reforzadas (0.3.30.10)
 
 - `application.risk_service.markowitz_optimize` valida la invertibilidad de la matriz de covarianzas y
   degrada a pesos `NaN` cuando detecta singularidad o entradas inválidas, evitando excepciones en la UI
@@ -164,7 +166,7 @@ validar escenarios sin depender de módulos obsoletos.
   y `tests/integration/test_portfolio_tabs.py` cubren la degradación controlada y los mensajes visibles
   en la UI, por lo que cualquier regresión se detecta en pipelines.
 
-**Resiliencia de APIs (0.3.30.9).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.30.10).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening y la procedencia (`primario`, `secundario`, `snapshot`). Al
 relanzarlo, la telemetría agrega la procedencia del dato y clasifica la recuperación según la estrategia
 aplicada:
@@ -178,16 +180,17 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos.
 
-Estas novedades convierten a la release 0.3.30.9 en la referencia para validar onboarding, telemetría y
+Estas novedades convierten a la release 0.3.30.10 en la referencia para validar onboarding, telemetría y
 resiliencia multi-API: el endpoint `/Cotizacion` expone la versión activa desde la UI y las integraciones
 externas, el manejo de errores 500 asegura continuidad visible en dashboards y la prueba de cobertura
 protege el flujo frente a regresiones mientras las exportaciones enriquecidas mantienen paridad total
-entre la visión en pantalla y los artefactos compartidos.
+entre la visión en pantalla y los artefactos compartidos, registrando cada paso en `analysis.log`.
 
 
 ## Configuración de claves API
 
-La release 0.3.30.9 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets`. Antes de
+La release 0.3.30.10 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets` y deja
+registro de la resolución de cada proveedor en `analysis.log`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
 
@@ -228,7 +231,7 @@ en ``~/.portafolio_iol/favorites.json`` con la siguiente estructura:
 - Podés borrar el archivo para reiniciar la lista; se volverá a generar cuando agregues un nuevo
   favorito.
 
-## Backend de snapshots para pipelines CI (0.3.30.9)
+## Backend de snapshots para pipelines CI (0.3.30.10)
 
 - Define `SNAPSHOT_BACKEND=null` para ejecutar suites sin escribir archivos persistentes; el módulo
   `services.snapshots` usará `NullSnapshotStorage` y evitará cualquier escritura en disco durante las
@@ -364,7 +367,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.30.9)
+##### Escenarios de fallback macro (0.3.30.10)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -513,11 +516,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.9".
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.10" y referencia la restauración de logging/export para auditorías.
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.9)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.10)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank y la bitácora asociada en `analysis.log`.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/banners/README
+++ b/banners/README
@@ -2,6 +2,6 @@
 
 Los assets de login y sidebar deben mostrar la versión activa de la aplicación.
 
-- Versión actual: 0.3.30.9
-- Fecha de publicación: 2025-10-10
-- Mensaje destacado: "Cotizaciones live restauradas"
+- Versión actual: 0.3.30.10
+- Fecha de publicación: 2025-10-15
+- Mensaje destacado: "Logging y exports restaurados"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,7 +51,7 @@ result = monte_carlo_simulation(
 De esta manera cada test controla explícitamente la semilla sin depender de `numpy.random.seed`, y
 los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralelo.
 
-## CI Checklist (0.3.30.9)
+## CI Checklist (0.3.30.10)
 
 1. **Suite determinista sin legacy.** Ejecuta `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy` y
    verifica que el resumen final no recolecte casos desde `tests/legacy/`.
@@ -64,17 +64,17 @@ los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralel
 4. **Exportaciones consistentes.** Invoca `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
  (o reutiliza `tmp_path` en las suites) y revisa que cada snapshot incluya los CSV (`kpis.csv`,
   `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
-  `analysis.xlsx` y el resumen `summary.csv` en la raíz del directorio de exportaciones.
+  `analysis.xlsx`, el resumen `summary.csv` y el log consolidado `analysis.log` en la raíz del directorio de exportaciones.
 5. **Checklist previa al merge.** Antes de aprobar la release inspecciona los artefactos del pipeline y
-  confirma que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
-  adjuntos. Si falta alguno, la ejecución debe considerarse fallida.
+  confirma que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
+  `analysis.log` estén adjuntos. Si falta alguno, la ejecución debe considerarse fallida.
 6. **Puerta de seguridad.** Ejecuta `bandit -r application controllers services` para auditar llamadas inseguras
   y `pip-audit --requirement requirements.txt --requirement requirements-dev.txt` para identificar
   dependencias vulnerables. Ambos comandos deben formar parte del pipeline y bloquear el merge ante
   hallazgos críticos.
 7. **Verificación del feed live.** Incluye un paso que ejecute `pytest tests/integration/test_quotes_flow.py`
-   (o el job equivalente) y aserte que la UI muestre la etiqueta "Cotizaciones live restauradas" cuando
-   `/Titulos/Cotizacion` entrega precios en tiempo real.
+   (o el job equivalente) y aserte que la UI muestre la etiqueta "Logging y exports restaurados" cuando
+   `/Titulos/Cotizacion` entrega precios en tiempo real y `analysis.log` queda actualizado.
 
 ### Suites legacy (deprecated)
 
@@ -119,11 +119,11 @@ frecuentes:
 
 ### Validación de snapshots y almacenamiento persistente
 
-La release 0.3.30.9 restablece el flujo de cotizaciones en vivo, propaga el indicador de procedencia a
-`/Titulos/Cotizacion` y añade el país al view-model del portafolio. Las pruebas continúan reforzando el
-fallback jerárquico mientras verifican que el feed live quede etiquetado correctamente en la UI y que los
-artefactos por país lleguen a los exports. Para cubrirlos en QA combina pruebas automáticas y
-verificaciones manuales:
+La release 0.3.30.10 restablece la bitácora unificada, mantiene el flujo de cotizaciones en vivo, propaga
+el indicador de procedencia a `/Titulos/Cotizacion` y añade el país al view-model del portafolio. Las
+pruebas continúan reforzando el fallback jerárquico mientras verifican que el feed live quede etiquetado
+correctamente en la UI, que `analysis.log` capture cada screening y que los artefactos por país lleguen a
+los exports. Para cubrirlos en QA combina pruebas automáticas y verificaciones manuales:
 
 - `pytest tests/test_sidebar_controls.py -k snapshot`: comprueba que los presets persistan en
   `st.session_state["controls_snapshot"]` y que el estado se limpie correctamente al cerrar sesión.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,12 +4,12 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Claves API
 
-> Nota: Esta guía corresponde a la release 0.3.30.9, centrada en restablecer las cotizaciones en vivo,
-> propagar los indicadores de procedencia hacia `/Titulos/Cotizacion` y completar la integración del
-> país de origen en el portafolio. Mantiene los refuerzos del fallback jerárquico documentados en la
-> serie 0.3.30.x.
+> Nota: Esta guía corresponde a la release 0.3.30.10, enfocada en restaurar la bitácora unificada y las
+> exportaciones multi-formato tras los incidentes de logging/export. Mantiene las cotizaciones en vivo
+> sincronizadas, la procedencia propagada hacia `/Titulos/Cotizacion` y los metadatos de país en el
+> portafolio, junto con los refuerzos del fallback jerárquico documentados en la serie 0.3.30.x.
 
-## CI Checklist (0.3.30.9)
+## CI Checklist (0.3.30.10)
 
 - **Suite legacy detectada.** Si el resumen de `pytest` menciona archivos dentro de `tests/legacy/`,
   ajustá el comando (`pytest --ignore=tests/legacy`) o revisá `norecursedirs` en `pyproject.toml` para
@@ -18,7 +18,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
   y bloqueá el pipeline si aparecen coincidencias fuera de `tests/legacy/` o de pruebas de compatibilidad
   explícitas.
 - **Pipelines sin artefactos.** Si un job finaliza sin adjuntar `coverage.xml`, `htmlcov/`, `analysis.zip`,
-  `analysis.xlsx` o `summary.csv`, márcalo como fallido y reejecuta las etapas de `pytest --cov` y
+  `analysis.xlsx`, `summary.csv` o `analysis.log`, márcalo como fallido y reejecuta las etapas de `pytest --cov` y
   `scripts/export_analysis.py`. Los pasos deben apuntar al mismo directorio temporal (`$RUNNER_TEMP` o
   `tmp_path`).
 - **Rutas inconsistentes de snapshots.** Cuando `scripts/export_analysis.py` no encuentra archivos,
@@ -61,13 +61,13 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **El timeline de resiliencia no persiste tras un rerun.**
   - **Síntomas:** Luego de presionar **⟳ Refrescar**, el bloque **Resiliencia de proveedores** se vacía.
-  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.9 o superior y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
+  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.10 o superior, que `analysis.log` se regenere tras cada screening y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
   - **Resolución:**
     1. Actualiza el repositorio y reinstala dependencias si trabajas con un build antiguo.
     2. Comprueba que el stub de tests (`tests/conftest.py`) conserve los datos de sesión entre llamadas; limpia `st.session_state` solo al finalizar las aserciones.
 
-- **La etiqueta "Cotizaciones live restauradas" no aparece en el sidebar.**
-  - **Síntomas:** El banner superior muestra la versión `0.3.30.9`, pero el bloque de salud indica que el feed live está degradado aun cuando `/Titulos/Cotizacion` responde.
+- **La etiqueta "Logging y exports restaurados" no aparece en el sidebar.**
+  - **Síntomas:** El banner superior muestra la versión `0.3.30.10`, pero el bloque de salud no adjunta el mensaje de logging/export y el feed live indica degradación aun cuando `/Titulos/Cotizacion` responde.
   - **Diagnóstico rápido:** Ejecuta `python tests/helpers/check_live_quotes.py` (o el script equivalente) para confirmar que el proveedor activo devuelve `last = price` y que `shared.version.DEFAULT_VERSION` coincide con la release actual.
   - **Resolución:**
     1. Revisa los logs de `services.quotes.live_quotes_flow` y verifica que `source="titulos"` llegue al `quotes_store`.
@@ -173,7 +173,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.
-  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.9` en el header/footer y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.10` en el header/footer, que el banner mencione "Logging y exports restaurados" y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
   - **Resolución:**
     1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
     2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.30.9"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.10"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.30.9"
+DEFAULT_VERSION: str = "0.3.30.10"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.30.10 and align the shared version constant
- document the logging/export fixes in the changelog, README and ancillary guides
- refresh troubleshooting, testing and banner notes to highlight the restored logging/export behaviour

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26e63877883329b66ee734fb2caca