### PR TITLE
Implement daily log rotation with retention cleanup

### DIFF
--- a/shared/settings.py
+++ b/shared/settings.py
@@ -36,6 +36,7 @@ notifications_url: str | None = getattr(settings, "NOTIFICATIONS_URL", None)
 notifications_timeout: float = getattr(settings, "NOTIFICATIONS_TIMEOUT", 3.0)
 min_score_threshold: int = settings.min_score_threshold
 max_results: int = settings.max_results
+log_retention_days: int = getattr(settings, "LOG_RETENTION_DAYS", 7)
 stub_max_runtime_warn: float = getattr(settings, "STUB_MAX_RUNTIME_WARN", 0.25)
 STUB_MAX_RUNTIME_WARN: float = stub_max_runtime_warn
 
@@ -122,6 +123,7 @@ __all__ = [
     "notifications_timeout",
     "min_score_threshold",
     "max_results",
+    "log_retention_days",
     "stub_max_runtime_warn",
     "STUB_MAX_RUNTIME_WARN",
     "snapshot_backend",

--- a/tests/shared/test_log_rotation.py
+++ b/tests/shared/test_log_rotation.py
@@ -1,0 +1,70 @@
+import logging
+from datetime import datetime, timedelta
+
+import pytest
+
+from shared import config
+
+
+@pytest.fixture()
+def _isolated_root_logger():
+    root_logger = logging.getLogger()
+    original_level = root_logger.level
+    original_handlers = root_logger.handlers[:]
+
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
+        try:
+            handler.close()
+        except Exception:
+            pass
+
+    try:
+        yield root_logger
+    finally:
+        for handler in root_logger.handlers[:]:
+            root_logger.removeHandler(handler)
+            try:
+                handler.close()
+            except Exception:
+                pass
+
+        for handler in original_handlers:
+            root_logger.addHandler(handler)
+
+        root_logger.setLevel(original_level)
+
+
+def test_configure_logging_prunes_old_log_files(tmp_path, monkeypatch, _isolated_root_logger):
+    retention_days = 3
+    monkeypatch.setattr(config, "BASE_DIR", tmp_path)
+    monkeypatch.setattr(config.settings, "LOG_RETENTION_DAYS", retention_days, raising=False)
+
+    today = datetime.now().date()
+    all_dates = [today - timedelta(days=offset) for offset in range(retention_days + 3)]
+    for current_date in all_dates:
+        log_path = tmp_path / f"analysis_{current_date.strftime('%Y-%m-%d')}.log"
+        log_path.write_text("legacy", encoding="utf-8")
+
+    legacy_path = tmp_path / "analysis.log"
+    legacy_path.write_text("legacy", encoding="utf-8")
+
+    config.configure_logging(level="INFO", json_format=False)
+
+    remaining_files = {path.name for path in tmp_path.glob("analysis_*.log")}
+
+    expected_kept = {
+        f"analysis_{(today - timedelta(days=offset)).strftime('%Y-%m-%d')}.log"
+        for offset in range(retention_days)
+    }
+    assert expected_kept <= remaining_files
+
+    removed_cutoff = today - timedelta(days=retention_days)
+    assert f"analysis_{removed_cutoff.strftime('%Y-%m-%d')}.log" not in remaining_files
+    assert not legacy_path.exists()
+
+    # Logging still works and writes to today's file.
+    _isolated_root_logger.info("rotation test")
+    today_file = tmp_path / f"analysis_{today.strftime('%Y-%m-%d')}.log"
+    assert today_file.exists()
+    assert "rotation test" in today_file.read_text(encoding="utf-8")

--- a/tests/shared/test_logging_configuration.py
+++ b/tests/shared/test_logging_configuration.py
@@ -1,7 +1,7 @@
 import json
 import logging
+from datetime import datetime
 from pathlib import Path
-from logging.handlers import RotatingFileHandler
 
 import pytest
 
@@ -58,12 +58,16 @@ def test_configure_logging_adds_rotating_file_handler(tmp_path, monkeypatch, jso
     try:
         config.configure_logging(level="INFO", json_format=json_format)
         file_handlers = [
-            handler for handler in root_logger.handlers if isinstance(handler, RotatingFileHandler)
+            handler
+            for handler in root_logger.handlers
+            if isinstance(handler, config.DailyTimedRotatingFileHandler)
         ]
         assert len(file_handlers) == 1
 
         log_file = Path(file_handlers[0].baseFilename)
         assert log_file.parent == tmp_path
+        today = datetime.now().strftime("%Y-%m-%d")
+        assert log_file.name == f"analysis_{today}.log"
 
         root_logger.info("hello world")
 

--- a/tests/shared/test_settings.py
+++ b/tests/shared/test_settings.py
@@ -130,6 +130,16 @@ def test_settings_score_parameters_from_config(monkeypatch):
         assert settings.max_results == 12
 
 
+def test_settings_log_retention_defaults_to_seven_days(monkeypatch):
+    with _fresh_settings(monkeypatch) as settings:
+        assert settings.LOG_RETENTION_DAYS == 7
+
+
+def test_settings_log_retention_respects_environment(monkeypatch):
+    with _fresh_settings(monkeypatch, env={"LOG_RETENTION_DAYS": "15"}) as settings:
+        assert settings.LOG_RETENTION_DAYS == 15
+
+
 def test_shared_settings_reload_reflects_overrides(monkeypatch):
     """``shared.settings`` should surface env overrides and keep aliases."""
 


### PR DESCRIPTION
## Summary
- replace the size-based log handler with a custom timed rotation that writes daily analysis_YYYY-MM-DD.log files
- add LOG_RETENTION_DAYS configuration and prune legacy/aged log files during logging setup
- expand logging and settings tests to cover the new rotation behavior and retention parsing

## Testing
- `PYTHONPATH=. pytest -o addopts="" tests/shared/test_logging_configuration.py tests/shared/test_log_rotation.py tests/shared/test_settings.py`


------
https://chatgpt.com/codex/tasks/task_e_68e2b297fcac833285f87bd505d2b631