### PR TITLE
Align risk heatmap asset types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## v0.3.4.4.4 — Asset Type Alignment in Risk Analysis (Nov 2025)
+
+### Summary
+- El cálculo de correlaciones ahora se apoya exclusivamente en la clasificación del portafolio
+  base antes de solicitar históricos, aplicando un mapeo canónico por símbolo para evitar que
+  instrumentos de distintos tipos se mezclen en el heatmap.
+- Los CEDEARs filtran explícitamente los tickers locales (LOMA, YPFD, TECO2) aunque el payload
+  de precios o cotizaciones los etiquete erróneamente, manteniendo matrices homogéneas por
+  categoría.
+- Se añadieron pruebas de controlador que validan el filtro corregido y la asignación de tipos
+  desde el catálogo maestro, junto con documentación y materiales de release actualizados para la
+  versión 0.3.4.4.4.
+
+## v0.3.4.4.3 — Risk Heatmap Polishing Pass (Nov 2025)
+
+### Summary
+- Elimina del cálculo de correlaciones a los activos con rendimientos de varianza nula o indefinida,
+  evitando coeficientes erráticos y matrices singulares.
+- Los heatmaps de correlación ahora muestran títulos contextualizados por tipo de activo (por
+  ejemplo, "Matriz de Correlación — CEDEARs"), lo que refuerza la segmentación aplicada en los
+  filtros del análisis de riesgo.
+- README y materiales de release actualizados para documentar el descarte de columnas sin
+  movimiento y el nuevo etiquetado por grupo.
+
 ## v0.3.4.4.2 — Vertical Sidebar Layout (Nov 2025)
 
 ### Summary

--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Aplicación Streamlit para consultar y analizar carteras de inversión en IOL.
 > en formato `YYYY-MM-DD HH:MM:SS` (UTC-3). El footer de la aplicación se actualiza en cada
 > renderizado con la hora de Argentina.
 
-## Quick-start (release 0.3.4.4.2 — Vertical Sidebar Layout)
+## Quick-start (release 0.3.4.4.4 — Asset Type Alignment)
 
-La versión **0.3.4.4.2** reorganiza el panel lateral en tarjetas apiladas verticalmente. Cada bloque —Actualización, Filtros, Moneda, Orden, Gráficos y Acciones— ocupa ahora una fila completa con padding uniforme, manteniendo la coherencia tipográfica y los tooltips cortos introducidos en 0.3.4.4.
+La versión **0.3.4.4.4** refuerza el análisis de riesgo alineando el heatmap de correlaciones con la clasificación del portafolio base. Antes de descargar históricos se aplica un mapeo canónico por símbolo, evitando que los CEDEARs compartan matriz con acciones locales y descartando explícitamente tickers como LOMA, YPFD o TECO2 cuando el payload de precios los etiqueta de forma ambigua.
 
 ## Quick-start (release 0.3.4.4.2 — Sidebar apilado y feedback guiado)
 
@@ -21,6 +21,13 @@ La versión **0.3.4.4.2** refuerza los siguientes ejes:
 > Desde la versión 0.3.4.4 las confirmaciones de acciones (guardar preset, refrescar, reintentar exportes) muestran el mismo mensaje en el panel principal y en **Monitoreo**. Las referencias en secciones previas del README se mantienen para conservar compatibilidad con los pipelines que validan flujos legacy.
 
 ## Historial de versiones
+
+### Versión 0.3.4.4.4 — Asset Type Alignment in Risk Analysis
+La release 0.3.4.4.4 alinea el heatmap de correlaciones con el catálogo maestro del portafolio, aplica
+un mapeo canónico por símbolo antes de solicitar históricos y excluye explícitamente los tickers
+locales de los grupos de CEDEARs. El objetivo es garantizar que cada matriz refleje únicamente los
+activos del tipo seleccionado, incluso cuando los datos de cotizaciones lleguen con etiquetas
+inconsistentes.
 
 ### Versión 0.3.4.4.2 — Vertical Sidebar Layout
 La versión 0.3.4.4.2 apila todos los grupos de controles en tarjetas verticales dentro del sidebar. Cada bloque conserva su título, descripción y tooltips, pero ahora ocupa una fila dedicada para facilitar la lectura y reducir el scroll horizontal. El feedback temporal de filtros mantiene el pulso suave incorporado en 0.3.4.4 y destaca únicamente la sección afectada.
@@ -66,8 +73,8 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    ```bash
    streamlit run app.py
    ```
-   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.4.4.2` junto con
-   el mensaje "Vertical Sidebar Layout" y el timestamp generado por `TimeProvider`.
+   La cabecera del sidebar y el banner del login mostrarán el número de versión `0.3.4.4.4` junto con
+   el mensaje "Asset Type Alignment in Risk Analysis" y el timestamp generado por `TimeProvider`.
    Observá el badge global bajo el encabezado principal para identificar rápidamente el estado de salud,
    verificá que cambie en sincronía con los badges del footer y accedé a la pestaña **Monitoreo**:
    allí encontrarás los mismos bloques de telemetría acompañados de los toasts y contadores
@@ -96,7 +103,7 @@ Sigue estos pasos para reproducir el flujo completo y validar las novedades clav
    > **Dependencia de Kaleido.** Plotly utiliza `kaleido` para renderizar los gráficos como PNG.
    > Instálalo con `pip install -r requirements.txt` (incluye la dependencia) o añádelo a tu entorno
    > manualmente si usas una instalación mínima. Cuando `kaleido` no está disponible, la release
-   > 0.3.4.4.2 muestra el banner "Vertical Sidebar Layout", mantiene el ZIP de CSV y
+   > 0.3.4.4.4 muestra el banner "Asset Type Alignment in Risk Analysis", mantiene el ZIP de CSV y
    > documenta en los artefactos que los PNG quedaron pendientes para reintento posterior. Además, el
    > bloque de **Descargas de observabilidad** ofrece un acceso directo para bajar el snapshot de
    > entorno y el paquete de logs rotados que acompañan el aviso, facilitando la apertura de tickets.
@@ -162,7 +169,7 @@ validar escenarios sin depender de módulos obsoletos.
   invertido en descarga remota vs. normalización y calcula el ahorro neto de la caché cooperativa y de
   la persistencia de snapshots durante la sesión.
 
-### CI Checklist (0.3.4.4.2)
+### CI Checklist (0.3.4.4.3)
 
 1. **Ejecuta la suite determinista sin legacy.** Lanza `pytest --maxfail=1 --disable-warnings -q --ignore=tests/legacy`
    (o confiá en el `norecursedirs` por defecto) y verificá que el resumen final no recolecte pruebas desde `tests/legacy/`.
@@ -181,6 +188,16 @@ validar escenarios sin depender de módulos obsoletos.
 8. **Verifica attachments antes de mergear.** En GitHub/GitLab, inspecciona los artefactos del pipeline
    y asegúrate de que `htmlcov/`, `coverage.xml`, `analysis.zip`, `analysis.xlsx`, `summary.csv` y
    los archivos `analysis.log*` rotados dentro de `~/.portafolio_iol/logs/` estén presentes. Si falta alguno, marca el pipeline como fallido y reprocesa la corrida.
+
+### Correlaciones segmentadas (0.3.4.4.4)
+
+- El heatmap de riesgo consulta históricos solo después de validar el tipo de activo en el catálogo
+  base, aplicando un mapeo canónico por símbolo que impide mezclar categorías (CEDEAR, Bonos, ETF,
+  FCI, Acciones locales, etc.).
+- Los grupos de CEDEARs excluyen explícitamente tickers locales como LOMA, YPFD o TECO2 incluso si la
+  fuente de precios los etiqueta como CEDEARs, asegurando correlaciones homogéneas.
+- Se mantiene el descarte de columnas con rendimientos de varianza nula o indefinida antes de calcular
+  la correlación para evitar coeficientes erráticos y comparar únicamente activos con movimiento real.
 
 ### Validaciones Markowitz reforzadas (0.3.4.0)
 

--- a/banners/README
+++ b/banners/README
@@ -2,7 +2,7 @@
 
 Los assets de login y sidebar deben mostrar la versión activa de la aplicación.
 
-- Versión actual: v0.3.4.4.2
-- Fecha de publicación: 2025-11-27
-- Mensaje destacado: "Vertical Sidebar Layout"
-- Elementos complementarios: destacar que el formulario lateral muestra tarjetas apiladas (Actualización, Filtros, Moneda, Orden, Gráficos y Acciones) con feedback visual consistente al aplicar cambios.
+- Versión actual: v0.3.4.4.4
+- Fecha de publicación: 2025-11-28
+- Mensaje destacado: "Asset Type Alignment in Risk Analysis"
+- Elementos complementarios: resaltar que el heatmap de riesgo segmenta los activos según el catálogo base y que los CEDEARs excluyen símbolos locales (LOMA, YPFD, TECO2) incluso si las cotizaciones los etiquetan distinto.

--- a/controllers/portfolio/risk.py
+++ b/controllers/portfolio/risk.py
@@ -1,4 +1,6 @@
 import logging
+import re
+import unicodedata
 from typing import Sequence
 
 import numpy as np
@@ -23,6 +25,7 @@ from application.risk_service import (
     max_drawdown,
     drawdown_series,
 )
+from application.portfolio_service import classify_symbol
 from services.notifications import NotificationFlags
 from ui.charts import plot_correlation_heatmap, _apply_layout
 from ui.export import PLOTLY_CONFIG
@@ -32,6 +35,142 @@ from services.health import record_tab_latency
 
 
 logger = logging.getLogger(__name__)
+
+_LOCAL_SYMBOL_BLACKLIST = {"LOMA", "YPFD", "TECO2"}
+
+_TYPE_ALIASES = {
+    "ACCION": "ACCION_LOCAL",
+    "ACCIONES": "ACCION_LOCAL",
+    "ACCION LOCAL": "ACCION_LOCAL",
+    "ACCION ARG": "ACCION_LOCAL",
+    "ACCION ARGENTINA": "ACCION_LOCAL",
+    "ACCION ARGENTINAS": "ACCION_LOCAL",
+    "ACCION_LOCAL": "ACCION_LOCAL",
+    "ACCIONES LOCALES": "ACCION_LOCAL",
+    "ACCIONES NACIONALES": "ACCION_LOCAL",
+    "BONO": "BONO",
+    "BONOS": "BONO",
+    "BONOS SOBERANOS": "BONO",
+    "BONOS CORPORATIVOS": "BONO",
+    "LETRA": "LETRA",
+    "LETRAS": "LETRA",
+    "CEDEAR": "CEDEAR",
+    "CEDEARS": "CEDEAR",
+    "ETF": "ETF",
+    "ETFS": "ETF",
+    "FONDO": "FCI",
+    "FONDOS": "FCI",
+    "FONDO COMUN": "FCI",
+    "FONDO COMUN DE INVERSION": "FCI",
+    "FONDO DE INVERSION": "FCI",
+    "FCI": "FCI",
+    "OTRO": "OTRO",
+    "OTROS": "OTRO",
+}
+
+_TYPE_DISPLAY_OVERRIDES = {
+    "ACCION_LOCAL": "Acciones locales",
+    "CEDEAR": "CEDEARs",
+    "BONO": "Bonos",
+    "LETRA": "Letras",
+    "ETF": "ETFs",
+    "FCI": "Fondos comunes (FCI)",
+    "OTRO": "Otros",
+}
+
+_SYMBOL_TYPE_OVERRIDES = {sym: "ACCION_LOCAL" for sym in _LOCAL_SYMBOL_BLACKLIST}
+
+
+def _string_or_empty(value) -> str:
+    """Return a trimmed string representation or ``""`` when not meaningful."""
+
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        text = value.strip()
+        return "" if not text or text.lower() in {"nan", "none"} else text
+    try:
+        if pd.isna(value):
+            return ""
+    except Exception:
+        pass
+    text = str(value).strip()
+    return "" if not text or text.lower() in {"nan", "none"} else text
+
+
+def _normalize_type_token(value: str) -> str:
+    normalized = unicodedata.normalize("NFKD", value)
+    normalized = normalized.encode("ascii", "ignore").decode("ascii")
+    normalized = normalized.replace("-", " ")
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized.upper()
+
+
+def _normalize_type_label(value) -> str:
+    text = _string_or_empty(value)
+    if not text:
+        return ""
+    token = _normalize_type_token(text)
+    if not token:
+        return ""
+    return _TYPE_ALIASES.get(token, token)
+
+
+def _normalize_symbol(symbol) -> str:
+    text = _string_or_empty(symbol)
+    return text.upper()
+
+
+def _canonical_type(symbol: str, raw_type) -> str:
+    sym_key = _normalize_symbol(symbol)
+    override = _SYMBOL_TYPE_OVERRIDES.get(sym_key)
+    if override:
+        return override
+
+    normalized = _normalize_type_label(raw_type)
+    if normalized:
+        return normalized
+
+    if sym_key:
+        fallback = classify_symbol(sym_key)
+        normalized = _normalize_type_label(fallback)
+        if normalized:
+            return _SYMBOL_TYPE_OVERRIDES.get(sym_key, normalized)
+    return ""
+
+
+def _build_type_metadata(df: pd.DataFrame | None) -> tuple[pd.Series, dict[str, str], dict[str, str]]:
+    """Return normalized type series, display labels and symbol→type map."""
+
+    if df is None or df.empty or "simbolo" not in df.columns:
+        empty_index = getattr(df, "index", pd.Index([])) if df is not None else pd.Index([])
+        return pd.Series(pd.NA, index=empty_index, dtype="object"), {}, {}
+
+    raw_types = df["tipo"] if "tipo" in df.columns else pd.Series(pd.NA, index=df.index)
+    normalized_values: list[object] = []
+    display_labels: dict[str, str] = {}
+    symbol_type_map: dict[str, str] = {}
+
+    for idx, symbol in enumerate(df["simbolo"].tolist()):
+        raw_value = raw_types.iloc[idx] if idx < len(raw_types) else None
+        canonical = _canonical_type(symbol, raw_value)
+        normalized_values.append(canonical if canonical else pd.NA)
+        if canonical:
+            sym_key = _normalize_symbol(symbol)
+            symbol_type_map[sym_key] = canonical
+            if sym_key not in _SYMBOL_TYPE_OVERRIDES:
+                raw_label = _string_or_empty(raw_value)
+                if raw_label and canonical not in display_labels:
+                    display_labels[canonical] = raw_label
+
+    for canonical, label in _TYPE_DISPLAY_OVERRIDES.items():
+        display_labels.setdefault(canonical, label)
+
+    for canonical in symbol_type_map.values():
+        display_labels.setdefault(canonical, canonical.replace("_", " ").title())
+
+    series = pd.Series(normalized_values, index=df.index, dtype="object")
+    return series, display_labels, symbol_type_map
 
 
 def compute_risk_metrics(returns_df, bench_ret, weights, *, var_confidence: float = 0.95):
@@ -94,24 +233,40 @@ def render_risk_analysis(
             help_text="Tus favoritos se sincronizan entre portafolio, riesgo, técnico y fundamental.",
         )
 
-    filtered_df = df_view.copy() if hasattr(df_view, "copy") else df_view
+    filtered_df = df_view.copy() if isinstance(df_view, pd.DataFrame) else df_view
     selected_type_filters = st.session_state.get("selected_asset_types") or []
     normalized_filters = [
-        str(t).strip()
+        _normalize_type_label(t)
         for t in selected_type_filters
-        if isinstance(t, str) and str(t).strip()
+        if isinstance(t, str) and _normalize_type_label(t)
     ]
 
-    if "tipo" in df_view:
-        type_series = df_view["tipo"].astype(str).str.strip()
-        type_series = type_series.replace("", pd.NA)
-        filtered_df = df_view.assign(_normalized_type=type_series)
+    normalized_series, type_display_map, symbol_type_map = _build_type_metadata(
+        filtered_df if isinstance(filtered_df, pd.DataFrame) else None
+    )
+
+    if isinstance(filtered_df, pd.DataFrame):
+        filtered_df["_normalized_type"] = normalized_series.reindex(
+            filtered_df.index
+        )
         if normalized_filters:
             filtered_df = filtered_df[
                 filtered_df["_normalized_type"].isin(normalized_filters)
-            ]
+            ].copy()
+
+        if not filtered_df.empty:
+            normalized_symbols = (
+                filtered_df["simbolo"].astype(str).str.strip().str.upper()
+            )
+            blacklist_mask = (
+                filtered_df["_normalized_type"].eq("CEDEAR")
+                & normalized_symbols.isin(_LOCAL_SYMBOL_BLACKLIST)
+            )
+            if blacklist_mask.any():
+                filtered_df = filtered_df.loc[~blacklist_mask].copy()
     else:
-        filtered_df = df_view.assign(_normalized_type=pd.NA)
+        type_display_map = {}
+        symbol_type_map = {}
 
     if filtered_df.empty:
         st.warning("No hay datos para los tipos seleccionados.")
@@ -125,11 +280,34 @@ def render_risk_analysis(
         ["3mo", "6mo", "1y", "2y", "5y"],
         index=2,
     )
-    portfolio_symbols = [
-        str(sym).strip()
-        for sym in filtered_df.get("simbolo", [])
-        if str(sym).strip()
-    ]
+    portfolio_symbols: list[str] = []
+    if isinstance(filtered_df, pd.DataFrame):
+        for sym, canon in zip(
+            filtered_df.get("simbolo", []),
+            filtered_df.get("_normalized_type", []),
+        ):
+            sym_str = str(sym).strip()
+            if not sym_str:
+                continue
+            sym_key = sym_str.upper()
+            canon_str = symbol_type_map.get(sym_key)
+            if not canon_str:
+                canon_str = (
+                    _normalize_type_label(canon)
+                    if isinstance(canon, str)
+                    else _canonical_type(sym_key, None)
+                )
+            if normalized_filters and canon_str not in normalized_filters:
+                continue
+            if canon_str == "CEDEAR" and sym_str.upper() in _LOCAL_SYMBOL_BLACKLIST:
+                continue
+            portfolio_symbols.append(sym_str)
+    else:
+        portfolio_symbols = [
+            str(sym).strip()
+            for sym in getattr(filtered_df, "get", lambda *_: [])("simbolo", [])
+            if str(sym).strip()
+        ]
     if len(portfolio_symbols) >= 2:
         corr_latency: float | None = None
         with st.spinner(f"Calculando correlación ({corr_period})…"):
@@ -158,11 +336,11 @@ def render_risk_analysis(
         record_tab_latency("riesgo", corr_latency, status="success")
         returns_for_corr = compute_returns(hist_df)
         available_types_in_view: list[str] = []
-        if "_normalized_type" in filtered_df:
+        if isinstance(filtered_df, pd.DataFrame) and "_normalized_type" in filtered_df:
             available_types_in_view = [
-                t
+                str(t)
                 for t in filtered_df["_normalized_type"].dropna().unique()
-                if isinstance(t, str)
+                if isinstance(t, str) and str(t)
             ]
 
         if normalized_filters:
@@ -172,39 +350,63 @@ def render_risk_analysis(
 
         type_groups: list[tuple[str, pd.DataFrame]] = []
         for type_name in ordered_types:
-            subset = filtered_df[filtered_df["_normalized_type"] == type_name]
-            if not subset.empty:
-                type_groups.append((type_name, subset))
+            subset = (
+                filtered_df[filtered_df["_normalized_type"] == type_name]
+                if isinstance(filtered_df, pd.DataFrame)
+                else pd.DataFrame()
+            )
+            if isinstance(subset, pd.DataFrame) and not subset.empty:
+                type_groups.append((type_name, subset.copy()))
 
         if not type_groups:
-            type_groups = [("Portafolio", filtered_df)]
+            label = "Portafolio"
+            type_groups = [(label, filtered_df if isinstance(filtered_df, pd.DataFrame) else pd.DataFrame())]
 
         display_targets: list = []
         if len(type_groups) > 1:
             display_targets = st.tabs(
-                [f"{type_name}" for type_name, _ in type_groups]
+                [
+                    type_display_map.get(
+                        type_name,
+                        type_name.replace("_", " ").title(),
+                    )
+                    for type_name, _ in type_groups
+                ]
             )
         else:
             display_targets = [st.container()]
 
         for (type_name, subset_df), display_host in zip(type_groups, display_targets):
             with display_host:
+                display_label = type_display_map.get(
+                    type_name,
+                    type_name.replace("_", " ").title(),
+                )
                 subset_symbols = [
                     str(sym).strip()
                     for sym in subset_df.get("simbolo", [])
                     if str(sym).strip()
                 ]
+                if type_name == "CEDEAR":
+                    subset_symbols = [
+                        sym
+                        for sym in subset_symbols
+                        if sym.upper() not in _LOCAL_SYMBOL_BLACKLIST
+                    ]
                 subset_symbols = [
                     sym for sym in subset_symbols if sym in hist_df.columns
                 ]
                 if len(set(subset_symbols)) < 2:
                     st.warning(
-                        f"⚠️ No hay suficientes activos del tipo {type_name} para calcular correlaciones."
+                        f"⚠️ No hay suficientes activos del tipo {display_label} para calcular correlaciones."
                     )
                     continue
 
                 subset_hist = hist_df[sorted(set(subset_symbols))]
-                fig = plot_correlation_heatmap(subset_hist)
+                fig = plot_correlation_heatmap(
+                    subset_hist,
+                    title=f"Matriz de Correlación — {display_label}",
+                )
                 if fig:
                     st.plotly_chart(
                         fig,
@@ -223,7 +425,7 @@ def render_risk_analysis(
                     )
                 else:
                     st.warning(
-                        f"⚠️ No hay suficientes datos históricos para calcular la correlación de {type_name}."
+                        f"⚠️ No hay suficientes datos históricos para calcular la correlación de {display_label}."
                     )
 
         if returns_for_corr.shape[1] >= 2:
@@ -273,7 +475,7 @@ def render_risk_analysis(
             "Necesitas al menos 2 activos en tu portafolio (después de aplicar filtros) para calcular la correlación."
         )
 
-    if "_normalized_type" in filtered_df:
+    if isinstance(filtered_df, pd.DataFrame) and "_normalized_type" in filtered_df:
         filtered_df = filtered_df.drop(columns="_normalized_type")
 
     st.subheader("Análisis de Riesgo")

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -45,7 +45,10 @@ de enlaces del footer, por lo que los tests deben asegurar que los snapshots y l
 generados por la app se publiquen como artefactos. La release 0.3.4.4.2 profundiza este trabajo al
 apilar los controles del sidebar en tarjetas verticales con feedback visual específico por sección,
 por lo que las verificaciones manuales deben incluir capturas del nuevo layout y la animación de
-feedback al aplicar filtros.
+feedback al aplicar filtros. La release 0.3.4.4.4 extiende esta validación al heatmap de riesgo,
+exigiendo evidencias de que cada tipo de activo se correlaciona únicamente con sus símbolos
+homogéneos y que los CEDEARs omiten acciones locales (LOMA, YPFD, TECO2) incluso cuando las
+cotizaciones llegan etiquetadas de forma inconsistente.
 
 > Las pruebas visuales se deben realizar mediante inspección manual del layout, verificando jerarquía tipográfica, alineación y visibilidad del menú de acciones.
 
@@ -54,6 +57,7 @@ feedback al aplicar filtros.
 1. **Sidebar de controles apilado.** Abrí la aplicación en resoluciones desktop y medianas para validar que las tarjetas de Actualización, Filtros, Moneda, Orden, Gráficos y Acciones se rendericen una debajo de la otra con padding uniforme, chips activos, tooltips cortos y botones de refresco/cierre funcionando.
 2. **Pestaña Monitoreo activa.** Navegá a la pestaña **Monitoreo** y confirmá que el healthcheck conserva las secciones de dependencias, snapshots, oportunidades y diagnósticos, registrando TTLs y latencias con la misma profundidad que el antiguo sidebar.
 3. **Badge global y footer.** Revisá que bajo el encabezado principal aparezca el badge de estado general y que el footer incluya el bloque de enlaces útiles con contraste reducido en los metadatos.
+4. **Heatmap alineado por tipo.** En la pestaña **Riesgo**, filtrá por CEDEARs y confirmá que el heatmap solo muestra tickers del catálogo base, excluyendo LOMA, YPFD y TECO2. Capturá evidencia de la advertencia cuando un tipo no tiene suficientes símbolos para generar la matriz.
 
 ### Generadores aleatorios reproducibles
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "portafolio-iol"
-version = "0.3.4.4.2"  # Keep shared.version.DEFAULT_VERSION aligned with this value
+version = "0.3.4.4.4"  # Keep shared.version.DEFAULT_VERSION aligned with this value
 dependencies = [
     "streamlit==1.49.1",
     "pandas==2.3.2",

--- a/shared/version.py
+++ b/shared/version.py
@@ -9,7 +9,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 fallback
 
 
 # Keep in sync with ``pyproject.toml``'s ``project.version``.
-DEFAULT_VERSION: str = "0.3.4.4.2"
+DEFAULT_VERSION: str = "0.3.4.4.4"
 PROJECT_FILE = Path(__file__).resolve().parent.parent / "pyproject.toml"
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test package to ensure deterministic import paths during collection."""

--- a/tests/controllers/test_risk_filtering.py
+++ b/tests/controllers/test_risk_filtering.py
@@ -1,0 +1,101 @@
+"""Tests for risk analysis asset type alignment."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+import pandas as pd
+
+from controllers.portfolio import risk as risk_mod
+from shared.favorite_symbols import FavoriteSymbols
+
+
+def test_heatmap_excludes_local_symbols_in_cedear_group(monkeypatch, streamlit_stub):
+    """Ensure CEDEAR heatmap excludes local tickers like LOMA and YPFD."""
+
+    df = pd.DataFrame(
+        {
+            "simbolo": ["AAPL", "NVDA", "LOMA", "YPFD"],
+            "valor_actual": [1000.0, 950.0, 400.0, 380.0],
+            "mercado": ["nyse", "nyse", "bcba", "bcba"],
+            "tipo": ["CEDEAR", "CEDEAR", None, None],
+        }
+    )
+
+    streamlit_stub.reset()
+    streamlit_stub.session_state["selected_asset_types"] = ["CEDEAR"]
+    monkeypatch.setattr(risk_mod, "st", streamlit_stub)
+    monkeypatch.setattr(risk_mod, "render_favorite_badges", lambda *a, **k: None)
+    monkeypatch.setattr(risk_mod, "render_favorite_toggle", lambda *a, **k: None)
+
+    class _ContainerCtx:
+        def __enter__(self):
+            return streamlit_stub
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(streamlit_stub, "container", lambda: _ContainerCtx(), raising=False)
+
+    original_selectbox = streamlit_stub.selectbox
+
+    def fake_selectbox(label, options, *, index=0, key=None, help=None, format_func=None):
+        return original_selectbox(label, options, index=index, key=key, help=help)
+
+    monkeypatch.setattr(streamlit_stub, "selectbox", fake_selectbox)
+
+    history_calls: list[list[str]] = []
+
+    def fake_history(*, simbolos, period):
+        history_calls.append(list(simbolos))
+        if len(history_calls) >= 2:
+            return pd.DataFrame()
+        idx = pd.date_range("2024-01-01", periods=8, freq="B")
+        data = {sym: np.linspace(100.0 + i, 105.0 + i, len(idx)) for i, sym in enumerate(simbolos)}
+        return pd.DataFrame(data, index=idx)
+
+    tasvc = SimpleNamespace(portfolio_history=fake_history)
+
+    heatmap_columns: list[list[str]] = []
+
+    def fake_heatmap(prices_df: pd.DataFrame, *, title: str | None = None):
+        heatmap_columns.append(list(prices_df.columns))
+        return MagicMock()
+
+    monkeypatch.setattr(risk_mod, "plot_correlation_heatmap", fake_heatmap)
+
+    def fake_compute_returns(df_hist: pd.DataFrame) -> pd.DataFrame:
+        if df_hist.empty:
+            return pd.DataFrame()
+        returns = df_hist.pct_change(fill_method=None).dropna(how="all")
+        return returns.replace([np.inf, -np.inf], np.nan).dropna(axis=1, how="all")
+
+    monkeypatch.setattr(risk_mod, "compute_returns", fake_compute_returns)
+
+    favorites = FavoriteSymbols({})
+
+    risk_mod.render_risk_analysis(df, tasvc, favorites=favorites)
+
+    assert history_calls, "portfolio_history should be invoked at least once"
+    assert set(history_calls[0]) == {"AAPL", "NVDA"}
+    assert all(sym not in {"LOMA", "YPFD", "TECO2"} for call in history_calls for sym in call)
+    assert heatmap_columns, "Expected heatmap to be rendered"
+    assert set(heatmap_columns[0]) == {"AAPL", "NVDA"}
+
+
+def test_build_type_metadata_respects_catalog_overrides():
+    """Local tickers are forced to ACCION_LOCAL even if raw type mislabels them."""
+
+    df = pd.DataFrame(
+        {
+            "simbolo": ["AAPL", "LOMA", "TECO2"],
+            "tipo": ["CEDEAR", "CEDEAR", None],
+        }
+    )
+
+    normalized, display_map, symbol_map = risk_mod._build_type_metadata(df)
+
+    assert normalized.tolist() == ["CEDEAR", "ACCION_LOCAL", "ACCION_LOCAL"]
+    assert symbol_map["LOMA"] == "ACCION_LOCAL"
+    assert symbol_map["TECO2"] == "ACCION_LOCAL"
+    assert display_map["ACCION_LOCAL"].lower().startswith("accion")

--- a/tests/shared/__init__.py
+++ b/tests/shared/__init__.py
@@ -1,0 +1,1 @@
+"""Namespace package for shared test utilities."""

--- a/tests/test_captions.py
+++ b/tests/test_captions.py
@@ -34,6 +34,7 @@ def test_render_basic_section_captions(monkeypatch):
         lambda df, top_n: {k: object() for k in ["pl_topn", "donut_tipo", "dist_tipo", "pl_diario"]},
     )
     monkeypatch.setattr(charts_mod.st, "subheader", lambda *a, **k: None)
+    monkeypatch.setattr(charts_mod.st, "selectbox", lambda *a, **k: None, raising=False)
     monkeypatch.setattr(charts_mod.st, "plotly_chart", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod.st, "info", lambda *a, **k: None)
     monkeypatch.setattr(charts_mod.st, "columns", lambda n: (DummyCtx(), DummyCtx()))
@@ -62,12 +63,17 @@ def test_render_risk_analysis_caption(monkeypatch):
     monkeypatch.setattr(risk_mod.st, "subheader", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod.st, "selectbox", lambda *a, **k: "1y")
     monkeypatch.setattr(risk_mod.st, "spinner", lambda *a, **k: DummyCtx())
+    monkeypatch.setattr(risk_mod.st, "container", lambda *a, **k: DummyCtx(), raising=False)
     monkeypatch.setattr(risk_mod.st, "plotly_chart", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod.st, "info", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod.st, "warning", lambda *a, **k: None)
     mock_caption = MagicMock()
     monkeypatch.setattr(risk_mod.st, "caption", mock_caption)
-    monkeypatch.setattr(risk_mod, "plot_correlation_heatmap", lambda df: object())
+    monkeypatch.setattr(
+        risk_mod,
+        "plot_correlation_heatmap",
+        lambda df, **kwargs: object(),
+    )
     monkeypatch.setattr(risk_mod, "compute_returns", lambda df: pd.DataFrame())
     monkeypatch.setattr(risk_mod, "render_favorite_badges", lambda *a, **k: None)
     monkeypatch.setattr(risk_mod, "render_favorite_toggle", lambda *a, **k: None)


### PR DESCRIPTION
## Summary
- build a canonical type map for risk heatmaps that relies on the portfolio catalog, normalises CEDEAR groups and excludes local tickers before requesting history
- adjust risk UI rendering to honour the new mappings, fall back gracefully when tabs/containers are unavailable in stubs and keep contextual titles per asset type
- document the alignment in CHANGELOG/README/docs, bump the app version to 0.3.4.4.4 and add targeted controller tests plus package initialisers to stabilise pytest collection

## Testing
- pytest --override-ini addopts="" *(fails: suite expects the full Streamlit stub and live services; numerous unrelated tests error out without those dependencies)*
- pytest --override-ini addopts="" tests/controllers/test_risk_filtering.py -q


------
https://chatgpt.com/codex/tasks/task_e_68e59a92f01883329bf3d8fe79163484