### PR TITLE
Remove matplotlib from dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -803,7 +803,7 @@ El script actualiza los paquetes a sus últimas versiones disponibles, ejecuta l
 2. Regenera la lista plana para CI: `python scripts/sync_requirements.py`.
 3. Reinstala las dependencias en tu entorno virtual (`pip install -r requirements.txt`) y ejecuta las suites necesarias.
 
-La guía interna que detalla cómo recrear los assets del dashboard se apoya en el script generador correspondiente; `matplotlib` y `kaleido` se incluyen automáticamente al instalar `requirements.txt`, por lo que no hace falta agregarlos manualmente antes de correr ese flujo.
+La guía interna que detalla cómo recrear los assets del dashboard se apoya en el script generador correspondiente; `kaleido` se incluye automáticamente al instalar `requirements.txt`, por lo que no hace falta agregarlo manualmente antes de correr ese flujo.
 
 ## Políticas de sesión y manejo de tokens
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ dependencies = [
     "python-dotenv==1.1.1",
     "iolConn==0.4.2",
     "plotly==6.3.0",
-    "matplotlib==3.10.6",
     "kaleido==0.2.1",
     "XlsxWriter==3.2.0",
     "tomli==2.0.1",

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ requests==2.31.0
 python-dotenv==1.1.1
 iolConn==0.4.2
 plotly==6.3.0
-matplotlib==3.10.6
 kaleido==0.2.1
 XlsxWriter==3.2.0
 tomli==2.0.1

--- a/scripts/update_dependencies.sh
+++ b/scripts/update_dependencies.sh
@@ -13,7 +13,6 @@ PACKAGES=(
   python-dotenv
   iolConn
   plotly
-  matplotlib
   kaleido
   XlsxWriter
   tomli


### PR DESCRIPTION
## Summary
- remove matplotlib from the pinned dependency list and regenerate the synced requirements files
- update contributor documentation to reflect that only kaleido ships automatically for the asset generator workflow
- align the dependency update helper script with the trimmed dependency set

## Testing
- python - <<'PY'
import importlib, sys
for module in ["application", "controllers", "services", "shared.config"]:
    importlib.import_module(module)
print("Imports succeeded")
print("matplotlib loaded:", any(name.startswith("matplotlib") for name in sys.modules))
PY


------
https://chatgpt.com/codex/tasks/task_e_68e2963b9e788332989141093a95dcb6