### PR TITLE
Remove redundant quote success debug log

### DIFF
--- a/infrastructure/iol/client.py
+++ b/infrastructure/iol/client.py
@@ -615,15 +615,6 @@ class IOLClient(IIOLProvider):
                         source="v2",
                         ok=True,
                     )
-                    logger.debug(
-                        "✅ Quotes OK from /Titulos/Cotizacion",
-                        extra={
-                            "market": resolved_market,
-                            "symbol": resolved_symbol,
-                            "panel": panel,
-                            "currency": payload.get("currency"),
-                        },
-                    )
                     self._record_batch_result(
                         resolved_market,
                         resolved_symbol,


### PR DESCRIPTION
## Summary
- remove the duplicate per-symbol success debug log from `IOLClient.get_quote`
- keep provider usage telemetry while relying on the existing batch summary from `fetch_quotes_bulk`

## Testing
- pytest tests/services/test_fetch_quotes_logging.py

------
https://chatgpt.com/codex/tasks/task_e_68e29638b66c8332ae3619c6914cf05c