### PR TITLE
Add startup diagnostics service and monitoring sidebar tests

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -27,6 +27,16 @@ Ejecuta todas las pruebas desde la raíz del repositorio:
 pytest
 ```
 
+Cuando necesites una corrida rápida sin la sobrecarga de cobertura puedes
+invocar Pytest anulando el valor de `addopts` definido en `pyproject.toml`:
+
+```bash
+pytest --override-ini addopts=''
+```
+
+Esto resulta útil para los ciclos de TDD locales o al depurar suites nuevas
+que no requieren medir cobertura.
+
 El proyecto incorpora `pytest.ini` con marcadores y configuración de logging. La ejecución completa
 usa los stubs deterministas para mantener resultados reproducibles.
 

--- a/services/diagnostics.py
+++ b/services/diagnostics.py
@@ -1,0 +1,152 @@
+
+from __future__ import annotations
+
+"""Utilities to collect startup diagnostics and publish them to telemetry logs."""
+
+from typing import Any, Mapping
+import logging
+
+import streamlit as st
+
+from shared.time_provider import TimeProvider
+from services.health import get_health_metrics
+
+
+analysis_logger = logging.getLogger("analysis")
+
+_STATUS_ICONS: Mapping[str, str] = {
+    "success": "✅",
+    "ok": "✅",
+    "warning": "⚠️",
+    "degraded": "⚠️",
+    "error": "❌",
+    "critical": "❌",
+    "stale": "🟡",
+    "info": "ℹ️",
+}
+
+
+def _normalize_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_normalize_value(item) for item in value]
+    if isinstance(value, Mapping):
+        return {str(key): _normalize_value(val) for key, val in value.items()}
+    return str(value)
+
+
+def _snapshot_session_state(state: Mapping[str, Any]) -> dict[str, Any]:
+    session_id = state.get("session_id")
+    snapshot: dict[str, Any] = {
+        "id": str(session_id) if session_id is not None else None,
+    }
+
+    values: dict[str, Any] = {}
+    flags: list[str] = []
+
+    for key in sorted(state):
+        if key == "session_id" or key.startswith("_"):
+            continue
+        value = state[key]
+        if isinstance(value, bool):
+            values[key] = value
+            if value:
+                flags.append(key)
+            continue
+        values[key] = _normalize_value(value)
+
+    if values:
+        snapshot["values"] = values
+    if flags:
+        snapshot["flags"] = sorted(flags)
+
+    return snapshot
+
+
+def _coerce_icon(entry: Mapping[str, Any], *, fallback: str) -> str:
+    icon = entry.get("icon")
+    if isinstance(icon, str) and icon.strip():
+        return icon.strip()
+
+    status = entry.get("status")
+    status_key = str(status or "").strip().casefold()
+    mapped = _STATUS_ICONS.get(status_key)
+    if mapped:
+        return mapped
+    return "ℹ️"
+
+
+def _resolve_label(entry: Mapping[str, Any], *, fallback: str) -> str:
+    label = entry.get("label")
+    if isinstance(label, str) and label.strip():
+        return label.strip()
+    name = entry.get("name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return fallback
+
+
+def _resolve_value(entry: Mapping[str, Any]) -> str:
+    status = entry.get("status")
+    detail = entry.get("detail")
+    value = None
+    if isinstance(status, str) and status.strip():
+        value = status.strip()
+    raw_value = entry.get("value")
+    if value is None and isinstance(raw_value, str) and raw_value.strip():
+        value = raw_value.strip()
+    if value is None:
+        numeric = entry.get("elapsed_ms") or entry.get("latency_ms")
+        if isinstance(numeric, (int, float)):
+            value = f"{float(numeric):.0f} ms"
+    if value is None:
+        value = "s/d"
+
+    if isinstance(detail, str) and detail.strip():
+        return f"{value} — {detail.strip()}"
+    return value
+
+
+def _collect_highlights(metrics: Mapping[str, Any]) -> list[dict[str, Any]]:
+    highlights: list[dict[str, Any]] = []
+    if not isinstance(metrics, Mapping):
+        return highlights
+
+    for key in sorted(metrics):
+        entry = metrics.get(key)
+        if not isinstance(entry, Mapping):
+            continue
+        label = _resolve_label(entry, fallback=key.replace("_", " ").title())
+        icon = _coerce_icon(entry, fallback=label)
+        value = _resolve_value(entry)
+        highlights.append({
+            "id": key,
+            "icon": icon,
+            "label": label,
+            "value": value,
+        })
+
+    return highlights
+
+
+def run_startup_diagnostics() -> dict[str, Any]:
+    """Gather startup diagnostics combining health metrics and session data."""
+
+    metrics = get_health_metrics()
+    session_snapshot = _snapshot_session_state(st.session_state)
+    timestamp = TimeProvider.now()
+
+    payload: dict[str, Any] = {
+        "event": "startup.diagnostics",
+        "timestamp": timestamp,
+        "session": session_snapshot,
+        "metrics": metrics,
+        "highlights": _collect_highlights(metrics),
+    }
+
+    analysis_logger.info("startup.diagnostics", extra={"analysis": payload})
+    return payload
+
+
+__all__ = ["run_startup_diagnostics"]

--- a/tests/services/test_diagnostics.py
+++ b/tests/services/test_diagnostics.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+import importlib
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def diagnostics_module(monkeypatch: pytest.MonkeyPatch, streamlit_stub):
+    import services.diagnostics as diagnostics
+
+    module = importlib.reload(diagnostics)
+    monkeypatch.setattr(module, "st", streamlit_stub)
+    return module
+
+
+def test_run_startup_diagnostics_formats_payload(
+    diagnostics_module, monkeypatch: pytest.MonkeyPatch, streamlit_stub
+) -> None:
+    streamlit_stub.session_state.update(
+        {
+            "session_id": "abc123",
+            "authenticated": True,
+            "force_login": False,
+            "locale": "es_AR",
+            "attempts": 3,
+            "metadata": {"region": "AR"},
+        }
+    )
+
+    fake_time = SimpleNamespace(now=lambda: "2024-05-18 10:15:00")
+    monkeypatch.setattr(diagnostics_module, "TimeProvider", fake_time)
+
+    health_metrics = {
+        "quotes": {"status": "success", "label": "Cotizaciones", "detail": "3 proveedores"},
+        "fx_api": {"status": "error", "label": "FX", "detail": "Timeout"},
+        "other": "ignored",
+    }
+    monkeypatch.setattr(diagnostics_module, "get_health_metrics", lambda: health_metrics)
+
+    logger = Mock()
+    monkeypatch.setattr(diagnostics_module, "analysis_logger", logger)
+
+    payload = diagnostics_module.run_startup_diagnostics()
+
+    assert payload["event"] == "startup.diagnostics"
+    assert payload["timestamp"] == "2024-05-18 10:15:00"
+
+    session = payload["session"]
+    assert session["id"] == "abc123"
+    assert "authenticated" in session.get("flags", [])
+    assert session["values"]["locale"] == "es_AR"
+    assert session["values"]["metadata"] == {"region": "AR"}
+
+    highlights = payload["highlights"]
+    assert any(entry["icon"] == "✅" and "Cotizaciones" in entry["label"] for entry in highlights)
+    assert any(entry["icon"] == "❌" and entry["label"] == "FX" for entry in highlights)
+
+    logger.info.assert_called_once()
+    args, kwargs = logger.info.call_args
+    assert args == ("startup.diagnostics",)
+    assert kwargs["extra"]["analysis"] == payload

--- a/tests/ui/test_health_sidebar_monitoring.py
+++ b/tests/ui/test_health_sidebar_monitoring.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+import sys
+from typing import Mapping
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+@pytest.fixture
+def monitoring_sidebar(monkeypatch: pytest.MonkeyPatch, streamlit_stub):
+    import ui.health_sidebar_monitoring as monitoring
+
+    module = importlib.reload(monitoring)
+    monkeypatch.setattr(module, "st", streamlit_stub)
+    return module
+
+
+def _sample_payload() -> Mapping[str, object]:
+    return {
+        "timestamp": "2024-05-18 10:15:00",
+        "highlights": [
+            {"icon": "✅", "label": "Cotizaciones", "value": "success"},
+            {"icon": "⚠️", "label": "FX", "value": "timeout"},
+        ],
+        "session": {
+            "values": {"session_id": "abc123", "authenticated": True, "locale": "es_AR"},
+            "flags": ["authenticated"],
+        },
+        "event": "startup.diagnostics",
+    }
+
+
+def test_render_monitoring_sidebar_renders_highlights(monitoring_sidebar, streamlit_stub) -> None:
+    payload = dict(_sample_payload())
+    monitoring_sidebar.render_monitoring_sidebar(payload)
+
+    markdowns = streamlit_stub.sidebar.markdowns
+    assert any("✅ **Cotizaciones:** success" in line for line in markdowns)
+    assert any("⚠️ **FX:** timeout" in line for line in markdowns)
+    assert any("• locale: es_AR" in line for line in markdowns)
+    assert any("✅ authenticated" in line for line in markdowns)
+
+    downloads = streamlit_stub.get_records("download_button")
+    assert downloads
+    button = downloads[0]
+    assert button["label"] == "Descargar diagnóstico"
+    assert button["mime"] == "application/json"
+    assert "startup.diagnostics" in button["data"]

--- a/ui/health_sidebar_monitoring.py
+++ b/ui/health_sidebar_monitoring.py
@@ -1,0 +1,82 @@
+
+from __future__ import annotations
+
+"""Render helpers for the monitoring sidebar that surfaces startup diagnostics."""
+
+from typing import Any, Mapping, Sequence
+import json
+
+import streamlit as st
+
+DEFAULT_DOWNLOAD_LABEL = "Descargar diagnóstico"
+DEFAULT_FILE_NAME = "startup_diagnostics.json"
+
+
+def _format_highlight(entry: Mapping[str, Any]) -> str:
+    icon = str(entry.get("icon") or "•").strip() or "•"
+    label = str(entry.get("label") or entry.get("id") or "").strip()
+    value = entry.get("value")
+    if isinstance(value, (int, float)):
+        value_text = f"{value}"
+    elif value is None:
+        value_text = "s/d"
+    else:
+        value_text = str(value)
+    if label:
+        return f"{icon} **{label}:** {value_text}"
+    return f"{icon} {value_text}"
+
+
+def _render_session_section(session: Mapping[str, Any]) -> None:
+    values = session.get("values")
+    if isinstance(values, Mapping) and values:
+        st.sidebar.markdown("#### Sesión")
+        for key in sorted(values):
+            st.sidebar.markdown(f"• {key}: {values[key]}")
+
+    flags = session.get("flags")
+    if isinstance(flags, Sequence):
+        active = [str(flag) for flag in flags if str(flag).strip()]
+    else:
+        active = []
+    if active:
+        st.sidebar.markdown("#### Flags activos")
+        for flag in active:
+            st.sidebar.markdown(f"✅ {flag}")
+
+
+def render_monitoring_sidebar(payload: Mapping[str, Any]) -> None:
+    """Render the monitoring sidebar based on the diagnostics payload."""
+
+    st.sidebar.header("🩺 Diagnóstico de arranque")
+    timestamp = payload.get("timestamp")
+    if isinstance(timestamp, str) and timestamp.strip():
+        st.sidebar.caption(f"Generado el {timestamp.strip()}")
+
+    highlights = payload.get("highlights")
+    if isinstance(highlights, Sequence):
+        for entry in highlights:
+            if isinstance(entry, Mapping):
+                st.sidebar.markdown(_format_highlight(entry))
+
+    session = payload.get("session")
+    if isinstance(session, Mapping):
+        _render_session_section(session)
+
+    export_label = payload.get("download_label")
+    label = str(export_label).strip() if isinstance(export_label, str) else DEFAULT_DOWNLOAD_LABEL
+    file_name = payload.get("download_file_name")
+    if not isinstance(file_name, str) or not file_name.strip():
+        file_name = DEFAULT_FILE_NAME
+
+    data = json.dumps(payload, ensure_ascii=False, sort_keys=True, indent=2)
+    st.download_button(
+        label,
+        data=data,
+        file_name=file_name,
+        mime="application/json",
+        key="startup_diagnostics",
+    )
+
+
+__all__ = ["render_monitoring_sidebar"]


### PR DESCRIPTION
## Summary
- introduce a diagnostics service that snapshots session state and health metrics while logging to the analysis channel
- add unit tests covering the diagnostics payload structure and monitoring sidebar rendering with fake metrics
- document how to disable coverage flags via `pytest --override-ini addopts=''` for quick local runs

## Testing
- pytest --override-ini addopts='' tests/services/test_diagnostics.py tests/ui/test_health_sidebar_monitoring.py

------
https://chatgpt.com/codex/tasks/task_e_68e2a09ca0e48332b3aa696cf971420b