### PR TITLE
chore: prepare v0.3.30.13 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## [0.3.30.13] — Observabilidad reforzada en ejecución
+
+### Added
+- Telemetría de entorno con snapshot automático de variables críticas (Python, Streamlit, Kaleido y
+  binarios del sistema) visible desde la UI y embebida en `analysis.log` para acelerar diagnósticos
+  remotos.
+- Rotación automática de logs con compresión diaria y retención configurable que evita que `~/.portafolio_iol/logs`
+  crezca sin control en estaciones con screenings intensivos.
+- Controles de dependencias al inicio que advierten por UI y CLI cuando falta Kaleido, faltan
+  binarios de exportación o la versión de Python está fuera del rango soportado.
+
+### Changed
+- Barra lateral y pantalla de login muestran un bloque de "Observabilidad" con accesos rápidos para
+  descargar snapshots de entorno y el paquete de logs rotados.
+- Documentación de descarga guiada dentro de la UI para educar a los analistas sobre cómo compartir
+  snapshots, logs y artefactos de exportación al escalar incidentes.
+
+### Fixed
+- Se evitó la sobrescritura silenciosa de `analysis.log` cuando el proceso se relanza en entornos con
+  permisos restringidos, delegando la rotación en un handler tolerante a fallas.
+
 ## [0.3.30.12.1] — Hotfix: diagnóstico de inicio resiliente
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -6,20 +6,20 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.30.12.1)
+## Quick-start (release 0.3.30.13)
 
-La versión **0.3.30.12.1** estabiliza la sesión de trabajo, refuerza la trazabilidad de eventos críticos y expone indicadores de monitoreo directamente en la UI. El paquete mantiene el fallback de exportaciones cuando Kaleido no está instalado, confirma explícitamente que los Excel se generan completos (sin gráficos PNG) aun cuando la librería esté ausente y ahora etiqueta cada artefacto con la sesión que lo originó.
+La versión **0.3.30.13** amplía la observabilidad end-to-end: captura un snapshot del entorno de ejecución, rota los logs automáticamente y guía las descargas desde la UI para compartir diagnósticos completos en segundos. El paquete mantiene el fallback de exportaciones cuando Kaleido no está instalado, confirma explícitamente que los Excel se generan completos (sin gráficos PNG) aun cuando la librería esté ausente y continúa etiquetando cada artefacto con la sesión que lo originó.
 
-## Quick-start (release 0.3.30.12.1 — Estabilización y monitoreo de sesión — 2025-11-06)
+## Quick-start (release 0.3.30.13 — Observabilidad operativa)
 
-La versión **0.3.30.12.1** refuerza los siguientes ejes:
-- El **logging consolidado** mueve `analysis.log` al directorio dedicado `~/.portafolio_iol/logs/` y adjunta un encabezado por screening con el identificador de sesión activo, el resumen de TTL y la secuencia de degradaciones controladas que la UI refleja en vivo.
-- La **configuración de caché** documenta y expone en la UI los valores de `CACHE_TTL_*`: cada bloque del health sidebar muestra ahora la vigencia restante, la fuente (API, caché o snapshot) y la sesión que originó el dato para que QA pueda contrastar rápidamente los tiempos de expiración y la estabilidad del flujo.
-- El **health sidebar** añade insignias de color con indicadores de salud, TTL restante y un timeline en vivo con los eventos relevantes de la sesión (login, screening, fallback, exportaciones), además de enlaces directos a la bitácora correspondiente dentro de `analysis.log`.
-- Los **exports enriquecidos** garantizan que `analysis.zip`, `analysis.xlsx` y `summary.csv` estén presentes en cada corrida, conservando los timestamps, registrando cuándo la exportación omitió PNG por ausencia de Kaleido e incluyendo una pestaña de "Sesión" que resume hitos de monitoreo y los contadores de resiliencia.
+La versión **0.3.30.13** refuerza los siguientes ejes:
+- La **telemetría de entorno** agrega un snapshot automático (versión de Python, dependencias críticas, binarios de apoyo y sistema operativo) visible en el health sidebar y embebido en `analysis.log` para que soporte pueda replicar incidentes sin solicitar datos adicionales.
+- La **rotación de logs** mueve `analysis.log` a manejadores diarios comprimidos dentro de `~/.portafolio_iol/logs/`, previene crecimientos descontrolados en screenings masivos y documenta cada rollover en la UI.
+- La **configuración de caché** sigue exponiendo en la UI los valores de `CACHE_TTL_*` y ahora adjunta el snapshot de entorno que originó cada lectura para correlacionar TTLs con builds específicos.
+- El **health sidebar** añade un bloque de **Descargas de observabilidad** con accesos directos para bajar el paquete de logs rotados y el snapshot de entorno, además de mantener el timeline en vivo con login, screenings, fallbacks y exportaciones.
+- Los **exports enriquecidos** garantizan que `analysis.zip`, `analysis.xlsx` y `summary.csv` estén presentes en cada corrida, conservando los timestamps, registrando cuándo la exportación omitió PNG por ausencia de Kaleido e incluyendo una pestaña de "Sesión" con el resumen de monitoreo, contadores de resiliencia y snapshot de entorno utilizado.
 - El **endpoint `/Titulos/Cotizacion`** mantiene los precios en vivo sincronizados con `/Cotizacion`, incluye la marca de procedencia, la insignia "TTL vigente" cuando la caché evita un salto al fallback y agrega un `session_tag` para anclar la medición de latencia a la UI.
-- El **portafolio integrado por país** añade metadatos de origen para cada posición, desbloquea filtros y dashboards por país en la UI y en los exports, y replica esas etiquetas en el monitoreo de sesión para seguir la procedencia de los datos.
-- La **CI Checklist reforzada** conserva los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`) y valida que los banners del login/sidebar indiquen "Estabilización y monitoreo de sesión" junto con la versión `0.3.30.12.1`.
+- La **CI Checklist reforzada** conserva los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`) y valida que los banners del login/sidebar destaquen "Observabilidad operativa" junto con la versión `0.3.30.13`.
 
 Sigue estos pasos para reproducir el flujo completo y validar las novedades clave:
 
@@ -37,13 +37,15 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.12.1` junto con
-   el mensaje "Estabilización y monitoreo de sesión" y el timestamp generado por `TimeProvider`. Abre el panel
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.30.13` junto con
+   el mensaje "Observabilidad operativa" y el timestamp generado por `TimeProvider`. Abre el panel
    **Salud del sistema**: además del estado de cada proveedor verás el bloque **Snapshots y
    almacenamiento**, que expone la ruta activa del disco, el contador de recuperaciones desde snapshot,
    la insignia de TTL restante para `/Titulos/Cotizacion`, el resumen de cache hits, la latencia
    agregada de escritura registrada en la bitácora y el timeline de sesión con cada hito (login, screenings,
-   exportaciones) acompañado de su `session_tag`.
+   exportaciones) acompañado de su `session_tag`. En la parte superior encontrarás el nuevo bloque de
+   **Descargas de observabilidad**, con atajos para bajar el snapshot de entorno y el paquete de logs
+   rotados que acompañan cada screening.
 3. **Lanza un screening con presets personalizados y comprueba la persistencia.**
    - Abre la pestaña **Empresas con oportunidad** y selecciona `Perfil recomendado → Crear preset`.
    - Guarda el preset y ejecútalo al menos dos veces. Tras la primera corrida, el health sidebar
@@ -68,10 +70,12 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    > **Dependencia de Kaleido.** Plotly utiliza `kaleido` para renderizar los gráficos como PNG.
    > Instálalo con `pip install -r requirements.txt` (incluye la dependencia) o añádelo a tu entorno
    > manualmente si usas una instalación mínima. Cuando `kaleido` no está disponible, la release
-   > 0.3.30.12.1 muestra el banner "Estabilización y monitoreo de sesión", mantiene el ZIP de CSV y
-   > documenta en los artefactos que los PNG quedaron pendientes para reintento posterior. Las
-   > exportaciones a Excel se completan igualmente con todas las tablas y logs, y omiten únicamente
-   > las imágenes PNG.
+   > 0.3.30.13 muestra el banner "Observabilidad operativa", mantiene el ZIP de CSV y
+   > documenta en los artefactos que los PNG quedaron pendientes para reintento posterior. Además, el
+   > bloque de **Descargas de observabilidad** ofrece un acceso directo para bajar el snapshot de
+   > entorno y el paquete de logs rotados que acompañan el aviso, facilitando la apertura de tickets.
+   > Las exportaciones a Excel se completan igualmente con todas las tablas y logs, y omiten
+   > únicamente las imágenes PNG.
 
 ### Migración fuera de módulos legacy
 
@@ -103,7 +107,8 @@ validar escenarios sin depender de módulos obsoletos.
 ### Validar el fallback jerárquico desde el health sidebar
 
 1. Abre el panel lateral **Salud del sistema** y localiza el bloque **Resiliencia de proveedores**. La
-   release 0.3.30.12.1 conserva la última secuencia de degradación, deja trazas en `~/.portafolio_iol/logs/analysis.log`
+   release 0.3.30.13 conserva la última secuencia de degradación, deja trazas en `~/.portafolio_iol/logs/analysis.log`
+   (con rotación diaria automática)
    y muestra el estado del feed
    `/Titulos/Cotizacion` junto con el TTL restante, la fuente (API/caché/snapshot) y el contador de snapshots reutilizados (`snapshot_hits`).
 2. Ejecuta nuevamente **⟳ Refrescar** desde el menú **⚙️ Acciones** y observa el timeline: debe listar
@@ -131,7 +136,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.30.12.1)
+### CI Checklist (0.3.30.13)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -143,13 +148,13 @@ validar escenarios sin depender de módulos obsoletos.
 4. **Valida exportaciones.** Ejecuta `python scripts/export_analysis.py --input ~/.portafolio_iol/snapshots --formats both --output exports/ci`
    o reutiliza los snapshots de `tmp_path`. Revisa que cada snapshot genere los CSV (`kpis.csv`,
    `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
-   `analysis.xlsx`, el resumen `summary.csv` y el log consolidado `analysis.log` en la raíz de `exports/ci`.
+   `analysis.xlsx`, el resumen `summary.csv` y el paquete de logs rotados (`analysis.log` más sus `.gz` diarios) en la raíz de `exports/ci`.
 5. **Audita TTLs y salud.** Ejecuta `streamlit run app.py` en modo headless (`--server.headless true`) y guarda una captura del health sidebar. Confirmá que cada proveedor muestre la insignia con el TTL restante y que el resumen coincida con los valores configurados en `CACHE_TTL_*`. Adjunta la captura o los logs en el pipeline.
 6. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
-   `analysis.log` (ubicado ahora en `~/.portafolio_iol/logs/`) estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
+   los archivos `analysis.log*` rotados dentro de `~/.portafolio_iol/logs/` estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 
-### Validaciones Markowitz reforzadas (0.3.30.12.1)
+### Validaciones Markowitz reforzadas (0.3.30.13)
 
 - `application.risk_service.markowitz_optimize` valida la invertibilidad de la matriz de covarianzas y
   degrada a pesos `NaN` cuando detecta singularidad o entradas inválidas, evitando excepciones en la UI
@@ -164,7 +169,7 @@ validar escenarios sin depender de módulos obsoletos.
   y `tests/integration/test_portfolio_tabs.py` cubren la degradación controlada y los mensajes visibles
   en la UI, por lo que cualquier regresión se detecta en pipelines.
 
-**Resiliencia de APIs (0.3.30.12.1).** Cuando guardas un preset, la aplicación persiste la combinación de
+**Resiliencia de APIs (0.3.30.13).** Cuando guardas un preset, la aplicación persiste la combinación de
 filtros, el último resultado del screening, la procedencia (`primario`, `secundario`, `snapshot`) y el TTL activo para cada proveedor. Al
 relanzarlo, la telemetría agrega la procedencia del dato, la vigencia de la caché y clasifica la recuperación según la estrategia
 aplicada:
@@ -178,16 +183,16 @@ aplicada:
   fallback estático con la leyenda "📦 Snapshot de contingencia" y el contador de resiliencia incrementa
   el total de recuperaciones exitosas sin datos frescos, marcando el TTL como expirado.
 
-Estas novedades convierten a la release 0.3.30.12.1 en la referencia para validar onboarding, telemetría y
+Estas novedades convierten a la release 0.3.30.13 en la referencia para validar onboarding, telemetría y
 resiliencia multi-API: el endpoint `/Cotizacion` expone la versión activa desde la UI y las integraciones
-externas, el manejo de errores 500 asegura continuidad visible en dashboards, la UI muestra la vigencia de cada caché y la prueba de cobertura
-protege el flujo frente a regresiones mientras las exportaciones enriquecidas mantienen paridad total
-entre la visión en pantalla y los artefactos compartidos, registrando cada paso en `~/.portafolio_iol/logs/analysis.log`.
+externas, el manejo de errores 500 asegura continuidad visible en dashboards, la UI muestra la vigencia de cada caché y la prueba de cobertura protege el flujo frente a regresiones. Además, las exportaciones enriquecidas mantienen paridad total
+entre la visión en pantalla y los artefactos compartidos, adjuntan `environment.json`, registran cada paso en los logs rotados de `~/.portafolio_iol/logs/analysis.log`
+y ofrecen un enlace directo para compartirlos desde la UI.
 
 
 ## Configuración de claves API
 
-La release 0.3.30.12.1 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets` y deja
+La release 0.3.30.13 consolida la carga de credenciales desde `config.json`, variables de entorno o `streamlit secrets` y deja
 registro de la resolución de cada proveedor en `~/.portafolio_iol/logs/analysis.log`. Antes de
 ejecutar la aplicación en modo live, define las claves según el proveedor habilitado. Si una clave falta, el health sidebar registrará
 el evento como `disabled` y la degradación continuará con el siguiente proveedor disponible.
@@ -229,7 +234,7 @@ en ``~/.portafolio_iol/favorites.json`` con la siguiente estructura:
 - Podés borrar el archivo para reiniciar la lista; se volverá a generar cuando agregues un nuevo
   favorito.
 
-## Backend de snapshots para pipelines CI (0.3.30.12.1)
+## Backend de snapshots para pipelines CI (0.3.30.13)
 
 - Define `SNAPSHOT_BACKEND=null` para ejecutar suites sin escribir archivos persistentes; el módulo
   `services.snapshots` usará `NullSnapshotStorage` y evitará cualquier escritura en disco durante las
@@ -365,7 +370,7 @@ Durante los failovers la UI etiqueta el origen como `stub` y conserva las notas 
 - Flujo de failover: si la API devuelve errores, alcanza el límite de rate limiting o falta la clave, el controlador intenta poblar `macro_outlook` con los valores declarados en `MACRO_SECTOR_FALLBACK`. Cuando no hay fallback, la columna queda en blanco y se agrega una nota explicando la causa (`Datos macro no disponibles: FRED sin credenciales configuradas`). Todos los escenarios se registran en `services.health.record_macro_api_usage`, exponiendo en el healthcheck si el último intento fue exitoso, error o fallback.
 - El rate limiting se maneja desde `infrastructure/macro/fred_client.py`, que serializa las llamadas según el umbral configurado (`FRED_API_RATE_LIMIT_PER_MINUTE`) y reutiliza el `User-Agent` global para respetar los términos de uso de FRED.
 
-##### Escenarios de fallback macro (0.3.30.12.1)
+##### Escenarios de fallback macro (0.3.30.13)
 
 1. **Secuencia `fred → worldbank → fallback`.** Con `MACRO_API_PROVIDER="fred,worldbank"` y sin `FRED_API_KEY`, el intento inicial queda marcado como `disabled`, el World Bank responde con `success` y la nota "Datos macro (World Bank)" deja registro de la latencia. El monitor de resiliencia del health sidebar incrementa los contadores de éxito, actualiza los buckets de latencia del proveedor secundario y agrega la insignia "Fallback cubierto".
 2. **World Bank sin credenciales o series.** Si el segundo proveedor no puede inicializarse (sin `WORLD_BANK_API_KEY` o sin `WORLD_BANK_SECTOR_SERIES`), el intento se registra como `error` o `unavailable` y el fallback estático cierra la secuencia con el detalle correspondiente, incluyendo el identificador `contingency_snapshot` en la telemetría.
@@ -514,11 +519,11 @@ La función `fetch_with_indicators` descarga OHLCV y calcula indicadores (SMA, E
 
 Tus credenciales nunca se almacenan en servidores externos. El acceso a IOL se realiza de forma segura mediante tokens cifrados, protegidos con clave Fernet y gestionados localmente por la aplicación.
 
-El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.12.1" y destaca "Estabilización y monitoreo de sesión" para documentar cuándo los PNG quedan pendientes en los artefactos y qué TTL quedó activo.
+El bloque de login muestra la versión actual de la aplicación con un mensaje como "Estas medidas de seguridad aplican a la versión 0.3.30.13" y destaca "Observabilidad operativa" para documentar cuándo los PNG quedan pendientes en los artefactos y qué TTL quedó activo.
 
 El menú **⚙️ Acciones** refuerza la seguridad operativa al anunciar con toasts cada vez que se refrescan los datos o se completa el cierre de sesión, dejando constancia en la propia UI sin depender de logs externos.
 
-El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.12.1)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega insignias con el TTL restante, estadísticas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank y la bitácora asociada en `~/.portafolio_iol/logs/analysis.log`.
+El sidebar finaliza con un bloque de **Healthcheck (versión 0.3.30.13)** que lista el estado de los servicios monitoreados, resalta si la respuesta proviene de la caché o de un fallback y ahora agrega insignias con el TTL restante, estadísticas de latencia, resiliencia y reutilización, incluyendo el resumen macro con World Bank y la bitácora asociada en `~/.portafolio_iol/logs/analysis.log`. El bloque superior agrupa las **Descargas de observabilidad** para bajar el snapshot de entorno y los logs rotados comprimidos que acompañan cada screening.
 
 ### Interpretación del health sidebar (KPIs agregados)
 

--- a/banners/README
+++ b/banners/README
@@ -2,7 +2,7 @@
 
 Los assets de login y sidebar deben mostrar la versión activa de la aplicación.
 
-- Versión actual: 0.3.30.12.1
+- Versión actual: 0.3.30.13
 - Fecha de publicación: 2025-11-06
-- Mensaje destacado: "Estabilización y monitoreo de sesión"
-- Elementos complementarios: incluir badge de `session_tag` activo y timeline resumido de eventos en la esquina inferior.
+- Mensaje destacado: "Observabilidad operativa"
+- Elementos complementarios: incluir badge de `session_tag` activo, timeline resumido de eventos, acceso rápido a "Descargas de observabilidad" y recordatorio de logs rotados en la esquina inferior.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,13 +4,12 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 ## Claves API
 
-> Nota: Esta guía corresponde a la release 0.3.30.12.1, enfocada en estabilizar la sesión, exponer los TTL de caché y la telemetría
-> de salud directamente en la UI. Además de preservar la bitácora unificada y las exportaciones multi-formato,
-> la release registra cada screening en `~/.portafolio_iol/logs/analysis.log`, anota el `session_tag` activo, muestra la vigencia restante del
-> cache y el timeline de eventos en el health sidebar y documenta cuándo los PNG quedan pendientes porque Kaleido no está instalado.
-> Cuando Kaleido falta, las exportaciones a Excel siguen generándose completas con todas las tablas y se etiqueta la sesión que originó cada artefacto.
+> Nota: Esta guía corresponde a la release 0.3.30.13, centrada en observabilidad operativa. La aplicación ahora captura un snapshot de entorno,
+> rota `analysis.log` diariamente, expone los TTL de caché y la telemetría de salud directamente en la UI y guía la descarga de logs/snapshots
+> desde el bloque **Descargas de observabilidad**. Cada screening registra el `session_tag` activo, documenta cuándo los PNG quedan pendientes por ausencia de Kaleido
+> y adjunta el entorno en `environment.json` junto con los logs comprimidos.
 
-## CI Checklist (0.3.30.12.1)
+## CI Checklist (0.3.30.13)
 
 - **Suite legacy detectada.** Si el resumen de `pytest` menciona archivos dentro de `tests/legacy/`,
   ajustá el comando (`pytest --ignore=tests/legacy`) o revisá `norecursedirs` en `pyproject.toml` para
@@ -19,7 +18,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
   y bloqueá el pipeline si aparecen coincidencias fuera de `tests/legacy/` o de pruebas de compatibilidad
   explícitas.
 - **Pipelines sin artefactos.** Si un job finaliza sin adjuntar `coverage.xml`, `htmlcov/`, `analysis.zip`,
-  `analysis.xlsx`, `summary.csv` o `analysis.log` (desde `~/.portafolio_iol/logs/`), márcalo como fallido y reejecuta las etapas de `pytest --cov` y
+  `analysis.xlsx`, `summary.csv`, `environment.json` o los archivos `analysis.log*` rotados (desde `~/.portafolio_iol/logs/`), márcalo como fallido y reejecuta las etapas de `pytest --cov` y
   `scripts/export_analysis.py`. Los pasos deben apuntar al mismo directorio temporal (`$RUNNER_TEMP` o
   `tmp_path`).
 - **TTL o timeline sin validar.** Ejecuta la aplicación en modo headless y capturá el health sidebar para confirmar que los TTL configurados en `CACHE_TTL_*` coincidan con los mostrados por cada proveedor y que el timeline de sesión liste los hitos más recientes (login, screenings, exportaciones) con el `session_tag` esperado. Conserva la captura o la salida de logs en los artefactos del pipeline.
@@ -63,13 +62,13 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **El timeline de resiliencia o los TTL no persisten tras un rerun.**
   - **Síntomas:** Luego de presionar **⟳ Refrescar**, el bloque **Resiliencia de proveedores** se vacía o pierde la insignia con el TTL restante.
-  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.12.1 o superior, que `analysis.log` se regenere tras cada screening, que `CACHE_TTL_*` no estén fijados en valores extremos y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]` ni `st.session_state["ttl_seconds"]`.
+  - **Diagnóstico rápido:** Verifica que estés en la release 0.3.30.13 o superior, que `analysis.log` se regenere tras cada screening, que `CACHE_TTL_*` no estén fijados en valores extremos y que no haya código externo reescribiendo `st.session_state["resilience_timeline"]` ni `st.session_state["ttl_seconds"]`.
   - **Resolución:**
     1. Actualiza el repositorio y reinstala dependencias si trabajas con un build antiguo.
     2. Comprueba que el stub de tests (`tests/conftest.py`) conserve los datos de sesión entre llamadas; limpia `st.session_state` solo al finalizar las aserciones.
 
-- **La etiqueta "Estabilización y monitoreo de sesión" o la insignia de TTL no aparece en el sidebar.**
-  - **Síntomas:** El banner superior muestra la versión `0.3.30.12.1`, pero el bloque de salud no adjunta el mensaje, no muestra el TTL restante y las exportaciones omiten los PNG sin explicar el motivo.
+- **La etiqueta "Observabilidad operativa" o la insignia de TTL no aparece en el sidebar.**
+  - **Síntomas:** El banner superior muestra la versión `0.3.30.13`, pero el bloque de salud no adjunta el mensaje, no muestra el TTL restante y las exportaciones omiten los PNG sin explicar el motivo.
   - **Diagnóstico rápido:** Ejecuta `python tests/helpers/check_live_quotes.py` (o el script equivalente) para confirmar que el
     proveedor activo devuelve `last = price`, que `shared.version.DEFAULT_VERSION` coincide con la release actual, que `CACHE_TTL_*` esté inicializado en `shared.settings` y que `python -c "import kaleido"` falle cuando el entorno no dispone de la librería.
   - **Resolución:**
@@ -78,6 +77,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
     3. Comprueba que no existan interceptores sobrescribiendo `st.session_state["live_quotes_status"]`; en caso de encontrarlos, elimínalos o actualízalos para reflejar el nuevo flujo.
     4. Valida que la ausencia de Kaleido sea intencional: si necesitás los PNG en la exportación instala la dependencia; en caso contrario el banner debe permanecer visible y el Excel se generará completo con las tablas aun con las exportaciones PNG deshabilitadas.
     5. Revisa el timeline del health sidebar y confirma que los eventos de la sesión lleven el `session_tag` activo y las marcas de tiempo ordenadas.
+    6. Descarga el snapshot de entorno y los logs rotados desde **Descargas de observabilidad** y verificá que `environment.json` y `analysis.log`/`analysis.log.YYYY-MM-DD.gz` contengan la metadata del build actual.
 - **El bloque "Snapshots y almacenamiento" aparece vacío o en error.**
   - **Síntomas:** El health sidebar muestra `snapshot_hits = 0` pese a ejecutar screenings consecutivos, o aparece un mensaje "Ruta de snapshots inaccesible".
   - **Diagnóstico rápido:** Ejecuta el siguiente snippet para validar la ruta configurada y los permisos:
@@ -177,7 +177,7 @@ Esta guía resume los síntomas más comunes que reportan usuarios y QA al opera
 
 - **Las notificaciones internas no aparecen tras refrescar el dashboard.**
   - **Síntomas:** El menú **⚙️ Acciones** ejecuta `⟳ Refrescar`, pero no se muestra el toast "Proveedor primario restablecido" ni el mensaje de cierre de sesión.
-  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.12.1` en el header/footer, que el banner mencione "Estabilización y monitoreo de sesión" y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
+  - **Diagnóstico rápido:** Verifica que la versión visible indique `0.3.30.13` en el header/footer, que el banner mencione "Observabilidad operativa" y que `st.toast` no esté sobreescrito en el entorno (suele ocurrir en notebooks o shells sin UI).
   - **Resolución:**
     1. Ejecuta la app en Streamlit 1.32+ (requerido para `st.toast`) o, en suites headless, garantiza que el stub defina el método antes de lanzar la UI.
     2. Confirma que `st.session_state["show_refresh_toast"]` y `st.session_state["logout_done"]` no queden fijados en `False` permanente por código externo; limpia la sesión (`st.session_state.clear()`) y vuelve a probar.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.30.12.1"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.30.13"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.30.12.1"
+DEFAULT_VERSION: str = "0.3.30.13"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- bump project metadata to v0.3.30.13
- document the new observability telemetry, log rotation, and download guidance across README and docs
- add the 0.3.30.13 changelog entry covering environment snapshots, UI tweaks, and dependency warnings

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e2b299e2b08332a3e43737c05010f6