### PR TITLE
docs: actualizar referencias visual polish 0.3.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configuración de `pytest` actualizada para imponer cobertura sobre `application`, `controllers` y
   `services` en cada ejecución, alineada con la nueva puerta de seguridad de CI.
 
+## v0.3.4.2 — Visual Polish Pass (Nov 2025)
+
+### Summary
+- Incremento de padding y márgenes clave para asegurar el respiro visual del panel superior y las
+  tarjetas de KPIs en resoluciones medianas.
+- Tarjetas contrastadas y tipografía reajustada para reforzar la jerarquía de información en los
+  indicadores del dashboard.
+- Alineación central consistente de los bloques del header y filtros, evitando saltos laterales en el
+  selector de riesgo.
+- Ajustes en el footer: espaciado, alineación de enlaces y consistencia con la narrativa “Observabilidad
+  operativa”.
+
 ## v0.3.4.1 — Layout y Filtros de Análisis de Riesgo (Nov 2025)
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -6,21 +6,26 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.4.1)
+## Quick-start (release 0.3.4.2 — Visual Polish Pass)
 
-La versión **0.3.4.1** extiende el roadmap de UI Experience Refresh iniciado en 0.3.30.13: reubica el panel superior en una franja horizontal fija, libera la barra lateral para el contenido principal y traslada los controles de riesgo al encabezado de la vista. El heatmap incorpora un selector por tipo de instrumento, se mantiene la coherencia visual con el footer y los badges del dashboard, y se garantiza el ancho completo del layout en la vista central.
+La versión **0.3.4.2** continúa el roadmap de UI Experience Refresh iniciado en 0.3.30.13: preserva el panel superior como franja horizontal fija y añade un pulido visual que incrementa el padding entre bloques, eleva el contraste de las tarjetas y centraliza los filtros clave para estabilizar la lectura del dashboard. El footer replica el ajuste con espaciado uniforme y enlaces alineados a la narrativa de "Observabilidad operativa".
 
-## Quick-start (release 0.3.4.1 — Layout y filtros de riesgo)
+## Quick-start (release 0.3.4.2 — Layout y filtros refinados)
 
-La versión **0.3.4.1** refuerza los siguientes ejes:
-- El **panel superior horizontal** ahora concentra KPIs, accesos rápidos y controles de refresco sin ocupar espacio lateral, lo que mantiene visible la narrativa de "Observabilidad operativa" aun en pantallas medianas.
-- La **pantalla de login** conserva el copy compacto de seguridad, muestra la versión `0.3.4.1` y enlaza el mensaje "Layout y filtros de análisis de riesgo" con el timestamp provisto por `TimeProvider`.
-- El **panel de acciones** permanece persistente pero comparte estilo con la barra horizontal para que el layout se adapte fluidamente a pantallas anchas.
-- El **health sidebar expandible** continúa dedicado a telemetría, mientras que la vista principal adopta **ancho completo** para priorizar el heatmap y los gráficos derivados.
-- Los **controles de riesgo** migran al encabezado del heatmap e incorporan un selector por tipo de instrumento que reemplaza los toggles de la barra lateral.
-- La **CI Checklist reforzada** sigue validando los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`) y ahora exige capturas del panel horizontal en sus estados responsive.
+La versión **0.3.4.2** refuerza los siguientes ejes:
+- El **panel superior horizontal** conserva KPIs, accesos rápidos y controles de refresco, ahora con mayor respiro visual y centrado consistente en resoluciones medianas.
+- La **pantalla de login** mantiene el copy compacto de seguridad, muestra la versión `0.3.4.2` y enlaza el mensaje "Visual Polish Pass" con el timestamp provisto por `TimeProvider`.
+- El **panel de acciones** continúa persistente y replica el contraste renovado para alinearse con la barra horizontal en anchos amplios.
+- El **health sidebar expandible** sigue dedicado a telemetría, mientras que la vista principal adopta **ancho completo** con tarjetas reespaciadas para priorizar el heatmap y los gráficos derivados.
+- Los **controles de riesgo** en el encabezado del heatmap sostienen el selector por tipo de instrumento, con padding equilibrado que evita saltos laterales y mejora la interacción táctil.
+- La **CI Checklist reforzada** sigue validando los artefactos (`analysis.zip`, `analysis.xlsx`, `summary.csv`) y ahora exige capturas que demuestren la mejora de contraste, centrado del header y alineación del footer.
 
 ## Historial de versiones
+
+### Versión 0.3.4.2 — Visual Polish Pass
+La release 0.3.4.2 aplica un pulido visual sobre el layout horizontal introducido en 0.3.4.1.
+Incrementa el padding de los bloques superiores, contrasta las tarjetas de KPIs, centra los filtros del heatmap y alinea el footer con espaciado uniforme para sostener la narrativa de "Observabilidad operativa".
+Los servicios y flujos de datos permanecen estables; el foco está en la legibilidad y coherencia estética en todas las resoluciones soportadas.
 
 ### Versión 0.3.4.1 — Layout y filtros de análisis de riesgo
 Esta versión profundiza el rediseño visual iniciado en 0.3.4.0.
@@ -44,8 +49,8 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.4.1` junto con
-   el mensaje "Layout y filtros de análisis de riesgo" y el timestamp generado por `TimeProvider`, conservando la narrativa de observabilidad operativa. Abre el panel
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.4.2` junto con
+   el mensaje "Visual Polish Pass" y el timestamp generado por `TimeProvider`, conservando la narrativa de observabilidad operativa. Abre el panel
    **Salud del sistema**: además del estado de cada proveedor verás el bloque **Snapshots y
    almacenamiento**, que expone la ruta activa del disco, el contador de recuperaciones desde snapshot,
    la insignia de TTL restante para `/Titulos/Cotizacion`, el resumen de cache hits, la latencia
@@ -77,7 +82,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    > **Dependencia de Kaleido.** Plotly utiliza `kaleido` para renderizar los gráficos como PNG.
    > Instálalo con `pip install -r requirements.txt` (incluye la dependencia) o añádelo a tu entorno
    > manualmente si usas una instalación mínima. Cuando `kaleido` no está disponible, la release
-   > 0.3.4.1 muestra el banner "Layout y filtros de análisis de riesgo", mantiene el ZIP de CSV y
+   > 0.3.4.2 muestra el banner "Visual Polish Pass", mantiene el ZIP de CSV y
    > documenta en los artefactos que los PNG quedaron pendientes para reintento posterior. Además, el
    > bloque de **Descargas de observabilidad** ofrece un acceso directo para bajar el snapshot de
    > entorno y el paquete de logs rotados que acompañan el aviso, facilitando la apertura de tickets.
@@ -143,7 +148,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.4.1)
+### CI Checklist (0.3.4.2)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -157,8 +162,9 @@ validar escenarios sin depender de módulos obsoletos.
    `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
    `analysis.xlsx`, el resumen `summary.csv` y el paquete de logs rotados (`analysis.log` más sus `.gz` diarios) en la raíz de `exports/ci`.
 5. **Audita TTLs y salud.** Ejecuta `streamlit run app.py` en modo headless (`--server.headless true`) y guarda una captura del health sidebar. Confirmá que cada proveedor muestre la insignia con el TTL restante y que el resumen coincida con los valores configurados en `CACHE_TTL_*`. Adjunta la captura o los logs en el pipeline.
-6. **Captura el panel horizontal responsive.** Valida que el panel superior conserve alineación, tooltips y accesos rápidos tanto en desktop como en resoluciones medianas, incluyendo el selector de tipo del heatmap sin depender del sidebar.
-7. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
+6. **Captura el panel horizontal refinado.** Valida que el panel superior conserve alineación, tooltips y accesos rápidos tanto en desktop como en resoluciones medianas, con el incremento de padding visible y los filtros centrados.
+7. **Documenta contraste y footer.** Adjunta evidencia de las tarjetas de KPIs contrastadas y del footer alineado con su nuevo espaciado, asegurando que los enlaces y badges mantengan la narrativa de "Observabilidad operativa".
+8. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
    los archivos `analysis.log*` rotados dentro de `~/.portafolio_iol/logs/` estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
 

--- a/banners/README
+++ b/banners/README
@@ -2,7 +2,7 @@
 
 Los assets de login y sidebar deben mostrar la versión activa de la aplicación.
 
-- Versión actual: v0.3.4.1
-- Fecha de publicación: 2025-11-05
-- Mensaje destacado: "Layout y filtros de análisis de riesgo"
-- Elementos complementarios: incluir badge de `session_tag` activo, timeline resumido de eventos, acceso rápido a "Descargas de observabilidad", recordatorio de logs rotados en la esquina inferior y mención al nuevo selector de tipo en el heatmap.
+- Versión actual: v0.3.4.2
+- Fecha de publicación: 2025-11-12
+- Mensaje destacado: "Visual Polish Pass"
+- Elementos complementarios: incluir badge de `session_tag` activo, timeline resumido de eventos, acceso rápido a "Descargas de observabilidad", recordatorio de logs rotados en la esquina inferior, mención al selector de tipo centrado en el heatmap y contraste reforzado en tarjetas clave.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -38,18 +38,18 @@ Esto resulta útil para los ciclos de TDD locales o al depurar suites nuevas
 que no requieren medir cobertura.
 
 El proyecto incorpora `pytest.ini` con marcadores y configuración de logging. La ejecución completa
-usa los stubs deterministas para mantener resultados reproducibles. La release 0.3.4.1 mantiene la
+usa los stubs deterministas para mantener resultados reproducibles. La release 0.3.4.2 mantiene la
 telemetría de entorno y la rotación automática de `analysis.log`, y suma verificaciones visuales
-sobre el panel horizontal y los controles de riesgo, por lo que los tests deben asegurar que los
-snapshots y los logs comprimidos generados por la app se publiquen como artefactos.
+sobre el panel horizontal refinado, el contraste de las tarjetas de KPIs y el footer alineado, por lo que los
+tests deben asegurar que los snapshots y los logs comprimidos generados por la app se publiquen como artefactos.
 
 > Las pruebas visuales se deben realizar mediante inspección manual del layout, verificando jerarquía tipográfica, alineación y visibilidad del menú de acciones.
 
-### Pruebas manuales sugeridas (0.3.4.1)
+### Pruebas manuales sugeridas (0.3.4.2)
 
-1. **Panel superior responsive.** Abrí la aplicación en resoluciones desktop y medianas para validar que la franja horizontal conserve alineación de KPIs, tooltips activos y accesos rápidos sin que aparezca un sidebar extra para controles.
-2. **Selector por tipo en riesgo.** En la pestaña de análisis de riesgo, alterná el nuevo filtro por tipo de instrumento y confirmá que el heatmap se actualiza en consecuencia, manteniendo el layout de ancho completo.
-3. **Enlaces del footer.** Revisá que los enlaces del footer se mantengan accesibles y alineados después de los cambios de layout, tanto en desktop como en vistas comprimidas.
+1. **Panel superior con padding ampliado.** Abrí la aplicación en resoluciones desktop y medianas para validar que la franja horizontal conserve alineación de KPIs, muestre el incremento de padding y mantenga tooltips activos sin volver a la barra lateral para controles.
+2. **Selector por tipo centrado.** En la pestaña de análisis de riesgo, alterná el filtro por tipo de instrumento y confirmá que el heatmap se actualiza en consecuencia, con el bloque de filtros centrado y sin saltos laterales.
+3. **Tarjetas contrastadas y footer.** Revisá que las tarjetas de KPIs y avisos mantengan el contraste reforzado y que el footer preserve los enlaces alineados con el nuevo espaciado en desktop y vistas comprimidas.
 
 ### Generadores aleatorios reproducibles
 
@@ -72,7 +72,7 @@ result = monte_carlo_simulation(
 De esta manera cada test controla explícitamente la semilla sin depender de `numpy.random.seed`, y
 los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralelo.
 
-## CI Checklist (0.3.4.1)
+## CI Checklist (0.3.4.2)
 
 1. **Suite determinista sin legacy.** Ejecuta `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy` y
    verifica que el resumen final no recolecte casos desde `tests/legacy/`.
@@ -87,11 +87,12 @@ los escenarios siguen siendo reproducibles incluso cuando se ejecutan en paralel
   `positions.csv`, `history.csv`, `contribution_by_symbol.csv`, etc.), el ZIP `analysis.zip`, el Excel
   `analysis.xlsx`, el resumen `summary.csv`, el snapshot de entorno (`environment.json`) y el paquete de logs rotados (`analysis.log` + `.gz`).
 5. **TTLs y monitoreo visibles.** Ejecuta la app en modo headless y capturá el health sidebar para confirmar que cada proveedor muestra el TTL restante configurado en `CACHE_TTL_*` y que el timeline de sesión despliega los hitos (login, screenings, exportaciones) en orden. Adjunta la captura o los logs en el pipeline.
-6. **Panel horizontal y filtros.** Capturá el panel superior responsive y documentá el selector por tipo en el heatmap de riesgo, verificando que no reaparezca una barra lateral para controles y que los KPIs se mantengan visibles.
-7. **Checklist previa al merge.** Antes de aprobar la release inspecciona los artefactos del pipeline y
+6. **Panel horizontal y filtros refinados.** Capturá el panel superior responsive con el padding ampliado y documentá el selector por tipo centrado en el heatmap de riesgo, verificando que no reaparezca una barra lateral para controles y que los KPIs se mantengan visibles.
+7. **Contraste y footer alineado.** Acompañá el pipeline con capturas o vídeos que muestren las tarjetas de KPIs contrastadas y el footer con el nuevo espaciado uniforme.
+8. **Checklist previa al merge.** Antes de aprobar la release inspecciona los artefactos del pipeline y
   confirma que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv`, el snapshot de entorno y
   los archivos `analysis.log*` rotados (desde `~/.portafolio_iol/logs/`) estén adjuntos. Si falta alguno, la ejecución debe considerarse fallida.
-8. **Puerta de seguridad.** Ejecuta `bandit -r application controllers services` para auditar llamadas inseguras
+9. **Puerta de seguridad.** Ejecuta `bandit -r application controllers services` para auditar llamadas inseguras
   y `pip-audit --requirement requirements.txt --requirement requirements-dev.txt` para identificar
   dependencias vulnerables. Ambos comandos deben formar parte del pipeline y bloquear el merge ante
   hallazgos críticos.


### PR DESCRIPTION
## Summary
- documentar la release 0.3.4.2 en el changelog con el pulido visual del panel, tarjetas y footer
- actualizar el README con el quick-start, historial y checklists que referencian el Visual Polish Pass
- extender docs/testing.md y banners/README con las verificaciones y mensajes estéticos de la versión 0.3.4.2

## Testing
- not run (documentación)


------
https://chatgpt.com/codex/tasks/task_e_68e45ca7c5708332a155e827a4554e91