### PR TITLE
chore: align codebase version with v0.3.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.4.0"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.4.2"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.4.0"
+DEFAULT_VERSION: str = "0.3.4.2"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 


### PR DESCRIPTION
## Summary
- update the project metadata in pyproject.toml to report version 0.3.4.2
- sync shared.version.DEFAULT_VERSION with the new release number so runtime helpers surface 0.3.4.2

## Testing
- pytest tests/test_version_sync.py --override-ini addopts=""

------
https://chatgpt.com/codex/tasks/task_e_68e39f34e9e08332b9da84c94aea8f2a