### PR TITLE
Adjust footer link and metadata styling

### DIFF
--- a/ui/footer.py
+++ b/ui/footer.py
@@ -36,16 +36,20 @@ def render_footer():
                 color: #212529;
             }}
             .footer-links a {{
-                color: #0d6efd;
-                text-decoration: none;
+                color: #4f6f8f;
+                text-decoration: underline;
                 font-weight: 600;
             }}
             .footer-links a:hover,
             .footer-links a:focus {{
-                text-decoration: underline;
+                color: #3c4f65;
+            }}
+            .footer-meta {{
+                color: #5c636a;
             }}
             .footer-meta strong {{
-                color: #0b7285;
+                color: #495057;
+                font-weight: 600;
             }}
             .footer-disclaimer {{
                 font-size: 0.75rem;


### PR DESCRIPTION
## Summary
- update the footer link styles to keep the underline and switch to the softer contrast palette
- soften the footer metadata colors using medium greys so labels and values remain distinct without a harsh contrast

## Testing
- pytest --override-ini addopts='' tests/test_version_display.py *(fails: missing streamlit radio attribute in DummyCtx test double)*

------
https://chatgpt.com/codex/tasks/task_e_68e45ca5faf083328e0265f70a174350