### PR TITLE
Refine risk heatmap correlations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.3.4.4.3 — Risk Heatmap Polishing Pass (Nov 2025)
+
+### Summary
+- Elimina del cálculo de correlaciones a los activos con rendimientos de varianza nula o indefinida,
+  evitando coeficientes erráticos y matrices singulares.
+- Los heatmaps de correlación ahora muestran títulos contextualizados por tipo de activo (por
+  ejemplo, "Matriz de Correlación — CEDEARs"), lo que refuerza la segmentación aplicada en los
+  filtros del análisis de riesgo.
+- README y materiales de release actualizados para documentar el descarte de columnas sin
+  movimiento y el nuevo etiquetado por grupo.
+
 ## v0.3.4.4.2 — Vertical Sidebar Layout (Nov 2025)
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.4.4.2)
+### CI Checklist (0.3.4.4.3)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -181,6 +181,14 @@ validar escenarios sin depender de módulos obsoletos.
 8. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
    los archivos `analysis.log*` rotados dentro de `~/.portafolio_iol/logs/` estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
+
+### Correlaciones segmentadas (0.3.4.4.3)
+
+- Los heatmaps de correlación del módulo de riesgo se construyen únicamente con los símbolos del tipo
+  seleccionado y muestran un título contextualizado (por ejemplo, "Matriz de Correlación — Bonos"),
+  lo que ayuda a distinguir rápidamente el grupo analizado.
+- Antes de calcular la correlación se descartan columnas con rendimientos de varianza nula o indefinida
+  para evitar coeficientes erráticos y garantizar que solo se comparen activos con movimiento real.
 
 ### Validaciones Markowitz reforzadas (0.3.4.0)
 

--- a/controllers/portfolio/risk.py
+++ b/controllers/portfolio/risk.py
@@ -204,7 +204,10 @@ def render_risk_analysis(
                     continue
 
                 subset_hist = hist_df[sorted(set(subset_symbols))]
-                fig = plot_correlation_heatmap(subset_hist)
+                fig = plot_correlation_heatmap(
+                    subset_hist,
+                    title=f"Matriz de Correlación — {type_name}",
+                )
                 if fig:
                     st.plotly_chart(
                         fig,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.4.4.2"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.4.4.3"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.4.4.2"
+DEFAULT_VERSION: str = "0.3.4.4.3"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -34,6 +34,7 @@ def test_render_basic_section_captions(monkeypatch):
         lambda df, top_n: {k: object() for k in ["pl_topn", "donut_tipo", "dist_tipo", "pl_diario"]},
     )
     monkeypatch.setattr(charts_mod.st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod.st, "selectbox", lambda *a, **k: None, raising=False)
     monkeypatch.setattr(charts_mod.st, "plotly_chart", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod.st, "info", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod.st, "columns", lambda n: (DummyCtx(), DummyCtx()))
@@ -62,12 +63,17 @@ def test_render_risk_analysis_caption(monkeypatch):
     monkeypatch.setattr(risk_mod.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod.st, "selectbox", lambda *a, **k: "1y")
     monkeypatch.setattr(risk_mod.st, "spinner", lambda *a, **k: DummyCtx())
+    monkeypatch.setattr(risk_mod.st, "container", lambda *a, **k: DummyCtx(), raising=False)
     monkeypatch.setattr(risk_mod.st, "plotly_chart", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod.st, "info", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod.st, "warning", lambda *a, **k: None)
     mock_caption = MagicMock()
     monkeypatch.setattr(risk_mod.st, "caption", mock_caption)
-    monkeypatch.setattr(risk_mod, "plot_correlation_heatmap", lambda df: object())
+    monkeypatch.setattr(
+        risk_mod,
+        "plot_correlation_heatmap",
+        lambda df, **kwargs: object(),
+    )
     monkeypatch.setattr(risk_mod, "compute_returns", lambda df: pd.DataFrame())
     monkeypatch.setattr(risk_mod, "render_favorite_badges", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod, "render_favorite_toggle", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- filter zero-variance series before computing correlation heatmaps and support contextual titles per asset type
- surface the new titles from the risk controller and document the segmented correlation behaviour in the README/CHANGELOG
- bump the project version to 0.3.4.4.3 and update tests to match the heatmap helper signature

## Testing
- pytest -o addopts='' tests/test_captions.py


------
https://chatgpt.com/codex/tasks/task_e_68e59a92f01883329bf3d8fe79163484