### PR TITLE
Track snapshot health events

### DIFF
--- a/tests/services/test_health_metrics.py
+++ b/tests/services/test_health_metrics.py
@@ -66,3 +66,24 @@ def test_quote_provider_summary_returns_dict(monkeypatch):
     assert isinstance(summary, dict)
     assert summary["providers"]
 
+
+def test_record_snapshot_event_stores_backend_details(monkeypatch):
+    fake_state: dict[str, dict] = {}
+    monkeypatch.setattr(health, "st", SimpleNamespace(session_state=fake_state))
+
+    health.record_snapshot_event(
+        kind="portfolio",
+        status="saved",
+        action="save",
+        storage_id="abc123",
+        backend={"name": "json", "path": "/tmp/snapshots.json"},
+    )
+
+    event = health.get_health_metrics()["snapshot_event"]
+
+    assert event["kind"] == "portfolio"
+    assert event["status"] == "saved"
+    assert event["action"] == "save"
+    assert event["storage_id"] == "abc123"
+    assert event["backend"]["name"] == "json"
+


### PR DESCRIPTION
## Summary
- add a snapshot event recorder to the health metrics store and expose it through get_health_metrics
- capture snapshot save/reuse events from PortfolioViewModelService so callers can see backend details and timestamps
- cover the new helper with a unit test

## Testing
- pytest --override-ini addopts="" tests/services/test_health_metrics.py tests/services/test_portfolio_view_model.py

------
https://chatgpt.com/codex/tasks/task_e_68e2963f1700833291fa886738d26554