### PR TITLE
Check critical dependencies at startup

### DIFF
--- a/tests/test_app_dependencies.py
+++ b/tests/test_app_dependencies.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "app.py"
+sys.path.insert(0, str(MODULE_PATH.parent))
+SPEC = importlib.util.spec_from_file_location("app", MODULE_PATH)
+assert SPEC and SPEC.loader  # pragma: no cover - defensive assertion
+app = importlib.util.module_from_spec(SPEC)
+sys.modules.setdefault("app", app)
+SPEC.loader.exec_module(app)
+
+
+def test_dependency_check_logs_warning(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    from services import health
+
+    fake_state: dict[str, object] = {}
+    stub_streamlit = SimpleNamespace(session_state=fake_state, stop=lambda: None)
+    monkeypatch.setattr(app, "st", stub_streamlit)
+    monkeypatch.setattr(health, "st", stub_streamlit)
+
+    original_import = app.importlib.import_module
+
+    def fake_import(name: str, *args, **kwargs):
+        if name == "plotly":
+            raise ImportError("plotly missing")
+        if name == "kaleido":
+            return SimpleNamespace()
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(app.importlib, "import_module", fake_import)
+    monkeypatch.setattr(app, "_ensure_kaleido_runtime_safe", lambda: None)
+
+    caplog.set_level(logging.WARNING, logger="analysis")
+
+    results = app._check_critical_dependencies()
+
+    assert results["plotly"]["status"] == "error"
+    assert any("plotly" in record.getMessage().lower() for record in caplog.records)

--- a/tests/test_health_sidebar_rendering.py
+++ b/tests/test_health_sidebar_rendering.py
@@ -68,6 +68,8 @@ def test_sidebar_shows_empty_state_labels(streamlit_stub, health_sidebar_module)
         "_Sin uso de caché registrado._",
         "#### 🔎 Screening de oportunidades",
         "_Sin screenings recientes._",
+        "#### 🧩 Dependencias críticas",
+        "_Sin registros de dependencias._",
         "#### ⏱️ Latencias",
         "#### 🧭 Monitoreo de sesiones",
         "_Sin métricas de sesiones._",
@@ -169,6 +171,8 @@ def test_sidebar_formats_populated_metrics(monkeypatch, streamlit_stub, health_s
             "✅ Cache reutilizada • "
             f"{formatted[4]} (12 ms • previo 46 ms) — universo 150→90 | descartes 40% | sectores: Energy, Utilities | origen: nyse=45, nasdaq=45"
         ),
+        "#### 🧩 Dependencias críticas",
+        "_Sin registros de dependencias._",
         "#### ⏱️ Latencias",
         "#### 🧭 Monitoreo de sesiones",
         "_Sin métricas de sesiones._",

--- a/ui/health_sidebar.py
+++ b/ui/health_sidebar.py
@@ -362,6 +362,46 @@ def _format_diagnostics_section(data: Optional[Mapping[str, Any]]) -> Iterable[s
     return lines
 
 
+def _format_dependencies_section(data: Optional[Mapping[str, Any]]) -> Iterable[str]:
+    if not isinstance(data, Mapping):
+        return ["_Sin registros de dependencias._"]
+
+    items = data.get("items")
+    if not isinstance(items, Mapping) or not items:
+        return ["_Sin registros de dependencias._"]
+
+    lines: list[str] = []
+
+    overall_status = data.get("status")
+    if isinstance(overall_status, str) and overall_status.strip():
+        icon, label = _status_badge(overall_status)
+        summary = f"{icon} Dependencias {label.lower()}"
+        lines.append(format_note(summary))
+
+    for name in sorted(items):
+        entry = items[name]
+        if not isinstance(entry, Mapping):
+            continue
+        icon, status_label = _status_badge(entry.get("status"))
+        label_text = (
+            _sanitize_text(entry.get("label"))
+            or _sanitize_text(name)
+            or "Dependencia"
+        )
+        ts_text = _format_timestamp(_coerce_timestamp(entry.get("ts")))
+        detail_text = _sanitize_text(entry.get("detail"))
+
+        summary_parts = [f"{icon} {label_text}", status_label.lower()]
+        if ts_text:
+            summary_parts.append(ts_text)
+        summary = " • ".join(summary_parts)
+        if detail_text:
+            summary += f" — {detail_text}"
+        lines.append(format_note(summary))
+
+    return lines or ["_Sin registros de dependencias._"]
+
+
 def _format_risk_summary(data: Optional[Mapping[str, Any]]) -> str:
     if not isinstance(data, Mapping):
         return "_Sin incidencias de riesgo registradas._"
@@ -1776,6 +1816,10 @@ def render_health_sidebar() -> None:
 
     sidebar.markdown("#### 🧪 Diagnóstico inicial")
     for line in _format_diagnostics_section(metrics.get("diagnostics")):
+        sidebar.markdown(line)
+
+    sidebar.markdown("#### 🧩 Dependencias críticas")
+    for line in _format_dependencies_section(metrics.get("dependencies")):
         sidebar.markdown(line)
 
     sidebar.markdown("#### ⏱️ Latencias")


### PR DESCRIPTION
## Summary
- log startup dependency checks for Plotly and Kaleido and record the results in the health metrics store
- surface the dependency status in the health sidebar diagnostics panel
- add regression coverage for dependency failures and update sidebar rendering expectations

## Testing
- pytest -o addopts= tests/test_app_dependencies.py tests/test_health_sidebar_rendering.py

------
https://chatgpt.com/codex/tasks/task_e_68e2b298ee5c8332b414ad354e3c9ed4