### PR TITLE
chore: release 0.3.30.10.1 hotfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## [0.3.30.10.1] - Hotfix entorno Kaleido
+
+### Changed
+- Limpieza y resincronización de dependencias en `pyproject.toml` y los requirements planos
+  para evitar paquetes redundantes en CI/CD y entornos mínimos.
+
+### Fixed
+- Restaurado el fallback de exportación cuando `kaleido` no está disponible: la aplicación
+  mantiene los artefactos CSV/Excel, etiqueta el estado en los banners y registra la ausencia
+  de PNG para los pipelines.
+
+### Documentation
+- README, guías de testing y troubleshooting actualizadas con la release 0.3.30.10.1, el hotfix
+  de Kaleido y el mensaje visible en los banners.
+
 ## [0.3.30.10] - 2025-10-15
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,27 +6,20 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.30.10)
+## Quick-start (release 0.3.30.10.1)
 
-La versión **0.3.30.10** restituye la bitácora unificada y la exportación multi-formato tras los
-incidentes de logging/export, manteniendo a la vez el flujo de cotizaciones en vivo, los metadatos por
-país y el sidebar corregido. Los pipelines recuperan la trazabilidad completa y la UI vuelve a exhibir
-los mensajes de auditoría en tiempo real.
+La versión **0.3.30.10.1** es un hotfix orientado a entornos donde Kaleido no está disponible: limpia dependencias residuales, resincroniza los requirements y refuerza el fallback de exportación para que los dashboards mantengan los artefactos aun sin los PNG generados por Plotly. A la vez preserva las mejoras previas de logging unificado, telemetría en vivo y sidebar corregido.
 
-## Quick-start (release 0.3.30.10 — logging y exports restaurados — 2025-10-15)
+## Quick-start (release 0.3.30.10.1 — Hotfix entorno Kaleido — 2025-10-16)
 
-La versión **0.3.30.10** destaca cinco ejes principales:
-- El **logging consolidado** vuelve a persistir `analysis.log` en cada screening, captura los
-  `snapshot_hits`, la procedencia de datos y las degradaciones controladas que la UI refleja en vivo.
-- Los **exports enriquecidos** garantizan que `analysis.zip`, `analysis.xlsx` y `summary.csv` estén
-  presentes en cada corrida, conservando los timestamps y adjuntando la bitácora en los artefactos de CI.
-- El **endpoint `/Titulos/Cotizacion`** mantiene los precios en vivo sincronizados con `/Cotizacion`,
-  incluyendo la marca de procedencia y el fallback jerárquico cuando el feed live se degrada.
-- El **portafolio integrado por país** añade metadatos de origen para cada posición y desbloquea filtros
-  y dashboards por país en la UI y en los exports.
-- La **CI Checklist reforzada** conserva los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`)
-  y valida que los banners del login/sidebar indiquen "Logging y exports restaurados" para evidenciar el
-  fix.
+La versión **0.3.30.10.1** refuerza los siguientes ejes:
+- El **hotfix de Kaleido** restaura el fallback automático cuando la librería no está disponible, manteniendo la generación de Excel y ZIP aun cuando los PNG no puedan incrustarse.
+- La **limpieza de dependencias** alinea `pyproject.toml` con los requirements planos y retira paquetes redundantes para que los entornos CI/CD instalen sólo lo necesario.
+- El **logging consolidado** vuelve a persistir `analysis.log` en cada screening, captura los `snapshot_hits`, la procedencia de datos y las degradaciones controladas que la UI refleja en vivo.
+- Los **exports enriquecidos** garantizan que `analysis.zip`, `analysis.xlsx` y `summary.csv` estén presentes en cada corrida, conservando los timestamps, adjuntando la bitácora en los artefactos de CI y mostrando claramente cuándo los PNG dependen de Kaleido.
+- El **endpoint `/Titulos/Cotizacion`** mantiene los precios en vivo sincronizados con `/Cotizacion`, incluyendo la marca de procedencia y el fallback jerárquico cuando el feed live se degrada.
+- El **portafolio integrado por país** añade metadatos de origen para cada posición y desbloquea filtros y dashboards por país en la UI y en los exports.
+- La **CI Checklist reforzada** conserva los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`) y valida que los banners del login/sidebar indiquen "Hotfix Kaleido: fallback restaurado" para evidenciar el fix.
 
 Sigue estos pasos para reproducir el flujo completo y validar las novedades clave:
 
@@ -44,8 +37,8 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.10` junto con
-   el mensaje "Logging y exports restaurados" y el timestamp generado por `TimeProvider`. Abre el panel
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.10.1` junto con
+   el mensaje "Hotfix Kaleido: fallback restaurado" y el timestamp generado por `TimeProvider`. Abre el panel
    **Salud del sistema**: además del estado de cada proveedor verás el bloque **Snapshots y
    almacenamiento**, que expone la ruta activa del disco, el contador de recuperaciones desde snapshot,
    la insignia que confirma si `/Titulos/Cotizacion` está entregando precios en vivo y la latencia
@@ -72,9 +65,9 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
 
    > **Dependencia de Kaleido.** Plotly utiliza `kaleido` para renderizar los gráficos como PNG.
    > Instálalo con `pip install -r requirements.txt` (incluye la dependencia) o añádelo a tu entorno
-   > manualmente si usas una instalación mínima. Cuando `kaleido` no está disponible, la aplicación y
-   > los scripts continúan ofreciendo el ZIP de CSV y muestran una advertencia que indica cómo activar
-   > la exportación a Excel con imágenes.
+   > manualmente si usas una instalación mínima. Cuando `kaleido` no está disponible, la release
+   > 0.3.30.10.1 muestra el banner "Hotfix Kaleido: fallback restaurado", mantiene el ZIP de CSV y
+   > documenta en los artefactos que los PNG quedaron pendientes para reintento posterior.
 
 ### Migración fuera de módulos legacy
 
@@ -106,7 +99,7 @@ validar escenarios sin depender de módulos obsoletos.
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.30.10 conserva la última secuencia de degradación, vuelve a dejar trazas en `analysis.log`,
+   release 0.3.30.10.1 conserva la última secuencia de degradación, vuelve a dejar trazas en `analysis.log`,
    muestra el estado del feed
    `/Titulos/Cotizacion` y ahora incluye el contador de snapshots reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
@@ -134,7 +127,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.30.10)
+### CI Checklist (0.3.30.10.1)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -151,7 +144,7 @@ validar escenarios sin depender de módulos obsoletos.
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
    `analysis.log` estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 
-### Validaciones Markowitz reforzadas (0.3.30.10)
+### Validaciones Markowitz reforzadas (0.3.30.10.1)
 
 - `application.risk_service.markowitz_optimize` valida la invertibilidad de la matriz de covarianzas y
   degrada a pesos `NaN` cuando detecta singularidad o entradas inválidas, evitando excepciones en la UI
@@ -166,7 +159,7 @@ validar escenarios sin depender de módulos obsoletos.
   y `tests/integration/test_portfolio_tabs.py` cubren la degradación controlada y los mensajes visibles
   en la UI, por lo que cualquier regresión se detecta en pipelines.
 
-**Resiliencia de APIs (0.3.30.10).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.30.10.1).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening y la procedencia (`primario`, `secundario`, `snapshot`). Al
 relanzarlo, la telemetría agrega la procedencia del dato y clasifica la recuperación según la estrategia
 aplicada:
@@ -180,7 +173,7 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos.
 
-Estas novedades convierten a la release 0.3.30.10 en la referencia para validar onboarding, telemetría y
+Estas novedades convierten a la release 0.3.30.10.1 en la referencia para validar onboarding, telemetría y
 resiliencia multi-API: el endpoint `/Cotizacion` expone la versión activa desde la UI y las integraciones
 externas, el manejo de errores 500 asegura continuidad visible en dashboards y la prueba de cobertura
 protege el flujo frente a regresiones mientras las exportaciones enriquecidas mantienen paridad total
@@ -189,7 +182,7 @@ entre la visión en pantalla y los artefactos compartidos, registrando cada paso
 
 ## Configuración de claves API
 
-La release 0.3.30.10 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets` y deja
+La release 0.3.30.10.1 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets` y deja
 registro de la resolución de cada proveedor en `analysis.log`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
@@ -231,7 +224,7 @@ en ``~/.portafolio_iol/favorites.json`` con la siguiente estructura:
 - Podés borrar el archivo para reiniciar la lista; se volverá a generar cuando agregues un nuevo
   favorito.
 
-## Backend de snapshots para pipelines CI (0.3.30.10)
+## Backend de snapshots para pipelines CI (0.3.30.10.1)
 
 - Define `SNAPSHOT_BACKEND=null` para ejecutar suites sin escribir archivos persistentes; el módulo
   `services.snapshots` usará `NullSnapshotStorage` y evitará cualquier escritura en disco durante las
@@ -367,7 +360,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.30.10)
+##### Escenarios de fallback macro (0.3.30.10.1)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -516,11 +509,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.10" y referencia la restauración de logging/export para auditorías.
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.10.1" y destaca el hotfix de Kaleido para documentar cuándo los PNG quedan pendientes en los artefactos.
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.10)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank y la bitácora asociada en `analysis.log`.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.10.1)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega estadísticas agregadas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank y la bitácora asociada en `analysis.log`.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/banners/README
+++ b/banners/README
@@ -2,6 +2,6 @@
 
 Los assets de login y sidebar deben mostrar la versión activa de la aplicación.
 
-- Versión actual: 0.3.30.10
-- Fecha de publicación: 2025-10-15
-- Mensaje destacado: "Logging y exports restaurados"
+- Versión actual: 0.3.30.10.1
+- Fecha de publicación: 2025-10-16
+- Mensaje destacado: "Hotfix Kaleido: fallback restaurado"

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,7 +51,7 @@ result = monte_carlo_simulation(
 De esta manera cada test controla explícitamente la semilla sin depender de `numpy.random.seed`, y
 los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralelo.
 
-## CI Checklist (0.3.30.10)
+## CI Checklist (0.3.30.10.1)
 
 1. **Suite determinista sin legacy.** Ejecuta `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy` y
    verifica que el resumen final no recolecte casos desde `tests/legacy/`.
@@ -73,7 +73,7 @@ los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralel
   dependencias vulnerables. Ambos comandos deben formar parte del pipeline y bloquear el merge ante
   hallazgos críticos.
 7. **Verificación del feed live.** Incluye un paso que ejecute `pytest tests/integration/test_quotes_flow.py`
-   (o el job equivalente) y aserte que la UI muestre la etiqueta "Logging y exports restaurados" cuando
+   (o el job equivalente) y aserte que la UI muestre la etiqueta "Hotfix Kaleido: fallback restaurado" cuando
    `/Titulos/Cotizacion` entrega precios en tiempo real y `analysis.log` queda actualizado.
 
 ### Suites legacy (deprecated)
@@ -119,11 +119,12 @@ frecuentes:
 
 ### Validación de snapshots y almacenamiento persistente
 
-La release 0.3.30.10 restablece la bitácora unificada, mantiene el flujo de cotizaciones en vivo, propaga
-el indicador de procedencia a `/Titulos/Cotizacion` y añade el país al view-model del portafolio. Las
+La release 0.3.30.10.1 restablece la bitácora unificada, mantiene el flujo de cotizaciones en vivo, propaga
+el indicador de procedencia a `/Titulos/Cotizacion`, añade el país al view-model del portafolio y documenta
+el hotfix de Kaleido para que los exports indiquen cuándo los PNG quedan pendientes. Las
 pruebas continúan reforzando el fallback jerárquico mientras verifican que el feed live quede etiquetado
 correctamente en la UI, que `analysis.log` capture cada screening y que los artefactos por país lleguen a
-los exports. Para cubrirlos en QA combina pruebas automáticas y verificaciones manuales:
+los exports aun cuando Kaleido no esté instalado. Para cubrirlos en QA combina pruebas automáticas y verificaciones manuales:
 
 - `pytest tests/test_sidebar_controls.py -k snapshot`: comprueba que los presets persistan en
   `st.session_state["controls_snapshot"]` y que el estado se limpie correctamente al cerrar sesión.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,12 +4,13 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Claves API
 
-> Nota: Esta guía corresponde a la release 0.3.30.10, enfocada en restaurar la bitácora unificada y las
-> exportaciones multi-formato tras los incidentes de logging/export. Mantiene las cotizaciones en vivo
-> sincronizadas, la procedencia propagada hacia `/Titulos/Cotizacion` y los metadatos de país en el
-> portafolio, junto con los refuerzos del fallback jerárquico documentados en la serie 0.3.30.x.
+> Nota: Esta guía corresponde a la release 0.3.30.10.1, un hotfix orientado al entorno de Kaleido. Además de
+> preservar la bitácora unificada y las exportaciones multi-formato, documenta cuándo los PNG quedan
+> pendientes porque la librería no está instalada. Mantiene las cotizaciones en vivo sincronizadas, la
+> procedencia propagada hacia `/Titulos/Cotizacion`, los metadatos de país en el portafolio y los refuerzos
+> del fallback jerárquico documentados en la serie 0.3.30.x.
 
-## CI Checklist (0.3.30.10)
+## CI Checklist (0.3.30.10.1)
 
 - **Suite legacy detectada.** Si el resumen de `pytest` menciona archivos dentro de `tests/legacy/`,
   ajustá el comando (`pytest --ignore=tests/legacy`) o revisá `norecursedirs` en `pyproject.toml` para
@@ -61,19 +62,21 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **El timeline de resiliencia no persiste tras un rerun.**
   - **Síntomas:** Luego de presionar **⟳ Refrescar**, el bloque **Resiliencia de proveedores** se vacía.
-  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.10 o superior, que `analysis.log` se regenere tras cada screening y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
+  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.10.1 o superior, que `analysis.log` se regenere tras cada screening y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]`.
   - **Resolución:**
     1. Actualiza el repositorio y reinstala dependencias si trabajas con un build antiguo.
     2. Comprueba que el stub de tests (`tests/conftest.py`) conserve los datos de sesión entre llamadas; limpia `st.session_state` solo al finalizar las aserciones.
 
-- **La etiqueta "Logging y exports restaurados" no aparece en el sidebar.**
-  - **Síntomas:** El banner superior muestra la versión `0.3.30.10`, pero el bloque de salud no adjunta el mensaje de logging/export y el feed live indica degradación aun cuando `/Titulos/Cotizacion` responde.
-  - **Diagnóstico rápido:** Ejecuta `python tests/helpers/check_live_quotes.py` (o el script equivalente) para confirmar que el proveedor activo devuelve `last = price` y que `shared.version.DEFAULT_VERSION` coincide con la release actual.
+- **La etiqueta "Hotfix Kaleido: fallback restaurado" no aparece en el sidebar.**
+  - **Síntomas:** El banner superior muestra la versión `0.3.30.10.1`, pero el bloque de salud no adjunta el mensaje del hotfix
+    y las exportaciones omiten los PNG sin explicar el motivo.
+  - **Diagnóstico rápido:** Ejecuta `python tests/helpers/check_live_quotes.py` (o el script equivalente) para confirmar que el
+    proveedor activo devuelve `last = price`, que `shared.version.DEFAULT_VERSION` coincide con la release actual y que `python -c "import kaleido"` falla cuando el entorno no dispone de la librería.
   - **Resolución:**
     1. Revisa los logs de `services.quotes.live_quotes_flow` y verifica que `source="titulos"` llegue al `quotes_store`.
     2. Si estás en modo offline, habilita el flag `LIVE_QUOTES_ENABLED=1` y vuelve a iniciar la app para forzar la consulta en vivo.
     3. Comprueba que no existan interceptores sobrescribiendo `st.session_state["live_quotes_status"]`; en caso de encontrarlos, elimínalos o actualízalos para reflejar el nuevo flujo.
-
+    4. Valida que la ausencia de Kaleido sea intencional: si necesitás los PNG en la exportación instala la dependencia; en caso contrario el banner del hotfix debe permanecer visible.
 - **El bloque "Snapshots y almacenamiento" aparece vacío o en error.**
   - **Síntomas:** El health sidebar muestra `snapshot_hits = 0` pese a ejecutar screenings consecutivos, o aparece un mensaje "Ruta de snapshots inaccesible".
   - **Diagnóstico rápido:** Ejecuta el siguiente snippet para validar la ruta configurada y los permisos:
@@ -173,7 +176,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.
-  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.10` en el header/footer, que el banner mencione "Logging y exports restaurados" y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.10.1` en el header/footer, que el banner mencione "Hotfix Kaleido: fallback restaurado" y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
   - **Resolución:**
     1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
     2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.30.10"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.10.1"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.30.10"
+DEFAULT_VERSION: str = "0.3.30.10.1"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump the project version to 0.3.30.10.1 and keep shared defaults in sync
- document the Kaleido hotfix across README, docs and banner assets
- add a 0.3.30.10.1 changelog entry and regenerate the synced requirements list

## Testing
- python scripts/sync_requirements.py

------
https://chatgpt.com/codex/tasks/task_e_68e27509a15c8332aeb370f70200b4b9