### PR TITLE
Improve sidebar interactive states

### DIFF
--- a/app.py
+++ b/app.py
@@ -124,18 +124,76 @@ st.markdown(
         .control-panel__actions .stButton button {
             border-radius: 999px;
             background: rgba(16, 163, 127, 0.12);
-            border: 1px solid rgba(16, 163, 127, 0.28);
-            color: rgb(11, 83, 69);
+            background: color-mix(in srgb, var(--color-accent) 16%, transparent);
+            border: 1px solid color-mix(in srgb, var(--color-accent) 36%, transparent);
+            color: color-mix(in srgb, var(--color-accent) 78%, var(--color-text) 22%);
+            transition: background-color 150ms ease, border-color 150ms ease,
+                color 150ms ease, box-shadow 150ms ease, transform 120ms ease;
         }
 
-        .control-panel__actions .stButton button:hover {
-            background: rgba(16, 163, 127, 0.18);
-            border-color: rgba(16, 163, 127, 0.35);
-            color: rgb(7, 65, 55);
+        .control-panel__actions .stButton button:hover,
+        .control-panel__actions .stButton button:focus-visible {
+            background: color-mix(in srgb, var(--color-accent) 26%, var(--color-bg) 74%);
+            border-color: color-mix(in srgb, var(--color-accent) 48%, transparent);
+            color: color-mix(in srgb, var(--color-accent) 86%, var(--color-text) 14%);
         }
 
-        .control-panel__actions .stButton button:focus {
-            box-shadow: 0 0 0 0.2rem rgba(16, 163, 127, 0.25);
+        .control-panel__actions .stButton button:active {
+            background: color-mix(in srgb, var(--color-accent) 34%, var(--color-bg) 66%);
+            border-color: color-mix(in srgb, var(--color-accent) 60%, transparent);
+            transform: translateY(1px);
+        }
+
+        .control-panel__actions .stButton button:focus-visible {
+            outline: none;
+            box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--color-accent) 32%, transparent);
+        }
+
+        [data-testid="stSidebar"] [role="switch"] {
+            border-radius: 999px;
+            background: color-mix(in srgb, var(--color-text) 14%, transparent);
+            border: 1px solid color-mix(in srgb, var(--color-text) 22%, transparent);
+            transition: background-color 150ms ease, border-color 150ms ease,
+                box-shadow 150ms ease;
+            outline: none;
+        }
+
+        [data-testid="stSidebar"] [role="switch"][aria-checked="true"] {
+            background: color-mix(in srgb, var(--color-accent) 40%, var(--color-bg) 60%);
+            border-color: color-mix(in srgb, var(--color-accent) 58%, transparent);
+        }
+
+        [data-testid="stSidebar"] [role="switch"]:hover {
+            border-color: color-mix(in srgb, var(--color-accent) 46%, transparent);
+        }
+
+        [data-testid="stSidebar"] [role="switch"]:active {
+            background: color-mix(in srgb, var(--color-accent) 48%, var(--color-bg) 52%);
+        }
+
+        [data-testid="stSidebar"] [role="switch"]:focus-visible {
+            box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--color-accent) 34%, transparent);
+        }
+
+        [data-testid="stSidebar"] div[data-baseweb="select"] {
+            border-radius: 0.75rem;
+            border: 1px solid color-mix(in srgb, var(--color-text) 22%, transparent);
+            transition: border-color 150ms ease, box-shadow 150ms ease,
+                background-color 150ms ease;
+        }
+
+        [data-testid="stSidebar"] div[data-baseweb="select"]:hover {
+            border-color: color-mix(in srgb, var(--color-accent) 48%, transparent);
+        }
+
+        [data-testid="stSidebar"] div[data-baseweb="select"]:focus-within {
+            border-color: color-mix(in srgb, var(--color-accent) 66%, transparent);
+            box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--color-accent) 30%, transparent);
+            background: color-mix(in srgb, var(--color-accent) 12%, var(--color-bg) 88%);
+        }
+
+        [data-testid="stSidebar"] div[data-baseweb="select"]:active {
+            border-color: color-mix(in srgb, var(--color-accent) 70%, transparent);
         }
 
         .control-panel__body .stCaption, .control-panel__section .stCaption {

--- a/ui/sidebar_controls.py
+++ b/ui/sidebar_controls.py
@@ -24,17 +24,36 @@ def _ensure_chip_styles(container) -> None:
                 margin: 0.25rem 0 1rem;
             }
             .sidebar-chip {
-                background: rgba(16, 163, 127, 0.08);
-                color: rgb(24, 79, 73);
+                background: rgba(16, 163, 127, 0.12);
+                background: color-mix(in srgb, var(--color-accent) 15%, transparent);
+                color: color-mix(in srgb, var(--color-accent) 70%, var(--color-text) 30%);
                 border-radius: 999px;
                 padding: 0.2rem 0.65rem;
                 font-size: 0.78rem;
                 font-weight: 600;
-                border: 1px solid rgba(16, 163, 127, 0.22);
+                border: 1px solid color-mix(in srgb, var(--color-accent) 32%, transparent);
                 display: inline-flex;
                 align-items: center;
                 gap: 0.35rem;
                 white-space: nowrap;
+                transition: background-color 150ms ease, border-color 150ms ease,
+                    box-shadow 150ms ease, color 150ms ease, transform 120ms ease;
+            }
+            .sidebar-chip:hover,
+            .sidebar-chip:focus-visible {
+                background: color-mix(in srgb, var(--color-accent) 24%, var(--color-bg) 76%);
+                border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
+                color: color-mix(in srgb, var(--color-accent) 82%, var(--color-text) 18%);
+            }
+            .sidebar-chip:active {
+                background: color-mix(in srgb, var(--color-accent) 32%, var(--color-bg) 68%);
+                border-color: color-mix(in srgb, var(--color-accent) 58%, transparent);
+                color: color-mix(in srgb, var(--color-accent) 88%, var(--color-text) 12%);
+                transform: translateY(1px);
+            }
+            .sidebar-chip:focus-visible {
+                outline: none;
+                box-shadow: 0 0 0 0.18rem color-mix(in srgb, var(--color-accent) 35%, transparent);
             }
             .sidebar-chip__label {
                 line-height: 1.1;
@@ -80,7 +99,7 @@ def _render_filter_overview(container, chips: list[str]) -> None:
 
     _ensure_chip_styles(container)
     chip_html = "".join(
-        "<span class='sidebar-chip'>"
+        "<span class='sidebar-chip' tabindex='0' role='status'>"
         "<span class='sidebar-chip__label'>{label}</span>"
         "</span>".format(label=html.escape(label))
         for label in chips


### PR DESCRIPTION
## Summary
- add hover, focus-visible and active styling to filter chips while keeping contrast with the theme palette
- align sidebar buttons, toggles and selects with the shared accent colors and provide visible keyboard focus affordances

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e4e8955d68833299a3588d9f3926a7