### PR TITLE
Remove plotly-get-chrome dependency from manifests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,6 @@ dependencies = [
     "plotly==6.3.0",
     "matplotlib==3.10.6",
     "kaleido==0.2.1",
-    "plotly-get-chrome>=0.1.0",
     "XlsxWriter==3.2.0",
     "tomli==2.0.1",
     "cryptography==41.0.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,6 @@ iolConn==0.4.2
 plotly==6.3.0
 matplotlib==3.10.6
 kaleido==0.2.1
-plotly-get-chrome>=0.1.0
 XlsxWriter==3.2.0
 tomli==2.0.1
 cryptography==41.0.3

--- a/tests/shared/test_portfolio_export.py
+++ b/tests/shared/test_portfolio_export.py
@@ -67,7 +67,7 @@ def test_fig_to_png_bytes_returns_none_and_warns_when_runtime_missing(
 
     class _Scope:
         def ensure_chrome(self) -> None:
-            raise export.ChromeNotFoundError("chromium not found")
+            raise OSError("chromium not found")
 
     monkeypatch.setattr(export, "_get_kaleido_scope", lambda: _Scope())
     monkeypatch.setattr(export.pio, "to_image", lambda *_args, **_kwargs: _DUMMY_PNG)


### PR DESCRIPTION
## Summary
- drop the plotly-get-chrome dependency from project manifests and regenerate requirements
- update the Kaleido export helper to rely on plotly's built-in ensure_chrome with runtime guards
- refresh export unit tests to cover success and failure paths without plotly-get-chrome

## Testing
- pytest --override-ini addopts='' tests/shared/test_portfolio_export.py

------
https://chatgpt.com/codex/tasks/task_e_68e27508cbb083328086e959881f3c72