### PR TITLE
Add diagnostics and session monitoring to health sidebar

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ class _DummySidebar:
         self.headers: list[str] = []
         self.captions: list[str] = []
         self.markdowns: list[str] = []
+        self.download_buttons: list[dict[str, Any]] = []
         self.elements: list[dict[str, Any]] = []
 
     def header(self, text: object) -> None:
@@ -53,6 +54,26 @@ class _DummySidebar:
         value = str(text)
         self.markdowns.append(value)
         self.elements.append({"type": "markdown", "text": value})
+
+    def download_button(
+        self,
+        label: str,
+        data: Any,
+        *,
+        file_name: str | None = None,
+        mime: str | None = None,
+        key: str | None = None,
+    ) -> None:
+        record = {
+            "type": "download_button",
+            "label": str(label),
+            "data": data,
+            "file_name": file_name,
+            "mime": mime,
+            "key": key,
+        }
+        self.download_buttons.append(record)
+        self.elements.append(record)
 
 
 class _DummyContext:


### PR DESCRIPTION
## Summary
- extend the sidebar helpers to render session monitoring and diagnostics status with new status badges
- expose an analysis.log download action with error handling
- update the sidebar stub and tests to cover the new sections and download button

## Testing
- pytest -o addopts='' tests/ui/test_health_sidebar.py tests/test_health_sidebar_rendering.py


------
https://chatgpt.com/codex/tasks/task_e_68e2a09b44108332a3482e015ea9c0a0