### PR TITLE
Handle empty chart PNG exports in Excel workbook

### DIFF
--- a/shared/portfolio_export.py
+++ b/shared/portfolio_export.py
@@ -858,7 +858,16 @@ def create_excel_workbook(
                     charts_sheet.write(row, 0, "No se pudo exportar el gráfico (kaleido ausente)")
                     row += 18
                     continue
-                charts_sheet.insert_image(row, 0, f"{key}.png", {"image_data": BytesIO(img_bytes), "x_scale": 0.9, "y_scale": 0.9})
+                if not img_bytes or len(img_bytes) < 8:
+                    logger.warning("⛔ Imagen omitida: %s (PNG vacío o inválido)", key)
+                    row += 20
+                    continue
+                charts_sheet.insert_image(
+                    row,
+                    0,
+                    f"{key}.png",
+                    {"image_data": BytesIO(img_bytes), "x_scale": 0.9, "y_scale": 0.9},
+                )
                 row += 20
 
     return buffer.getvalue()


### PR DESCRIPTION
## Summary
- skip embedding chart images when the generated PNG data is empty or too small
- keep existing kaleido conversion warning path while maintaining row spacing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e278a9d25083329479887af76af730