### PR TITLE
Handle missing chart images when exporting Excel

### DIFF
--- a/shared/portfolio_export.py
+++ b/shared/portfolio_export.py
@@ -858,6 +858,12 @@ def create_excel_workbook(
                     charts_sheet.write(row, 0, "No se pudo exportar el gráfico (kaleido ausente)")
                     row += 18
                     continue
+
+                if not img_bytes:
+                    logger.warning("⛔ Imagen omitida: %s", key)
+                    charts_sheet.write(row, 0, "⛔ Imagen omitida")
+                    row += 2
+                    continue
                 charts_sheet.insert_image(row, 0, f"{key}.png", {"image_data": BytesIO(img_bytes), "x_scale": 0.9, "y_scale": 0.9})
                 row += 20
 

--- a/tests/shared/test_excel_export_resilience.py
+++ b/tests/shared/test_excel_export_resilience.py
@@ -1,0 +1,70 @@
+"""Regression tests for Excel export resilience when chart images are missing."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+import sys
+
+import pandas as pd
+import plotly.graph_objects as go
+import pytest
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from shared import portfolio_export as export
+
+
+def _snapshot() -> export.PortfolioSnapshotExport:
+    return export.PortfolioSnapshotExport(
+        name="demo",
+        generated_at=None,
+        positions=pd.DataFrame([{"simbolo": "AAA", "pl": 10.0, "valor_actual": 100.0}]),
+        totals={"total_value": 100.0},
+        history=pd.DataFrame(),
+        contributions_by_symbol=pd.DataFrame(),
+        contributions_by_type=pd.DataFrame(),
+    )
+
+
+def _patch_export_dependencies(monkeypatch: pytest.MonkeyPatch) -> list[str]:
+    chart_keys = ["timeline", "composition"]
+
+    def fake_assemble_tables(*_args, **_kwargs):
+        return {"kpis": pd.DataFrame([{"metric": "dummy", "value": 1}])}
+
+    def fake_build_chart_figures(
+        _snapshot: export.PortfolioSnapshotExport,
+        keys: list[str],
+        *,
+        limit: int = 10,
+    ) -> dict[str, go.Figure]:
+        return {key: go.Figure() for key in keys}
+
+    monkeypatch.setattr(export, "assemble_tables", fake_assemble_tables)
+    monkeypatch.setattr(export, "build_chart_figures", fake_build_chart_figures)
+
+    return chart_keys
+
+
+@pytest.mark.parametrize("png_bytes", [None, b""])
+def test_excel_export_skips_missing_chart_images(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture, png_bytes: bytes | None
+) -> None:
+    chart_keys = _patch_export_dependencies(monkeypatch)
+    monkeypatch.setattr(export, "fig_to_png_bytes", lambda _fig: png_bytes)
+
+    caplog.set_level(logging.WARNING, logger=export.logger.name)
+
+    workbook_bytes = export.create_excel_workbook(_snapshot(), chart_keys=chart_keys)
+
+    assert workbook_bytes
+    assert len(workbook_bytes) > 0
+
+    for key in chart_keys:
+        assert any(
+            "⛔ Imagen omitida" in record.message and key in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
## Summary
- log and skip chart images when PNG rendering returns no bytes
- add regression tests covering Excel export resilience when chart PNGs are unavailable

## Testing
- pytest --override-ini=addopts= tests/shared/test_excel_export_resilience.py

------
https://chatgpt.com/codex/tasks/task_e_68e278aabc7c8332a93f6e3490f0f4c0