### PR TITLE
Add environment badge and recent stats charts to health sidebar

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,6 +55,40 @@ class _DummySidebar:
         self.markdowns.append(value)
         self.elements.append({"type": "markdown", "text": value})
 
+    def line_chart(
+        self,
+        data: Any,
+        *,
+        use_container_width: bool | None = None,
+        height: int | None = None,
+        width: int | None = None,
+    ) -> None:
+        record = {
+            "type": "line_chart",
+            "data": data,
+            "use_container_width": use_container_width,
+            "height": height,
+            "width": width,
+        }
+        self.elements.append(record)
+
+    def area_chart(
+        self,
+        data: Any,
+        *,
+        use_container_width: bool | None = None,
+        height: int | None = None,
+        width: int | None = None,
+    ) -> None:
+        record = {
+            "type": "area_chart",
+            "data": data,
+            "use_container_width": use_container_width,
+            "height": height,
+            "width": width,
+        }
+        self.elements.append(record)
+
     def download_button(
         self,
         label: str,
@@ -224,6 +258,38 @@ class _DummyStreamlitCore:
 
     def plotly_chart(self, fig: object, **kwargs: Any) -> None:
         self._record("plotly_chart", fig=fig, kwargs=kwargs)
+
+    def line_chart(
+        self,
+        data: Any,
+        *,
+        use_container_width: bool | None = None,
+        height: int | None = None,
+        width: int | None = None,
+    ) -> None:
+        self._record(
+            "line_chart",
+            data=data,
+            use_container_width=use_container_width,
+            height=height,
+            width=width,
+        )
+
+    def area_chart(
+        self,
+        data: Any,
+        *,
+        use_container_width: bool | None = None,
+        height: int | None = None,
+        width: int | None = None,
+    ) -> None:
+        self._record(
+            "area_chart",
+            data=data,
+            use_container_width=use_container_width,
+            height=height,
+            width=width,
+        )
 
     def write(self, text: object) -> None:
         self._record("write", text=text)
@@ -500,6 +566,8 @@ for _name in (
     "empty",
     "dataframe",
     "download_button",
+    "line_chart",
+    "area_chart",
     "altair_chart",
     "cache_resource",
     "cache_data",

--- a/tests/ui/test_health_sidebar_history.py
+++ b/tests/ui/test_health_sidebar_history.py
@@ -1,0 +1,112 @@
+import importlib
+from typing import Any
+
+import pandas as pd
+import pytest
+
+
+def _render(module, metrics: dict[str, Any]) -> None:
+    module.st.session_state["health_metrics"] = metrics
+    module.render_health_sidebar()
+
+
+@pytest.fixture
+def health_sidebar(streamlit_stub, monkeypatch: pytest.MonkeyPatch):
+    import ui.health_sidebar as health_sidebar_module
+
+    module = importlib.reload(health_sidebar_module)
+    monkeypatch.setattr(
+        module,
+        "get_health_metrics",
+        lambda: module.st.session_state.get("health_metrics", {}),
+    )
+    return module
+
+
+def test_recent_stats_render_charts_and_badge(health_sidebar, streamlit_stub) -> None:
+    metrics = {
+        "environment_snapshot": {
+            "python_version": "3.11.6",
+            "streamlit_version": "1.32.0",
+            "runtime": "Local",
+            "ts": 1700000000.0,
+        },
+        "authentication": {},
+        "iol_refresh": {},
+        "yfinance": {},
+        "snapshot": {},
+        "fx_api": {
+            "stats": {"latency": {"samples": [110.0, 95.0, 102.0]}},
+        },
+        "fx_cache": {
+            "stats": {"age": {"samples": [1.0, 1.5, 0.5]}},
+        },
+        "portfolio": {
+            "stats": {"latency": {"samples": [200.0, 180.0, 220.0]}},
+        },
+        "quotes": {
+            "stats": {"latency": {"samples": [320.0, 300.0]}},
+        },
+        "session_monitoring": {
+            "http_errors": {
+                "count": 2,
+                "last": {
+                    "status_code": 502,
+                    "method": "get",
+                    "url": "/api/portfolio",
+                    "detail": "Bad gateway",
+                    "ts": 1699999999.0,
+                },
+            }
+        },
+    }
+
+    _render(health_sidebar, metrics)
+
+    assert any(
+        "🐍" in markdown and "Streamlit" in markdown
+        for markdown in streamlit_stub.sidebar.markdowns
+    ), "Expected environment badge in sidebar"
+
+    line_charts = [
+        element for element in streamlit_stub.sidebar.elements if element["type"] == "line_chart"
+    ]
+    assert line_charts, "Expected a line chart with latency samples"
+    assert isinstance(line_charts[0]["data"], pd.DataFrame)
+
+    area_charts = [
+        element for element in streamlit_stub.sidebar.elements if element["type"] == "area_chart"
+    ]
+    assert area_charts, "Expected an area chart with cache age samples"
+    assert isinstance(area_charts[0]["data"], pd.DataFrame)
+
+    assert any(
+        "Último error HTTP" in markdown for markdown in streamlit_stub.sidebar.markdowns
+    ), "Expected last HTTP error note"
+
+
+def test_recent_stats_section_handles_missing_samples(health_sidebar, streamlit_stub) -> None:
+    metrics: dict[str, Any] = {
+        "authentication": {},
+        "iol_refresh": {},
+        "yfinance": {},
+        "snapshot": {},
+        "session_monitoring": {},
+    }
+
+    _render(health_sidebar, metrics)
+
+    recent_section = [
+        markdown
+        for markdown in streamlit_stub.sidebar.markdowns
+        if "Estadísticas recientes" in markdown
+    ]
+    assert recent_section, "Section header should be rendered"
+
+    assert "_Sin estadísticas recientes._" in streamlit_stub.sidebar.markdowns
+    assert not [
+        element
+        for element in streamlit_stub.sidebar.elements
+        if element["type"] in {"line_chart", "area_chart"}
+    ]
+

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 """Sidebar panel summarising recent data source health."""
 
+import math
+import re
 from pathlib import Path
 from typing import Any, Iterable, Mapping, Optional, Sequence
 
+import pandas as pd
 import streamlit as st
 
 from services.health import get_health_metrics
@@ -214,14 +217,196 @@ def _format_session_monitoring(
     if avg_login:
         lines.append(format_note(f"⏱️ Promedio login→render: {avg_login}"))
 
-    last_error = _format_http_error(data.get("last_http_error"))
-    if last_error:
-        lines.append(last_error)
+    http_block = data.get("http_errors")
+    if isinstance(http_block, Mapping):
+        count_value = http_block.get("count")
+        summary_bits: list[str] = []
+        if isinstance(count_value, (int, float)) and int(count_value) > 0:
+            summary_bits.append(f"🚨 Errores HTTP {int(count_value)}")
+        last_entry = http_block.get("last")
+        last_ts = None
+        if isinstance(last_entry, Mapping):
+            last_ts = _coerce_timestamp(last_entry.get("ts"))
+        if last_ts is not None:
+            summary_bits.append(f"último {_format_timestamp(last_ts)}")
+        if summary_bits:
+            lines.append(format_note(" • ".join(summary_bits)))
+    else:
+        last_error = _format_http_error(data.get("last_http_error"))
+        if last_error:
+            lines.append(last_error)
 
     if len(lines) == 1:
         lines.append("_Sin datos de sesiones adicionales._")
 
     return lines
+
+
+def _normalize_numeric_samples(data: Any) -> list[float]:
+    if isinstance(data, Mapping):
+        raw_samples = data.get("samples")
+    else:
+        raw_samples = data
+
+    if not isinstance(raw_samples, Iterable) or isinstance(
+        raw_samples, (str, bytes, bytearray)
+    ):
+        return []
+
+    samples: list[float] = []
+    for entry in raw_samples:
+        try:
+            numeric = float(entry)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(numeric):
+            continue
+        samples.append(float(numeric))
+    return samples
+
+
+def _extract_stat_samples(entry: Any, metric: str) -> list[float]:
+    if not isinstance(entry, Mapping):
+        return []
+
+    stats = entry.get("stats")
+    if not isinstance(stats, Mapping):
+        return []
+
+    block = stats.get(metric)
+    if not isinstance(block, Mapping):
+        return []
+
+    return _normalize_numeric_samples(block.get("samples"))
+
+
+def _build_series_dataframe(series: Mapping[str, Iterable[float]]) -> Optional[pd.DataFrame]:
+    columns: dict[str, pd.Series] = {}
+    for label, values in series.items():
+        numeric_values = list(values)
+        if not numeric_values:
+            continue
+        columns[label] = pd.Series(numeric_values, dtype="float64")
+
+    if not columns:
+        return None
+
+    frame = pd.DataFrame(columns)
+    frame.index = frame.index + 1
+    frame.index.name = "Muestra"
+    return frame
+
+
+def _collect_latency_series(metrics: Mapping[str, Any]) -> Mapping[str, list[float]]:
+    series: dict[str, list[float]] = {}
+    entries = [
+        ("portfolio", "Portafolio (ms)"),
+        ("quotes", "Cotizaciones (ms)"),
+        ("fx_api", "FX API (ms)"),
+    ]
+    for key, label in entries:
+        samples = _extract_stat_samples(metrics.get(key), "latency")
+        if samples:
+            series[label] = samples
+    return series
+
+
+def _extract_semver(text: str) -> Optional[str]:
+    match = re.search(r"\d+(?:\.\d+){0,2}", text)
+    if not match:
+        return None
+    version = match.group(0)
+    parts = version.split(".")
+    if len(parts) >= 2:
+        return ".".join(parts[:2])
+    return version
+
+
+def _format_version_token(value: Any, *, icon: str, label: Optional[str] = None) -> Optional[str]:
+    text = _sanitize_text(value)
+    if not text:
+        return None
+    version = _extract_semver(text) or text
+    if label:
+        return f"{icon} {label} {version}"
+    return f"{icon} {version}"
+
+
+def _format_environment_badge(snapshot: Any) -> Optional[str]:
+    if not isinstance(snapshot, Mapping):
+        return None
+
+    python_token = _format_version_token(
+        snapshot.get("python_version") or snapshot.get("python"), icon="🐍"
+    )
+    streamlit_token = _format_version_token(
+        snapshot.get("streamlit_version") or snapshot.get("streamlit"),
+        icon="📊",
+        label="Streamlit",
+    )
+    runtime_label = _sanitize_text(
+        snapshot.get("runtime")
+        or snapshot.get("environment")
+        or snapshot.get("platform")
+    )
+    runtime_token = f"🖥️ {runtime_label}" if runtime_label else None
+
+    tokens = [token for token in (python_token, streamlit_token, runtime_token) if token]
+    if not tokens:
+        return None
+
+    ts_value = _coerce_timestamp(snapshot.get("ts"))
+    ts_text = _format_timestamp(ts_value)
+    if ts_text and ts_text != "Sin registro":
+        tokens.append(ts_text)
+
+    return format_note(" • ".join(tokens))
+
+
+def _format_recent_http_error(metrics: Mapping[str, Any]) -> Optional[str]:
+    monitoring = metrics.get("session_monitoring")
+    if isinstance(monitoring, Mapping):
+        http_block = monitoring.get("http_errors")
+        if isinstance(http_block, Mapping):
+            formatted = _format_http_error(http_block.get("last"))
+            if formatted:
+                return formatted
+            count_value = http_block.get("count")
+            if isinstance(count_value, (int, float)) and int(count_value) > 0:
+                return format_note(f"🚨 Errores HTTP registrados: {int(count_value)}")
+
+    raw_error = metrics.get("last_http_error")
+    if raw_error:
+        formatted = _format_http_error(raw_error)
+        if formatted:
+            return formatted
+    return None
+
+
+def _render_recent_stats(sidebar: Any, metrics: Mapping[str, Any]) -> None:
+    charts_rendered = False
+
+    latency_series = _collect_latency_series(metrics)
+    latency_frame = _build_series_dataframe(latency_series)
+    if latency_frame is not None:
+        sidebar.line_chart(latency_frame)
+        charts_rendered = True
+
+    cache_samples = _extract_stat_samples(metrics.get("fx_cache"), "age")
+    if cache_samples:
+        cache_frame = pd.DataFrame({"Edad caché (s)": pd.Series(cache_samples, dtype="float64")})
+        cache_frame.index = cache_frame.index + 1
+        cache_frame.index.name = "Muestra"
+        sidebar.area_chart(cache_frame)
+        charts_rendered = True
+
+    http_note = _format_recent_http_error(metrics)
+    if http_note:
+        sidebar.markdown(http_note)
+        charts_rendered = True
+
+    if not charts_rendered:
+        sidebar.markdown("_Sin estadísticas recientes._")
 
 
 def _format_active_sessions(data: Any) -> Optional[str]:
@@ -278,7 +463,8 @@ def _format_http_error(data: Any) -> Optional[str]:
         return None
 
     status_code = data.get("status") or data.get("status_code")
-    path = _sanitize_text(data.get("path") or data.get("endpoint"))
+    method = _sanitize_text(data.get("method"))
+    path = _sanitize_text(data.get("path") or data.get("endpoint") or data.get("url"))
     ts_text = _format_timestamp(_coerce_timestamp(data.get("ts")))
     detail_text = _sanitize_text(data.get("detail") or data.get("message"))
 
@@ -286,6 +472,8 @@ def _format_http_error(data: Any) -> Optional[str]:
     if status_code is not None:
         header += f" {status_code}"
     tokens = [header]
+    if method:
+        tokens.append(method.upper())
     if path:
         tokens.append(path)
     if ts_text:
@@ -1702,6 +1890,10 @@ def render_health_sidebar() -> None:
     sidebar.header(f"🩺 Healthcheck (versión {__version__})")
     sidebar.caption("Monitorea la procedencia y el rendimiento de los datos cargados.")
 
+    env_badge = _format_environment_badge(metrics.get("environment_snapshot"))
+    if env_badge:
+        sidebar.markdown(env_badge)
+
     auth_metrics = None
     for key in ("authentication", "auth_state", "auth"):
         candidate = metrics.get(key)
@@ -1773,6 +1965,9 @@ def render_health_sidebar() -> None:
     sidebar.markdown("#### 🧭 Monitoreo de sesiones")
     for line in _format_session_monitoring(metrics.get("session_monitoring")):
         sidebar.markdown(line)
+
+    sidebar.markdown("#### 📈 Estadísticas recientes")
+    _render_recent_stats(sidebar, metrics)
 
     sidebar.markdown("#### 🧪 Diagnóstico inicial")
     for line in _format_diagnostics_section(metrics.get("diagnostics")):


### PR DESCRIPTION
## Summary
- enrich the health sidebar with an environment snapshot badge, updated HTTP error formatting and a recent statistics section that renders latency and cache history charts
- extend the Streamlit test stub to record line and area charts so UI tests can assert the new behaviour
- add regression tests for the sidebar recent history features and HTTP error integration

## Testing
- pytest -o addopts='' tests/ui/test_health_sidebar.py tests/ui/test_health_sidebar_monitoring.py tests/ui/test_health_sidebar_history.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b299005483329e9860eed3af7972