### PR TITLE
Add changelog entry for 0.3.30.10.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## [0.3.30.10.2] - Robust Excel export
+
+### Fixed
+- Reforzada la generación de `analysis.xlsx` para reintentar exportes con hojas vacías y conservar
+  el archivo dentro de `analysis.zip` aun cuando la primera iteración falle.
+- Normalizados los nombres de hojas y encabezados para evitar errores de `ExcelSheetNameError` en
+  portafolios con símbolos extensos o caracteres especiales.
+- Alineada la conversión de tipos mixtos en columnas numéricas para impedir que se descarten
+  registros al aplicar formatos durante la exportación.
+
 ## [0.3.30.10.1] - Hotfix entorno Kaleido
 
 ### Changed


### PR DESCRIPTION
## Summary
- document release 0.3.30.10.2 with a dedicated section in the changelog
- note the robustness fixes applied to the Excel export workflow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e278abd5f08332bbc9836ec8b6bee6