### PR TITLE
Improve control panel layout and reorganize health sidebar

### DIFF
--- a/app.py
+++ b/app.py
@@ -161,12 +161,16 @@ def main(argv: list[str] | None = None):
     if fx_error:
         st.warning(fx_error)
     render_header(rates=fx_rates)
-    _, hcol2 = st.columns([4, 1])
-    with hcol2:
-        timestamp = TimeProvider.now()
-        st.caption(f"🕒 {timestamp}")
-        render_action_menu()
-    main_col = st.container()
+    content_col, controls_col = st.columns([5, 2], gap="large")
+    with controls_col:
+        controls_area = st.container()
+        with controls_area:
+            st.markdown("#### 🎛️ Panel de control")
+            st.caption("Consulta el estado de la sesión y ejecuta acciones clave.")
+            timestamp = TimeProvider.now()
+            st.markdown(f"**🕒 {timestamp}**")
+            render_action_menu()
+    main_col = content_col.container()
 
     cli = build_iol_client()
 

--- a/ui/actions.py
+++ b/ui/actions.py
@@ -12,16 +12,17 @@ logger = logging.getLogger(__name__)
 
 
 def render_action_menu() -> None:
-    """Render refresh and logout actions in a compact popover."""
+    """Render refresh and logout actions in a compact control panel."""
 
-    pop = st.popover("⚙️ Acciones")
-    with pop:
-        st.caption("Operaciones rápidas")
+    action_panel = st.container(border=True)
+    with action_panel:
+        st.markdown("#### ⚙️ Acciones rápidas")
+        st.caption("Mantén esta sección a la vista para actuar sin perder contexto.")
         c1, c2 = st.columns(2)
         if c1.button("⟳ Refrescar", width="stretch"):
             st.session_state["refresh_pending"] = True
             st.rerun()
-        if c2.button("🔒 Cerrar sesión", width="stretch"):
+        if c2.button("🔒 Cerrar sesión", width="stretch", help="Cierra inmediatamente tu sesión actual"):
             st.session_state["logout_pending"] = True
             st.rerun()
 


### PR DESCRIPTION
## Summary
- Promote the action menu into a persistent control card with contextual guidance while keeping the underlying logic intact.
- Restructure the main page layout to dedicate a stable column for interactive controls alongside the portfolio content.
- Group the health sidebar metrics into prioritised accordion sections with concise summaries and an organised diagnostics area.

## Testing
- python -m compileall app.py ui/actions.py ui/health_sidebar.py

------
https://chatgpt.com/codex/tasks/task_e_68e2c1e22c108332ab033a3f6d7c0d06