### PR TITLE
Bump application version to 0.3.30.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.30.10.2"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.11"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.30.10.2"
+DEFAULT_VERSION: str = "0.3.30.11"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- update the package metadata to version 0.3.30.11 in pyproject.toml
- sync shared.version.DEFAULT_VERSION with the new release so UI surfaces display the bumped version automatically

## Testing
- pytest --override-ini addopts='' tests/test_version_sync.py

------
https://chatgpt.com/codex/tasks/task_e_68e2963ffa3c8332b87a09ede8ce23ca